### PR TITLE
feat(llm): add LLMClient wrapper with structured JSON output + Zod validation

### DIFF
--- a/src/llm/client.test.ts
+++ b/src/llm/client.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { extractJson } from './client';
+
+// Mock the Anthropic SDK
+const mockCreate = vi.fn();
+vi.mock('@anthropic-ai/sdk', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      messages: { create: mockCreate },
+    })),
+  };
+});
+
+describe('extractJson', () => {
+  it('returns bare JSON object as-is', () => {
+    const input = '{"type":"test"}';
+    expect(extractJson(input)).toBe('{"type":"test"}');
+  });
+
+  it('strips ```json fences', () => {
+    const input = '```json\n{"type":"test"}\n```';
+    expect(JSON.parse(extractJson(input))).toEqual({ type: 'test' });
+  });
+
+  it('strips bare ``` fences', () => {
+    const input = '```\n{"type":"test"}\n```';
+    expect(JSON.parse(extractJson(input))).toEqual({ type: 'test' });
+  });
+
+  it('handles uppercase ```JSON', () => {
+    const input = '```JSON\n{"type":"test"}\n```';
+    expect(JSON.parse(extractJson(input))).toEqual({ type: 'test' });
+  });
+
+  it('extracts JSON from surrounding text', () => {
+    const input = 'Here is the result:\n{"type":"test"}\nDone.';
+    expect(JSON.parse(extractJson(input))).toEqual({ type: 'test' });
+  });
+
+  it('handles JSON arrays', () => {
+    const input = '[1,2,3]';
+    expect(extractJson(input)).toBe('[1,2,3]');
+  });
+
+  it('passes through non-JSON unchanged', () => {
+    const input = 'not json at all';
+    expect(extractJson(input)).toBe('not json at all');
+  });
+});
+
+describe('LLMClient', () => {
+  beforeEach(() => {
+    mockCreate.mockReset();
+  });
+
+  describe('generateText', () => {
+    it('returns text from successful response', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'Hello world' }],
+      });
+
+      const { LLMClient } = await import('./client');
+      const client = new LLMClient({ apiKey: 'test-key' });
+      const result = await client.generateText({
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+
+      expect(result).toBe('Hello world');
+    });
+
+    it('returns empty string for empty content', async () => {
+      mockCreate.mockResolvedValueOnce({ content: [] });
+
+      const { LLMClient } = await import('./client');
+      const client = new LLMClient({ apiKey: 'test-key' });
+      const result = await client.generateText({
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+
+      expect(result).toBe('');
+    });
+
+    it('returns fallback string on API error', async () => {
+      mockCreate.mockRejectedValueOnce(new Error('API timeout'));
+
+      const { LLMClient } = await import('./client');
+      const client = new LLMClient({ apiKey: 'test-key' });
+      const result = await client.generateText({
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+      });
+
+      expect(result).toBe('[系統暫時無法回應，請稍後再試]');
+    });
+  });
+
+  describe('generateStructured', () => {
+    const TestSchema = z.object({ type: z.string(), value: z.number() });
+
+    it('returns parsed data for valid JSON response', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: '{"type":"test","value":42}' }],
+      });
+
+      const { LLMClient } = await import('./client');
+      const client = new LLMClient({ apiKey: 'test-key' });
+      const result = await client.generateStructured({
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+        schema: TestSchema,
+        schemaDescription: 'Test schema',
+      });
+
+      expect(result).toEqual({ ok: true, data: { type: 'test', value: 42 } });
+    });
+
+    it('handles markdown-fenced JSON', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: '```json\n{"type":"test","value":42}\n```' }],
+      });
+
+      const { LLMClient } = await import('./client');
+      const client = new LLMClient({ apiKey: 'test-key' });
+      const result = await client.generateStructured({
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+        schema: TestSchema,
+        schemaDescription: 'Test schema',
+      });
+
+      expect(result).toEqual({ ok: true, data: { type: 'test', value: 42 } });
+    });
+
+    it('returns error for invalid JSON', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: 'not valid json' }],
+      });
+
+      const { LLMClient } = await import('./client');
+      const client = new LLMClient({ apiKey: 'test-key' });
+      const result = await client.generateStructured({
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+        schema: TestSchema,
+        schemaDescription: 'Test schema',
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toBeDefined();
+    });
+
+    it('returns error for valid JSON that fails schema', async () => {
+      mockCreate.mockResolvedValueOnce({
+        content: [{ type: 'text', text: '{"type":"test","value":"not-a-number"}' }],
+      });
+
+      const { LLMClient } = await import('./client');
+      const client = new LLMClient({ apiKey: 'test-key' });
+      const result = await client.generateStructured({
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+        schema: TestSchema,
+        schemaDescription: 'Test schema',
+      });
+
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.error).toContain('Schema validation failed');
+    });
+
+    it('returns error for empty response', async () => {
+      mockCreate.mockResolvedValueOnce({ content: [] });
+
+      const { LLMClient } = await import('./client');
+      const client = new LLMClient({ apiKey: 'test-key' });
+      const result = await client.generateStructured({
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+        schema: TestSchema,
+        schemaDescription: 'Test schema',
+      });
+
+      expect(result).toEqual({ ok: false, error: 'Empty response from LLM' });
+    });
+
+    it('returns error on API failure', async () => {
+      mockCreate.mockRejectedValueOnce(new Error('Rate limited'));
+
+      const { LLMClient } = await import('./client');
+      const client = new LLMClient({ apiKey: 'test-key' });
+      const result = await client.generateStructured({
+        system: 'test',
+        messages: [{ role: 'user', content: 'hi' }],
+        schema: TestSchema,
+        schemaDescription: 'Test schema',
+      });
+
+      expect(result).toEqual({ ok: false, error: 'Rate limited' });
+    });
+  });
+});

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -1,1 +1,115 @@
-export {};
+import Anthropic from '@anthropic-ai/sdk';
+import { z } from 'zod';
+
+export interface LLMClientConfig {
+  apiKey?: string;
+  model?: string;
+}
+
+export interface LLMCallOptions {
+  system: string;
+  messages: { role: 'user' | 'assistant'; content: string }[];
+  maxTokens?: number;
+}
+
+export interface LLMStructuredOptions<T extends z.ZodType> extends LLMCallOptions {
+  schema: T;
+  schemaDescription: string;
+}
+
+/**
+ * Extract JSON from LLM response text.
+ * Handles: bare JSON, markdown-fenced JSON, JSON with surrounding text.
+ */
+export function extractJson(raw: string): string {
+  let str = raw.trim();
+
+  // Strip markdown code fences (case-insensitive)
+  const fenceMatch = str.match(/^```\s*(?:json)?\s*\n([\s\S]*?)\n?\s*```\s*$/i);
+  if (fenceMatch) {
+    return fenceMatch[1].trim();
+  }
+
+  // Already looks like JSON
+  if (str.startsWith('{') || str.startsWith('[')) {
+    return str;
+  }
+
+  // Last resort: extract first JSON object
+  const firstBrace = str.indexOf('{');
+  const lastBrace = str.lastIndexOf('}');
+  if (firstBrace !== -1 && lastBrace > firstBrace) {
+    return str.substring(firstBrace, lastBrace + 1);
+  }
+
+  return str;
+}
+
+export class LLMClient {
+  private client: Anthropic;
+  private model: string;
+
+  constructor(config?: LLMClientConfig) {
+    this.client = new Anthropic({
+      apiKey: config?.apiKey ?? process.env.ANTHROPIC_API_KEY,
+    });
+    this.model = config?.model ?? process.env.VOLVA_MODEL ?? 'claude-sonnet-4-20250514';
+  }
+
+  async generateText(options: LLMCallOptions): Promise<string> {
+    try {
+      const response = await this.client.messages.create({
+        model: this.model,
+        system: options.system,
+        messages: options.messages,
+        max_tokens: options.maxTokens ?? 2000,
+      });
+      const textBlock = response.content.find(
+        (b): b is Anthropic.TextBlock => b.type === 'text'
+      );
+      return textBlock?.text ?? '';
+    } catch (error) {
+      console.error('[LLMClient] generateText failed:', error);
+      return '[系統暫時無法回應，請稍後再試]';
+    }
+  }
+
+  async generateStructured<T extends z.ZodType>(
+    options: LLMStructuredOptions<T>
+  ): Promise<{ ok: true; data: z.infer<T> } | { ok: false; error: string }> {
+    try {
+      const systemWithSchema = `${options.system}\n\nYou MUST respond with valid JSON matching this description: ${options.schemaDescription}\nRespond ONLY with JSON, no other text.`;
+
+      const response = await this.client.messages.create({
+        model: this.model,
+        system: systemWithSchema,
+        messages: options.messages,
+        max_tokens: options.maxTokens ?? 2000,
+      });
+
+      const textBlock = response.content.find(
+        (b): b is Anthropic.TextBlock => b.type === 'text'
+      );
+      if (!textBlock?.text) {
+        return { ok: false, error: 'Empty response from LLM' };
+      }
+
+      const jsonStr = extractJson(textBlock.text);
+      const parsed = JSON.parse(jsonStr);
+      const validated = options.schema.safeParse(parsed);
+
+      if (!validated.success) {
+        return {
+          ok: false,
+          error: `Schema validation failed: ${validated.error.message}`,
+        };
+      }
+
+      return { ok: true, data: validated.data };
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      console.error('[LLMClient] generateStructured failed:', msg);
+      return { ok: false, error: msg };
+    }
+  }
+}


### PR DESCRIPTION
Closes #3

## Summary
- LLMClient class wrapping Anthropic SDK with config options
- `generateText()` — plain text response with graceful fallback
- `generateStructured<T>()` — JSON response with Zod safeParse validation (CONTRACT LLM-01)
- `extractJson()` exported utility — handles markdown fences, bare JSON, embedded JSON
- Graceful error handling: timeout/API error → fallback string (CONTRACT LLM-02)

## Test plan
- [x] `bun run build` zero errors
- [x] 16 tests pass: extractJson edge cases + LLMClient mock tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)