### PR TITLE
feat(conductor): add state machine with explicit transition conditions

### DIFF
--- a/src/conductor/state-machine.test.ts
+++ b/src/conductor/state-machine.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { checkTransition, type Phase, type IntentType } from './state-machine';
+import type { WorldCard } from '../schemas/card';
+
+function makeCard(opts: {
+  hardRules?: string[];
+  mustHave?: string[];
+  pendingCount?: number;
+}): WorldCard {
+  return {
+    goal: 'test',
+    confirmed: {
+      hard_rules: opts.hardRules ?? [],
+      soft_rules: [],
+      must_have: opts.mustHave ?? [],
+      success_criteria: [],
+    },
+    pending: Array.from({ length: opts.pendingCount ?? 0 }, (_, i) => ({
+      question: `q${i}`,
+      context: `c${i}`,
+    })),
+    chief_draft: null,
+    budget_draft: null,
+    current_proposal: null,
+    version: 1,
+  };
+}
+
+// Group 1: EXPLORE → FOCUS
+
+describe('EXPLORE → FOCUS transitions', () => {
+  it('explore → focus when hard_rule exists and must_have >= 3', () => {
+    const card = makeCard({ hardRules: ['r1'], mustHave: ['a', 'b', 'c'] });
+    const result = checkTransition('explore', card, 'add_info');
+    expect(result.newPhase).toBe('focus');
+    expect(result.reason).not.toBeNull();
+  });
+
+  it('explore → focus on set_boundary when must_have >= 2', () => {
+    const card = makeCard({ mustHave: ['a', 'b'] });
+    const result = checkTransition('explore', card, 'set_boundary');
+    expect(result.newPhase).toBe('focus');
+    expect(result.reason).not.toBeNull();
+  });
+
+  it('explore stays when must_have < 3 and no boundary', () => {
+    const card = makeCard({ mustHave: ['a'] });
+    const result = checkTransition('explore', card, 'add_info');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).toBeNull();
+  });
+
+  it('explore stays when set_boundary but must_have < 2', () => {
+    const card = makeCard({ mustHave: ['a'] });
+    const result = checkTransition('explore', card, 'set_boundary');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).toBeNull();
+  });
+
+  it('explore stays on settle_signal (cannot skip focus)', () => {
+    const card = makeCard({});
+    const result = checkTransition('explore', card, 'settle_signal');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).toBeNull();
+  });
+});
+
+// Group 2: FOCUS → SETTLE
+
+describe('FOCUS → SETTLE transitions', () => {
+  it('focus → settle when pending empty and confirm', () => {
+    const card = makeCard({ pendingCount: 0 });
+    const result = checkTransition('focus', card, 'confirm');
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).not.toBeNull();
+  });
+
+  it('focus stays when pending not empty and confirm', () => {
+    const card = makeCard({ pendingCount: 2 });
+    const result = checkTransition('focus', card, 'confirm');
+    expect(result.newPhase).toBe('focus');
+    expect(result.reason).toBeNull();
+  });
+
+  it('focus → settle on explicit settle_signal', () => {
+    const card = makeCard({ pendingCount: 1 });
+    const result = checkTransition('focus', card, 'settle_signal');
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).not.toBeNull();
+  });
+});
+
+// Group 3: Rollback transitions
+
+describe('Rollback transitions', () => {
+  it('focus → explore on new_intent (rollback)', () => {
+    const card = makeCard({});
+    const result = checkTransition('focus', card, 'new_intent');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).not.toBeNull();
+  });
+
+  it('settle → explore on new_intent (new cycle)', () => {
+    const card = makeCard({});
+    const result = checkTransition('settle', card, 'new_intent');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).not.toBeNull();
+  });
+});
+
+// Group 4: No-transition cases
+
+describe('No-transition cases', () => {
+  it('settle stays on confirm (no transition)', () => {
+    const card = makeCard({});
+    const result = checkTransition('settle', card, 'confirm');
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).toBeNull();
+  });
+
+  it('explore stays on add_info with insufficient card state', () => {
+    const card = makeCard({});
+    const result = checkTransition('explore', card, 'add_info');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).toBeNull();
+  });
+});

--- a/src/conductor/state-machine.ts
+++ b/src/conductor/state-machine.ts
@@ -1,1 +1,62 @@
-export {};
+import type { WorldCard } from '../schemas/card';
+
+export type Phase = 'explore' | 'focus' | 'settle';
+
+export interface TransitionResult {
+  newPhase: Phase;
+  reason: string | null;
+}
+
+export type IntentType =
+  | 'new_intent'
+  | 'add_info'
+  | 'set_boundary'
+  | 'add_constraint'
+  | 'style_preference'
+  | 'confirm'
+  | 'modify'
+  | 'settle_signal'
+  | 'question'
+  | 'off_topic';
+
+export function checkTransition(
+  currentPhase: Phase,
+  card: WorldCard,
+  intentType: IntentType,
+): TransitionResult {
+  // EXPLORE → FOCUS
+  if (currentPhase === 'explore') {
+    if (card.confirmed.hard_rules.length > 0 && card.confirmed.must_have.length >= 3) {
+      return { newPhase: 'focus', reason: 'hard_rule + must_have >= 3' };
+    }
+    if (intentType === 'set_boundary' && card.confirmed.must_have.length >= 2) {
+      return { newPhase: 'focus', reason: 'boundary set + must_have >= 2' };
+    }
+  }
+
+  // FOCUS → SETTLE
+  if (currentPhase === 'focus') {
+    if (card.pending.length === 0 && intentType === 'confirm') {
+      return { newPhase: 'settle', reason: 'pending empty + user confirmed' };
+    }
+    if (intentType === 'settle_signal') {
+      return { newPhase: 'settle', reason: 'user explicit settle signal' };
+    }
+  }
+
+  // SETTLE → EXPLORE
+  if (currentPhase === 'settle') {
+    if (intentType === 'new_intent') {
+      return { newPhase: 'explore', reason: 'new topic after settlement' };
+    }
+  }
+
+  // FOCUS → EXPLORE (rollback)
+  if (currentPhase === 'focus') {
+    if (intentType === 'new_intent') {
+      return { newPhase: 'explore', reason: 'major direction change' };
+    }
+  }
+
+  return { newPhase: currentPhase, reason: null };
+}


### PR DESCRIPTION
Closes #7

## Summary
- `checkTransition()` pure function for explore/focus/settle phase transitions
- Every transition has explicit boolean condition (CONTRACT COND-01)
- Phase/TransitionResult/IntentType type exports

## Test plan
- [x] `bun run build` zero errors
- [x] 12 tests pass: 5 EXPLORE→FOCUS, 3 FOCUS→SETTLE, 2 rollback, 2 no-transition

🤖 Generated with [Claude Code](https://claude.com/claude-code)