### PR TITLE
feat(thyra): add HTTP client wrapper for Thyra API

### DIFF
--- a/src/thyra-client/client.test.ts
+++ b/src/thyra-client/client.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from 'vitest';
+import { ThyraClient } from './client';
+import {
+  ThyraApiError,
+  ThyraNetworkError,
+  ThyraHttpError,
+  ThyraValidationError,
+} from './schemas';
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  return handler as unknown as typeof fetch;
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// ─── URL Construction ───
+
+describe('URL construction', () => {
+  it('createVillage → POST /api/villages', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    const client = new ThyraClient({
+      fetchFn: mockFetch((url, init) => {
+        capturedUrl = url;
+        capturedMethod = init?.method ?? 'GET';
+        return jsonResponse({ ok: true, data: { id: '1', name: 'test', target_repo: 'repo' } });
+      }),
+    });
+    await client.createVillage({ name: 'test', target_repo: 'repo' });
+    expect(capturedUrl).toBe('http://localhost:3462/api/villages');
+    expect(capturedMethod).toBe('POST');
+  });
+
+  it('createConstitution → POST /api/villages/:id/constitutions', async () => {
+    let capturedUrl = '';
+    const client = new ThyraClient({
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true, data: { id: '1', village_id: 'v1' } });
+      }),
+    });
+    await client.createConstitution('v1', { rules: [] });
+    expect(capturedUrl).toBe('http://localhost:3462/api/villages/v1/constitutions');
+  });
+
+  it('createChief → POST /api/villages/:id/chiefs', async () => {
+    let capturedUrl = '';
+    const client = new ThyraClient({
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true, data: { id: '1', village_id: 'v1', name: 'Chief' } });
+      }),
+    });
+    await client.createChief('v1', { name: 'Chief', role: 'support' });
+    expect(capturedUrl).toBe('http://localhost:3462/api/villages/v1/chiefs');
+  });
+
+  it('createSkill → POST /api/skills', async () => {
+    let capturedUrl = '';
+    const client = new ThyraClient({
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true, data: { id: '1', name: 'skill1' } });
+      }),
+    });
+    await client.createSkill({ name: 'skill1', type: 'retrieval' });
+    expect(capturedUrl).toBe('http://localhost:3462/api/skills');
+  });
+
+  it('applyVillagePack → POST /api/villages/pack/apply', async () => {
+    let capturedUrl = '';
+    let capturedBody = '';
+    const client = new ThyraClient({
+      fetchFn: mockFetch((url, init) => {
+        capturedUrl = url;
+        capturedBody = init?.body as string;
+        return jsonResponse({ ok: true, data: { village_id: 'v1', applied: true } });
+      }),
+    });
+    await client.applyVillagePack('village:\n  name: test');
+    expect(capturedUrl).toBe('http://localhost:3462/api/villages/pack/apply');
+    expect(JSON.parse(capturedBody)).toEqual({ yaml: 'village:\n  name: test' });
+  });
+
+  it('getHealth → /api/health', async () => {
+    let capturedUrl = '';
+    const client = new ThyraClient({
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true });
+      }),
+    });
+    await client.getHealth();
+    expect(capturedUrl).toBe('http://localhost:3462/api/health');
+  });
+
+  it('custom baseUrl is used', async () => {
+    let capturedUrl = '';
+    const client = new ThyraClient({
+      baseUrl: 'http://thyra:9999',
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true, data: { id: '1', name: 'x', target_repo: 'r' } });
+      }),
+    });
+    await client.createVillage({ name: 'x', target_repo: 'r' });
+    expect(capturedUrl).toBe('http://thyra:9999/api/villages');
+  });
+});
+
+// ─── Success Response Parsing ───
+
+describe('success response parsing', () => {
+  it('createVillage returns typed VillageData', async () => {
+    const client = new ThyraClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: true, data: { id: 'v1', name: 'Test', target_repo: 'repo' } })
+      ),
+    });
+    const result = await client.createVillage({ name: 'Test', target_repo: 'repo' });
+    expect(result).toEqual({ id: 'v1', name: 'Test', target_repo: 'repo' });
+  });
+});
+
+// ─── Error Handling ───
+
+describe('error handling', () => {
+  it('throws ThyraApiError on { ok: false } response', async () => {
+    const client = new ThyraClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: false, error: { code: 'NOT_FOUND', message: 'Village not found' } })
+      ),
+    });
+    await expect(client.createVillage({ name: 'x', target_repo: 'r' }))
+      .rejects.toBeInstanceOf(ThyraApiError);
+  });
+
+  it('throws ThyraHttpError on 4xx', async () => {
+    const client = new ThyraClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        new Response('Bad Request', { status: 400, statusText: 'Bad Request' })
+      ),
+    });
+    await expect(client.createVillage({ name: 'x', target_repo: 'r' }))
+      .rejects.toBeInstanceOf(ThyraHttpError);
+  });
+
+  it('throws ThyraValidationError on malformed response', async () => {
+    const client = new ThyraClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        jsonResponse({ unexpected: 'format' })
+      ),
+    });
+    await expect(client.createVillage({ name: 'x', target_repo: 'r' }))
+      .rejects.toBeInstanceOf(ThyraValidationError);
+  });
+
+  it('throws ThyraNetworkError on fetch failure', async () => {
+    const client = new ThyraClient({
+      retries: 0,
+      fetchFn: mockFetch(() => { throw new TypeError('fetch failed'); }),
+    });
+    await expect(client.createVillage({ name: 'x', target_repo: 'r' }))
+      .rejects.toBeInstanceOf(ThyraNetworkError);
+  });
+
+  it('getHealth returns { ok: false } on error (does not throw)', async () => {
+    const client = new ThyraClient({
+      fetchFn: mockFetch(() => { throw new TypeError('connection refused'); }),
+    });
+    const result = await client.getHealth();
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+// ─── Retry Behavior ───
+
+describe('retry behavior', () => {
+  it('retries on 5xx up to max retries', async () => {
+    let attempts = 0;
+    const client = new ThyraClient({
+      retries: 2,
+      fetchFn: mockFetch(() => {
+        attempts++;
+        if (attempts < 3) return new Response('Error', { status: 503, statusText: 'Service Unavailable' });
+        return jsonResponse({ ok: true, data: { id: '1', name: 'x', target_repo: 'r' } });
+      }),
+    });
+    const result = await client.createVillage({ name: 'x', target_repo: 'r' });
+    expect(attempts).toBe(3);
+    expect(result.id).toBe('1');
+  });
+
+  it('does not retry on 4xx', async () => {
+    let attempts = 0;
+    const client = new ThyraClient({
+      retries: 2,
+      fetchFn: mockFetch(() => {
+        attempts++;
+        return new Response('Not Found', { status: 404, statusText: 'Not Found' });
+      }),
+    });
+    await expect(client.createVillage({ name: 'x', target_repo: 'r' }))
+      .rejects.toBeInstanceOf(ThyraHttpError);
+    expect(attempts).toBe(1);
+  });
+
+  it('retries on network error', async () => {
+    let attempts = 0;
+    const client = new ThyraClient({
+      retries: 1,
+      fetchFn: mockFetch(() => {
+        attempts++;
+        if (attempts < 2) throw new TypeError('fetch failed');
+        return jsonResponse({ ok: true, data: { id: '1', name: 'x', target_repo: 'r' } });
+      }),
+    });
+    const result = await client.createVillage({ name: 'x', target_repo: 'r' });
+    expect(attempts).toBe(2);
+    expect(result.id).toBe('1');
+  });
+});

--- a/src/thyra-client/client.ts
+++ b/src/thyra-client/client.ts
@@ -1,1 +1,161 @@
-export {};
+import { z } from 'zod';
+import {
+  type CreateVillageInput,
+  type CreateConstitutionInput,
+  type CreateChiefInput,
+  type CreateSkillInput,
+  type VillageData,
+  type ConstitutionData,
+  type ChiefData,
+  type SkillData,
+  type PackApplyData,
+  type HealthResponse,
+  VillageDataSchema,
+  ConstitutionDataSchema,
+  ChiefDataSchema,
+  SkillDataSchema,
+  PackApplyDataSchema,
+  HealthResponseSchema,
+  ThyraErrorResponseSchema,
+  thyraSuccess,
+  ThyraNetworkError,
+  ThyraHttpError,
+  ThyraValidationError,
+  ThyraApiError,
+} from './schemas';
+
+export interface ThyraClientOptions {
+  baseUrl?: string;
+  timeout?: number;
+  retries?: number;
+  fetchFn?: typeof fetch;
+}
+
+export class ThyraClient {
+  private readonly baseUrl: string;
+  private readonly timeout: number;
+  private readonly retries: number;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: ThyraClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? 'http://localhost:3462';
+    this.timeout = options.timeout ?? 10_000;
+    this.retries = options.retries ?? 2;
+    this.fetchFn = options.fetchFn ?? globalThis.fetch;
+  }
+
+  async createVillage(input: CreateVillageInput): Promise<VillageData> {
+    return this.request('POST', '/api/villages', VillageDataSchema, input);
+  }
+
+  async createConstitution(villageId: string, input: CreateConstitutionInput): Promise<ConstitutionData> {
+    return this.request('POST', `/api/villages/${villageId}/constitutions`, ConstitutionDataSchema, input);
+  }
+
+  async createChief(villageId: string, input: CreateChiefInput): Promise<ChiefData> {
+    return this.request('POST', `/api/villages/${villageId}/chiefs`, ChiefDataSchema, input);
+  }
+
+  async createSkill(input: CreateSkillInput): Promise<SkillData> {
+    return this.request('POST', '/api/skills', SkillDataSchema, input);
+  }
+
+  async applyVillagePack(yaml: string): Promise<PackApplyData> {
+    return this.request('POST', '/api/villages/pack/apply', PackApplyDataSchema, { yaml });
+  }
+
+  async getHealth(): Promise<HealthResponse> {
+    const url = `${this.baseUrl}/api/health`;
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), this.timeout);
+      try {
+        const response = await this.fetchFn(url, { signal: controller.signal });
+        const json: unknown = await response.json();
+        const parsed = HealthResponseSchema.safeParse(json);
+        return parsed.success ? parsed.data : { ok: false };
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      return { ok: false };
+    }
+  }
+
+  private async request<T extends z.ZodTypeAny>(
+    method: string,
+    path: string,
+    dataSchema: T,
+    body?: unknown,
+  ): Promise<z.infer<T>> {
+    const response = await this.fetchWithRetry(method, path, body);
+    const json: unknown = await response.json();
+
+    // Check for error response first
+    const errorParsed = ThyraErrorResponseSchema.safeParse(json);
+    if (errorParsed.success) {
+      throw new ThyraApiError(errorParsed.data.error.code, errorParsed.data.error.message);
+    }
+
+    // Parse success response
+    const successSchema = thyraSuccess(dataSchema);
+    const successParsed = successSchema.safeParse(json);
+    if (!successParsed.success) {
+      throw new ThyraValidationError(successParsed.error);
+    }
+
+    return successParsed.data.data as z.infer<T>;
+  }
+
+  private async fetchWithRetry(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= this.retries; attempt++) {
+      if (attempt > 0) {
+        await new Promise(resolve => setTimeout(resolve, 100 * Math.pow(2, attempt - 1)));
+      }
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), this.timeout);
+
+      try {
+        const response = await this.fetchFn(url, {
+          method,
+          headers: { 'Content-Type': 'application/json' },
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const responseBody = await response.text();
+          const error = new ThyraHttpError(response.status, response.statusText, responseBody);
+          if (!error.retryable) throw error;
+          lastError = error;
+          continue;
+        }
+
+        return response;
+      } catch (error) {
+        if (error instanceof ThyraHttpError) throw error;
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          lastError = new ThyraNetworkError(`Request timeout after ${this.timeout}ms`, error);
+          continue;
+        }
+        lastError = new ThyraNetworkError(
+          error instanceof Error ? error.message : 'Network error',
+          error,
+        );
+        continue;
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    throw lastError ?? new ThyraNetworkError('Request failed after retries');
+  }
+}

--- a/src/thyra-client/schemas.ts
+++ b/src/thyra-client/schemas.ts
@@ -1,1 +1,150 @@
-export {};
+import { z } from 'zod';
+
+// ─── Error Classes ───
+
+export class ThyraError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'ThyraError';
+  }
+}
+
+export class ThyraNetworkError extends ThyraError {
+  readonly retryable = true as const;
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = 'ThyraNetworkError';
+  }
+}
+
+export class ThyraHttpError extends ThyraError {
+  readonly retryable: boolean;
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly body: string,
+  ) {
+    super(`HTTP ${status}: ${statusText}`);
+    this.name = 'ThyraHttpError';
+    this.retryable = status >= 500 || status === 429;
+  }
+}
+
+export class ThyraValidationError extends ThyraError {
+  readonly retryable = false as const;
+  constructor(public readonly zodError: z.ZodError) {
+    super(`Response validation failed: ${zodError.message}`);
+    this.name = 'ThyraValidationError';
+  }
+}
+
+export class ThyraApiError extends ThyraError {
+  readonly retryable = false as const;
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'ThyraApiError';
+  }
+}
+
+// ─── Response Schemas ───
+
+export const ThyraErrorResponseSchema = z.object({
+  ok: z.literal(false),
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
+export function thyraSuccess<T extends z.ZodTypeAny>(dataSchema: T) {
+  return z.object({
+    ok: z.literal(true),
+    data: dataSchema,
+  });
+}
+
+export const ThyraResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
+  z.discriminatedUnion('ok', [
+    thyraSuccess(dataSchema),
+    ThyraErrorResponseSchema,
+  ]);
+
+// ─── Entity Data Schemas ───
+
+export const VillageDataSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  target_repo: z.string(),
+});
+export type VillageData = z.infer<typeof VillageDataSchema>;
+
+export const ConstitutionDataSchema = z.object({
+  id: z.string(),
+  village_id: z.string(),
+});
+export type ConstitutionData = z.infer<typeof ConstitutionDataSchema>;
+
+export const ChiefDataSchema = z.object({
+  id: z.string(),
+  village_id: z.string(),
+  name: z.string(),
+});
+export type ChiefData = z.infer<typeof ChiefDataSchema>;
+
+export const SkillDataSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+export type SkillData = z.infer<typeof SkillDataSchema>;
+
+export const PackApplyDataSchema = z.object({
+  village_id: z.string(),
+  applied: z.boolean(),
+});
+export type PackApplyData = z.infer<typeof PackApplyDataSchema>;
+
+export const HealthResponseSchema = z.object({
+  ok: z.boolean(),
+});
+export type HealthResponse = z.infer<typeof HealthResponseSchema>;
+
+// ─── Input Schemas ───
+
+export const CreateVillageInputSchema = z.object({
+  name: z.string().min(1),
+  target_repo: z.string().min(1),
+});
+export type CreateVillageInput = z.infer<typeof CreateVillageInputSchema>;
+
+export const CreateConstitutionInputSchema = z.object({
+  rules: z.array(z.object({
+    description: z.string(),
+    enforcement: z.enum(['hard', 'soft']),
+    scope: z.array(z.string()),
+  })),
+  allowed_permissions: z.array(z.string()).optional(),
+  budget_limits: z.object({
+    max_cost_per_action: z.number(),
+    max_cost_per_day: z.number(),
+    max_cost_per_loop: z.number(),
+  }).optional(),
+});
+export type CreateConstitutionInput = z.infer<typeof CreateConstitutionInputSchema>;
+
+export const CreateChiefInputSchema = z.object({
+  name: z.string().min(1),
+  role: z.string().min(1),
+  personality: z.string().optional(),
+  permissions: z.array(z.string()).optional(),
+});
+export type CreateChiefInput = z.infer<typeof CreateChiefInputSchema>;
+
+export const CreateSkillInputSchema = z.object({
+  name: z.string().min(1),
+  type: z.string().min(1),
+  description: z.string().optional(),
+});
+export type CreateSkillInput = z.infer<typeof CreateSkillInputSchema>;


### PR DESCRIPTION
Closes #10

## Summary
- ThyraClient class with constructor-injected fetch (CONTRACT ARCH-01: no direct DB access)
- 6 API methods: createVillage, createConstitution, createChief, createSkill, applyVillagePack, getHealth
- Zod response validation for all endpoints
- Typed error hierarchy: ThyraNetworkError, ThyraHttpError, ThyraValidationError, ThyraApiError
- Exponential backoff retry on 5xx/429/network errors
- getHealth gracefully returns `{ ok: false }` on failure (never throws)

## Test plan
- [x] `bun run build` zero errors
- [x] 16 tests pass: URL construction, response parsing, 4 error types, retry behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)