### PR TITLE
feat(llm): add intent parser + response generator with structured prompts

### DIFF
--- a/src/conductor/state-machine.ts
+++ b/src/conductor/state-machine.ts
@@ -1,4 +1,7 @@
 import type { WorldCard } from '../schemas/card';
+import type { IntentType } from '../schemas/intent';
+
+export type { IntentType } from '../schemas/intent';
 
 export type Phase = 'explore' | 'focus' | 'settle';
 
@@ -6,18 +9,6 @@ export interface TransitionResult {
   newPhase: Phase;
   reason: string | null;
 }
-
-export type IntentType =
-  | 'new_intent'
-  | 'add_info'
-  | 'set_boundary'
-  | 'add_constraint'
-  | 'style_preference'
-  | 'confirm'
-  | 'modify'
-  | 'settle_signal'
-  | 'question'
-  | 'off_topic';
 
 export function checkTransition(
   currentPhase: Phase,

--- a/src/llm/intent-parser.test.ts
+++ b/src/llm/intent-parser.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGenerateStructured = vi.fn();
+vi.mock('./client', () => ({
+  LLMClient: vi.fn().mockImplementation(() => ({
+    generateStructured: mockGenerateStructured,
+  })),
+}));
+
+import { parseIntent } from './intent-parser';
+import type { LLMClient } from './client';
+
+describe('parseIntent', () => {
+  const mockLlm = { generateStructured: mockGenerateStructured } as unknown as LLMClient;
+  const cardSnapshot = '{"goal":"test","version":1}';
+
+  beforeEach(() => {
+    mockGenerateStructured.mockReset();
+  });
+
+  it('returns parsed intent on success', async () => {
+    const intent = {
+      type: 'new_intent' as const,
+      summary: '使用者想做自動化客服',
+      entities: { domain: 'customer_service' },
+    };
+    mockGenerateStructured.mockResolvedValueOnce({ ok: true, data: intent });
+
+    const result = await parseIntent(mockLlm, '我想做一個客服', cardSnapshot);
+    expect(result).toEqual(intent);
+  });
+
+  it('falls back to off_topic on schema validation failure', async () => {
+    mockGenerateStructured.mockResolvedValueOnce({
+      ok: false,
+      error: 'Schema validation failed',
+    });
+
+    const result = await parseIntent(mockLlm, '亂七八糟的話', cardSnapshot);
+    expect(result.type).toBe('off_topic');
+    expect(result.summary).toBe('亂七八糟的話');
+  });
+
+  it('falls back to off_topic on LLM error', async () => {
+    mockGenerateStructured.mockResolvedValueOnce({
+      ok: false,
+      error: 'API timeout',
+    });
+
+    const result = await parseIntent(mockLlm, 'hello', cardSnapshot);
+    expect(result.type).toBe('off_topic');
+    expect(result.summary).toBe('hello');
+  });
+
+  it('passes card snapshot and user message to LLM', async () => {
+    mockGenerateStructured.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'confirm', summary: '好' },
+    });
+
+    await parseIntent(mockLlm, '好', '{"goal":"客服"}');
+
+    expect(mockGenerateStructured).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [
+          expect.objectContaining({
+            content: expect.stringContaining('客服'),
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/src/llm/intent-parser.ts
+++ b/src/llm/intent-parser.ts
@@ -1,1 +1,32 @@
-export {};
+import type { LLMClient } from './client';
+import { IntentSchema, type Intent } from '../schemas/intent';
+import { INTENT_SYSTEM_PROMPT } from './prompts';
+
+const FALLBACK_INTENT = (userMessage: string): Intent => ({
+  type: 'off_topic',
+  summary: userMessage,
+});
+
+export async function parseIntent(
+  llm: LLMClient,
+  userMessage: string,
+  cardSnapshot: string,
+): Promise<Intent> {
+  const result = await llm.generateStructured({
+    system: INTENT_SYSTEM_PROMPT,
+    messages: [
+      {
+        role: 'user',
+        content: `短卡現狀：\n${cardSnapshot}\n\n使用者說：${userMessage}`,
+      },
+    ],
+    schema: IntentSchema,
+    schemaDescription:
+      'Intent object with type (one of 10 enum values), summary (string), optional entities (record), optional enforcement (hard|soft), optional signals (string array)',
+  });
+
+  if (result.ok) return result.data;
+
+  console.warn('[parseIntent] fallback to off_topic:', result.error);
+  return FALLBACK_INTENT(userMessage);
+}

--- a/src/llm/prompts.ts
+++ b/src/llm/prompts.ts
@@ -1,1 +1,44 @@
-export {};
+export const INTENT_SYSTEM_PROMPT = `你是一個意圖理解專家。分析使用者的話語，提取結構化意圖。
+
+你必須回傳有效的 JSON，格式如下：
+{
+  "type": "new_intent|add_info|set_boundary|add_constraint|style_preference|confirm|modify|settle_signal|question|off_topic",
+  "summary": "一句話摘要使用者的意圖",
+  "entities": { "key": "value" },
+  "enforcement": "hard|soft",
+  "signals": ["keyword1"]
+}
+
+重要規則：
+- set_boundary：使用者明確說「一定要」「不能」「必須」→ enforcement: "hard"
+- set_boundary：使用者說「最好」「盡量」「建議」→ enforcement: "soft"
+- confirm：使用者說「好」「可以」「沒問題」「OK」
+- settle_signal：使用者說「生成」「套用」「建立」「開始」
+- entities 和 enforcement 和 signals 是可選的，沒有就不要加
+- 只回傳 JSON，不要加任何其他文字`;
+
+export type Strategy = 'mirror' | 'probe' | 'propose' | 'confirm' | 'settle' | 'redirect';
+
+export function buildReplyPrompt(strategy: Strategy, cardSnapshot: string): string {
+  return `你是 Völva，一個友善的對話導演。你的任務是引導使用者逐步收斂想法。
+
+當前策略：${strategy}
+
+策略說明：
+- mirror：重述使用者的話確認理解，不加新東西
+- probe：問一個小問題，幫助使用者想更清楚（最多問 1 個問題）
+- propose：提出一個具體的小提案，讓使用者確認或修改
+- confirm：摘要目前已確認的內容，問要不要繼續
+- settle：展示最終摘要，問要不要生成/套用
+- redirect：溫和地引導回主題
+
+當前短卡狀態：
+${cardSnapshot}
+
+重要規則：
+- 用繁體中文回覆
+- 語氣親切自然，不要太正式
+- 不要一次問太多問題（最多 1 個）
+- 不要主動提到「短卡」「schema」「Village Pack」等技術術語
+- 簡短回覆，不超過 3 句話`;
+}

--- a/src/llm/response-gen.test.ts
+++ b/src/llm/response-gen.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGenerateText = vi.fn();
+vi.mock('./client', () => ({
+  LLMClient: vi.fn().mockImplementation(() => ({
+    generateText: mockGenerateText,
+  })),
+}));
+
+import { generateReply } from './response-gen';
+import type { Strategy } from './prompts';
+import type { LLMClient } from './client';
+
+describe('generateReply', () => {
+  const mockLlm = { generateText: mockGenerateText } as unknown as LLMClient;
+  const cardSnapshot = '{"goal":"test","version":1}';
+
+  beforeEach(() => {
+    mockGenerateText.mockReset();
+  });
+
+  it('returns LLM-generated text', async () => {
+    mockGenerateText.mockResolvedValueOnce('好的，自動化客服。你的客戶主要會問什麼類型的問題？');
+
+    const result = await generateReply(mockLlm, 'probe', cardSnapshot, '我想做客服');
+    expect(result).toBe('好的，自動化客服。你的客戶主要會問什麼類型的問題？');
+  });
+
+  it('passes strategy to system prompt', async () => {
+    mockGenerateText.mockResolvedValueOnce('reply');
+
+    await generateReply(mockLlm, 'mirror', cardSnapshot, 'test');
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining('mirror'),
+      }),
+    );
+  });
+
+  it('passes card snapshot to system prompt', async () => {
+    mockGenerateText.mockResolvedValueOnce('reply');
+
+    await generateReply(mockLlm, 'propose', '{"goal":"客服系統"}', 'test');
+
+    expect(mockGenerateText).toHaveBeenCalledWith(
+      expect.objectContaining({
+        system: expect.stringContaining('客服系統'),
+      }),
+    );
+  });
+
+  it('accepts all 6 strategy types', async () => {
+    const strategies: Strategy[] = ['mirror', 'probe', 'propose', 'confirm', 'settle', 'redirect'];
+
+    for (const strategy of strategies) {
+      mockGenerateText.mockResolvedValueOnce('reply');
+      const result = await generateReply(mockLlm, strategy, cardSnapshot, 'test');
+      expect(result).toBe('reply');
+    }
+  });
+
+  it('returns fallback string on LLM failure', async () => {
+    mockGenerateText.mockResolvedValueOnce('[系統暫時無法回應，請稍後再試]');
+
+    const result = await generateReply(mockLlm, 'probe', cardSnapshot, 'test');
+    expect(result).toBe('[系統暫時無法回應，請稍後再試]');
+  });
+});

--- a/src/llm/response-gen.ts
+++ b/src/llm/response-gen.ts
@@ -1,1 +1,21 @@
-export {};
+import type { LLMClient } from './client';
+import { buildReplyPrompt, type Strategy } from './prompts';
+
+export type { Strategy } from './prompts';
+
+export async function generateReply(
+  llm: LLMClient,
+  strategy: Strategy,
+  cardSnapshot: string,
+  userMessage: string,
+): Promise<string> {
+  const system = buildReplyPrompt(strategy, cardSnapshot);
+
+  const reply = await llm.generateText({
+    system,
+    messages: [{ role: 'user', content: userMessage }],
+    maxTokens: 500,
+  });
+
+  return reply;
+}

--- a/src/schemas/intent.test.ts
+++ b/src/schemas/intent.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest';
+import { IntentSchema, IntentType } from './intent';
+
+describe('IntentType', () => {
+  it('accepts all 10 valid intent types', () => {
+    const types = [
+      'new_intent', 'add_info', 'set_boundary', 'add_constraint',
+      'style_preference', 'confirm', 'modify', 'settle_signal',
+      'question', 'off_topic',
+    ];
+    for (const t of types) {
+      expect(IntentType.safeParse(t).success).toBe(true);
+    }
+  });
+
+  it('rejects invalid intent type', () => {
+    expect(IntentType.safeParse('invalid').success).toBe(false);
+    expect(IntentType.safeParse('').success).toBe(false);
+    expect(IntentType.safeParse(123).success).toBe(false);
+  });
+});
+
+describe('IntentSchema', () => {
+  it('accepts valid intent with all fields', () => {
+    const result = IntentSchema.safeParse({
+      type: 'new_intent',
+      summary: '使用者想做自動化客服',
+      entities: { domain: 'customer_service' },
+      enforcement: 'hard',
+      signals: ['automation'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts minimal intent (type + summary only)', () => {
+    const result = IntentSchema.safeParse({
+      type: 'confirm',
+      summary: '好',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts set_boundary with enforcement', () => {
+    const result = IntentSchema.safeParse({
+      type: 'set_boundary',
+      summary: '退款必須轉人工',
+      enforcement: 'hard',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.enforcement).toBe('hard');
+    }
+  });
+
+  it('accepts soft enforcement', () => {
+    const result = IntentSchema.safeParse({
+      type: 'add_constraint',
+      summary: '庫存延遲最好不超過 5 分鐘',
+      enforcement: 'soft',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid type', () => {
+    const result = IntentSchema.safeParse({
+      type: 'invalid_type',
+      summary: 'test',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing summary', () => {
+    const result = IntentSchema.safeParse({
+      type: 'confirm',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid enforcement value', () => {
+    const result = IntentSchema.safeParse({
+      type: 'set_boundary',
+      summary: 'test',
+      enforcement: 'medium',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts entities as string record', () => {
+    const result = IntentSchema.safeParse({
+      type: 'add_info',
+      summary: '補充功能',
+      entities: { feature1: 'product_intro', feature2: 'inventory' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects entities with non-string values', () => {
+    const result = IntentSchema.safeParse({
+      type: 'add_info',
+      summary: 'test',
+      entities: { count: 42 },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/schemas/intent.ts
+++ b/src/schemas/intent.ts
@@ -1,1 +1,24 @@
-export {};
+import { z } from 'zod';
+
+export const IntentType = z.enum([
+  'new_intent',
+  'add_info',
+  'set_boundary',
+  'add_constraint',
+  'style_preference',
+  'confirm',
+  'modify',
+  'settle_signal',
+  'question',
+  'off_topic',
+]);
+export type IntentType = z.infer<typeof IntentType>;
+
+export const IntentSchema = z.object({
+  type: IntentType,
+  summary: z.string(),
+  entities: z.record(z.string()).optional(),
+  enforcement: z.enum(['hard', 'soft']).optional(),
+  signals: z.array(z.string()).optional(),
+});
+export type Intent = z.infer<typeof IntentSchema>;


### PR DESCRIPTION
Closes #4

## Summary
- IntentType enum (10 types) + IntentSchema with Zod validation
- parseIntent() with off_topic fallback (CONTRACT LLM-01, LLM-02)
- generateReply() with 6 strategies (mirror/probe/propose/confirm/settle/redirect)
- Dedup: state-machine.ts now imports IntentType from schemas/intent

## Test plan
- [x] `bun run build` zero errors
- [x] 20 new tests pass (11 schema + 4 parser + 5 response-gen)
- [x] Existing state-machine tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)