### PR TITLE
feat(cards): add CardManager with CRUD, versioning, and diff

### DIFF
--- a/src/cards/card-manager.test.ts
+++ b/src/cards/card-manager.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CardManager, computeDiff } from './card-manager';
+import type { WorldCard } from '../schemas/card';
+
+const minimalWorldCard: WorldCard = {
+  goal: null,
+  confirmed: {
+    hard_rules: [],
+    soft_rules: [],
+    must_have: [],
+    success_criteria: [],
+  },
+  pending: [],
+  chief_draft: null,
+  budget_draft: null,
+  current_proposal: null,
+  version: 1,
+};
+
+const fullWorldCard: WorldCard = {
+  goal: 'Build automated customer service',
+  confirmed: {
+    hard_rules: ['No refunds without human approval'],
+    soft_rules: ['Avoid robotic tone'],
+    must_have: ['24/7 availability'],
+    success_criteria: ['90% satisfaction'],
+  },
+  pending: [
+    { question: 'What languages?', context: 'User mentioned intl' },
+  ],
+  chief_draft: {
+    name: 'ServiceBot',
+    role: 'Support lead',
+    style: 'Friendly',
+  },
+  budget_draft: { per_action: 0.05, per_day: 10 },
+  current_proposal: 'Start with FAQ',
+  version: 1,
+};
+
+// ─── Create Tests ───
+
+describe('CardManager.create', () => {
+  let mgr: CardManager;
+
+  beforeEach(() => {
+    mgr = new CardManager();
+  });
+
+  it('creates a WorldCard with version=1', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    expect(card.version).toBe(1);
+    expect(card.type).toBe('world');
+    expect(card.conversationId).toBe('conv1');
+    expect(card.content.version).toBe(1);
+  });
+
+  it('assigns unique id', () => {
+    const card1 = mgr.create('conv1', 'world', minimalWorldCard);
+    const card2 = mgr.create('conv2', 'world', minimalWorldCard);
+    expect(card1.id).not.toBe(card2.id);
+  });
+
+  it('sets timestamps', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    expect(card.createdAt).toBeTruthy();
+    expect(card.updatedAt).toBeTruthy();
+  });
+
+  it('stores card retrievable by conversationId', () => {
+    mgr.create('conv1', 'world', fullWorldCard);
+    const found = mgr.getLatest('conv1');
+    expect(found).not.toBeNull();
+    expect((found!.content as WorldCard).goal).toBe('Build automated customer service');
+  });
+});
+
+// ─── Update Tests ───
+
+describe('CardManager.update', () => {
+  let mgr: CardManager;
+
+  beforeEach(() => {
+    mgr = new CardManager();
+  });
+
+  it('increments version on update', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    const { card: updated } = mgr.update(card.id, {
+      ...minimalWorldCard,
+      goal: 'New goal',
+    });
+    expect(updated.version).toBe(2);
+    expect(updated.content.version).toBe(2);
+  });
+
+  it('returns diff with changed fields', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    const { diff } = mgr.update(card.id, {
+      ...minimalWorldCard,
+      goal: 'New goal',
+    });
+    expect(diff.changed).toContain('goal');
+  });
+
+  it('consecutive updates increment version', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    const { card: v2 } = mgr.update(card.id, { ...minimalWorldCard, goal: 'v2' });
+    const { card: v3 } = mgr.update(v2.id, { ...minimalWorldCard, goal: 'v3' });
+    expect(v3.version).toBe(3);
+  });
+
+  it('throws on non-existent cardId', () => {
+    expect(() => mgr.update('nonexistent', minimalWorldCard)).toThrow('Card not found');
+  });
+});
+
+// ─── Diff Tests ───
+
+describe('computeDiff', () => {
+  it('detects changed fields', () => {
+    const diff = computeDiff(
+      { goal: 'old', version: 1 },
+      { goal: 'new', version: 2 },
+    );
+    expect(diff.changed).toContain('goal');
+    expect(diff.changed).toContain('version');
+  });
+
+  it('detects added fields', () => {
+    const diff = computeDiff(
+      { goal: null },
+      { goal: 'new', extra: 'field' },
+    );
+    expect(diff.added).toContain('extra');
+  });
+
+  it('detects removed fields', () => {
+    const diff = computeDiff(
+      { goal: 'old', extra: 'field' },
+      { goal: 'old' },
+    );
+    expect(diff.removed).toContain('extra');
+  });
+
+  it('returns empty diff for identical content', () => {
+    const obj = { goal: 'same', version: 1 };
+    const diff = computeDiff(obj, { ...obj });
+    expect(diff.added).toHaveLength(0);
+    expect(diff.removed).toHaveLength(0);
+    expect(diff.changed).toHaveLength(0);
+  });
+
+  it('detects nested changes', () => {
+    const diff = computeDiff(
+      { confirmed: { hard_rules: ['rule1'] } },
+      { confirmed: { hard_rules: ['rule1', 'rule2'] } },
+    );
+    expect(diff.changed.some(p => p.includes('hard_rules'))).toBe(true);
+  });
+
+  it('handles array element changes', () => {
+    const diff = computeDiff(
+      { items: [{ name: 'a' }] },
+      { items: [{ name: 'b' }] },
+    );
+    expect(diff.changed).toContain('items[0].name');
+  });
+});
+
+// ─── Edge Cases ───
+
+describe('CardManager edge cases', () => {
+  it('getLatest returns null for unknown conversation', () => {
+    const mgr = new CardManager();
+    expect(mgr.getLatest('unknown')).toBeNull();
+  });
+
+  it('diff method works without persisting', () => {
+    const mgr = new CardManager();
+    const diff = mgr.diff(minimalWorldCard, fullWorldCard);
+    expect(diff.changed).toContain('goal');
+  });
+});

--- a/src/cards/card-manager.ts
+++ b/src/cards/card-manager.ts
@@ -1,1 +1,141 @@
-export {};
+import type { CardType, AnyCard, CardDiff, CardEnvelope } from '../schemas/card';
+
+// ─── Diff Logic ───
+
+function flattenObject(
+  obj: Record<string, unknown>,
+  prefix = '',
+): Map<string, unknown> {
+  const result = new Map<string, unknown>();
+
+  for (const [key, value] of Object.entries(obj)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+
+    if (Array.isArray(value)) {
+      result.set(path, `[length:${value.length}]`);
+      for (let i = 0; i < value.length; i++) {
+        const itemPath = `${path}[${i}]`;
+        if (typeof value[i] === 'object' && value[i] !== null) {
+          for (const [k, v] of flattenObject(
+            value[i] as Record<string, unknown>,
+            itemPath,
+          )) {
+            result.set(k, v);
+          }
+        } else {
+          result.set(itemPath, value[i]);
+        }
+      }
+    } else if (typeof value === 'object' && value !== null) {
+      for (const [k, v] of flattenObject(
+        value as Record<string, unknown>,
+        path,
+      )) {
+        result.set(k, v);
+      }
+    } else {
+      result.set(path, value);
+    }
+  }
+  return result;
+}
+
+export function computeDiff(
+  oldContent: Record<string, unknown>,
+  newContent: Record<string, unknown>,
+): CardDiff {
+  const oldFlat = flattenObject(oldContent);
+  const newFlat = flattenObject(newContent);
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const changed: string[] = [];
+
+  for (const key of newFlat.keys()) {
+    if (!oldFlat.has(key)) {
+      added.push(key);
+    } else if (
+      JSON.stringify(oldFlat.get(key)) !== JSON.stringify(newFlat.get(key))
+    ) {
+      changed.push(key);
+    }
+  }
+
+  for (const key of oldFlat.keys()) {
+    if (!newFlat.has(key)) {
+      removed.push(key);
+    }
+  }
+
+  return { added, removed, changed };
+}
+
+// ─── CardManager ───
+
+export class CardManager {
+  private cards = new Map<string, CardEnvelope>();
+  private conversationIndex = new Map<string, string>();
+
+  create(
+    conversationId: string,
+    type: CardType,
+    content: AnyCard,
+  ): CardEnvelope {
+    const now = new Date().toISOString();
+    const card: CardEnvelope = {
+      id: crypto.randomUUID(),
+      conversationId,
+      type,
+      content: { ...content, version: 1 },
+      version: 1,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.cards.set(card.id, card);
+    this.conversationIndex.set(conversationId, card.id);
+    return card;
+  }
+
+  update(
+    cardId: string,
+    content: AnyCard,
+  ): { card: CardEnvelope; diff: CardDiff } {
+    const existing = this.cards.get(cardId);
+    if (!existing) {
+      throw new Error(`Card not found: ${cardId}`);
+    }
+
+    const newVersion = existing.version + 1;
+    const now = new Date().toISOString();
+
+    const mergedContent = { ...content, version: newVersion };
+
+    const diff = computeDiff(
+      existing.content as unknown as Record<string, unknown>,
+      mergedContent as unknown as Record<string, unknown>,
+    );
+
+    const updatedCard: CardEnvelope = {
+      ...existing,
+      content: mergedContent,
+      version: newVersion,
+      updatedAt: now,
+    };
+
+    this.cards.set(cardId, updatedCard);
+    return { card: updatedCard, diff };
+  }
+
+  getLatest(conversationId: string): CardEnvelope | null {
+    const cardId = this.conversationIndex.get(conversationId);
+    if (!cardId) return null;
+    return this.cards.get(cardId) ?? null;
+  }
+
+  diff(oldContent: AnyCard, newContent: AnyCard): CardDiff {
+    return computeDiff(
+      oldContent as unknown as Record<string, unknown>,
+      newContent as unknown as Record<string, unknown>,
+    );
+  }
+}

--- a/src/schemas/card.ts
+++ b/src/schemas/card.ts
@@ -81,3 +81,24 @@ export type TaskCard = z.infer<typeof TaskCardSchema>;
 // ─── Union type for downstream consumers ───
 
 export type AnyCard = WorldCard | WorkflowCard | TaskCard;
+
+// ─── Card Diff ───
+
+export const CardDiffSchema = z.object({
+  added: z.array(z.string()),
+  removed: z.array(z.string()),
+  changed: z.array(z.string()),
+});
+export type CardDiff = z.infer<typeof CardDiffSchema>;
+
+// ─── Card Envelope ───
+
+export interface CardEnvelope {
+  id: string;
+  conversationId: string;
+  type: CardType;
+  content: AnyCard;
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
Closes #6

## Summary
- CardManager: create (version=1), update (version+1), getLatest, diff
- computeDiff() with recursive dot-path flattening
- CardEnvelope + CardDiff types added to schemas/card.ts

## Test plan
- [x] `bun run build` zero errors
- [x] 16 tests pass: create, update, diff, edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)