### PR TITLE
feat(settlement): add router + village pack builder from WorldCard

### DIFF
--- a/src/schemas/settlement.ts
+++ b/src/schemas/settlement.ts
@@ -1,1 +1,20 @@
-export {};
+import { z } from 'zod';
+
+export const SettlementTarget = z.enum(['village_pack', 'workflow', 'task']);
+export type SettlementTarget = z.infer<typeof SettlementTarget>;
+
+export const SettlementStatus = z.enum(['draft', 'confirmed', 'applied', 'failed']);
+export type SettlementStatus = z.infer<typeof SettlementStatus>;
+
+export const SettlementSchema = z.object({
+  id: z.string(),
+  conversation_id: z.string(),
+  card_id: z.string(),
+  target: SettlementTarget,
+  payload: z.string(),
+  status: SettlementStatus,
+  thyra_response: z.string().nullable(),
+  created_at: z.string(),
+});
+
+export type Settlement = z.infer<typeof SettlementSchema>;

--- a/src/settlement/router.test.ts
+++ b/src/settlement/router.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { classifySettlement } from './router';
+import type { WorldCard, WorkflowCard, TaskCard } from '../schemas/card';
+
+const emptyWorldCard: WorldCard = {
+  goal: null,
+  confirmed: { hard_rules: [], soft_rules: [], must_have: [], success_criteria: [] },
+  pending: [],
+  chief_draft: null,
+  budget_draft: null,
+  current_proposal: null,
+  version: 1,
+};
+
+describe('classifySettlement', () => {
+  it('WorldCard with hard_rules → village_pack', () => {
+    const card: WorldCard = {
+      ...emptyWorldCard,
+      confirmed: { ...emptyWorldCard.confirmed, hard_rules: ['rule1'] },
+    };
+    expect(classifySettlement('world', card)).toBe('village_pack');
+  });
+
+  it('WorldCard with chief_draft (no hard_rules) → village_pack', () => {
+    const card: WorldCard = {
+      ...emptyWorldCard,
+      chief_draft: { name: 'Bot', role: 'support', style: 'friendly' },
+    };
+    expect(classifySettlement('world', card)).toBe('village_pack');
+  });
+
+  it('empty WorldCard → null', () => {
+    expect(classifySettlement('world', emptyWorldCard)).toBeNull();
+  });
+
+  it('WorkflowCard with steps → workflow', () => {
+    const card: WorkflowCard = {
+      name: 'test',
+      purpose: null,
+      steps: [{ order: 0, description: 'step1', skill: null, conditions: null }],
+      confirmed: { triggers: [], exit_conditions: [], failure_handling: [] },
+      pending: [],
+      version: 1,
+    };
+    expect(classifySettlement('workflow', card)).toBe('workflow');
+  });
+
+  it('WorkflowCard with empty steps → null', () => {
+    const card: WorkflowCard = {
+      name: null,
+      purpose: null,
+      steps: [],
+      confirmed: { triggers: [], exit_conditions: [], failure_handling: [] },
+      pending: [],
+      version: 1,
+    };
+    expect(classifySettlement('workflow', card)).toBeNull();
+  });
+
+  it('TaskCard → task', () => {
+    const card: TaskCard = {
+      intent: 'test',
+      inputs: {},
+      constraints: [],
+      success_condition: null,
+      version: 1,
+    };
+    expect(classifySettlement('task', card)).toBe('task');
+  });
+});

--- a/src/settlement/router.ts
+++ b/src/settlement/router.ts
@@ -1,1 +1,29 @@
-export {};
+import type { CardType, AnyCard, WorldCard, WorkflowCard } from '../schemas/card';
+import type { SettlementTarget } from '../schemas/settlement';
+
+export function classifySettlement(
+  cardType: CardType,
+  card: AnyCard,
+): SettlementTarget | null {
+  if (cardType === 'world') {
+    const worldCard = card as WorldCard;
+    if (worldCard.confirmed.hard_rules.length > 0 || worldCard.chief_draft !== null) {
+      return 'village_pack';
+    }
+    return null;
+  }
+
+  if (cardType === 'workflow') {
+    const workflowCard = card as WorkflowCard;
+    if (workflowCard.steps.length > 0) {
+      return 'workflow';
+    }
+    return null;
+  }
+
+  if (cardType === 'task') {
+    return 'task';
+  }
+
+  return null;
+}

--- a/src/settlement/village-pack-builder.test.ts
+++ b/src/settlement/village-pack-builder.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
+import { buildVillagePack } from './village-pack-builder';
+import type { WorldCard } from '../schemas/card';
+
+const baseCard: WorldCard = {
+  goal: 'My Village',
+  confirmed: {
+    hard_rules: ['No refunds'],
+    soft_rules: ['Be polite'],
+    must_have: ['Product FAQ', 'Inventory Check'],
+    success_criteria: [],
+  },
+  pending: [],
+  chief_draft: { name: 'Bot', role: 'support', style: 'warm' },
+  budget_draft: { per_action: 5, per_day: 200 },
+  current_proposal: null,
+  version: 3,
+};
+
+describe('buildVillagePack', () => {
+  it('produces valid YAML string', () => {
+    const result = buildVillagePack(baseCard);
+    expect(typeof result).toBe('string');
+    expect(() => yaml.load(result)).not.toThrow();
+  });
+
+  it('maps goal to village.name', () => {
+    const result = yaml.load(buildVillagePack(baseCard)) as Record<string, unknown>;
+    expect((result.village as Record<string, unknown>).name).toBe('My Village');
+  });
+
+  it('uses fallback name when goal is null', () => {
+    const card: WorldCard = { ...baseCard, goal: null };
+    const result = yaml.load(buildVillagePack(card)) as Record<string, unknown>;
+    expect((result.village as Record<string, unknown>).name).toBe('Untitled Village');
+  });
+
+  it('includes constitution rules from card', () => {
+    const result = yaml.load(buildVillagePack(baseCard)) as Record<string, unknown>;
+    const constitution = result.constitution as Record<string, unknown>;
+    const rules = constitution.rules as Array<Record<string, string>>;
+    expect(rules).toHaveLength(2);
+    expect(rules[0].enforcement).toBe('hard');
+    expect(rules[1].enforcement).toBe('soft');
+  });
+
+  it('includes chief section when chief_draft is present', () => {
+    const result = yaml.load(buildVillagePack(baseCard)) as Record<string, unknown>;
+    const chief = result.chief as Record<string, unknown>;
+    expect(chief.name).toBe('Bot');
+    expect(chief.personality).toBe('warm');
+  });
+
+  it('omits chief section when chief_draft is null', () => {
+    const card: WorldCard = { ...baseCard, chief_draft: null };
+    const result = yaml.load(buildVillagePack(card)) as Record<string, unknown>;
+    expect(result.chief).toBeUndefined();
+  });
+
+  it('maps must_have to skills array', () => {
+    const result = yaml.load(buildVillagePack(baseCard)) as Record<string, unknown>;
+    const skills = result.skills as Array<Record<string, string>>;
+    expect(skills).toHaveLength(2);
+    expect(skills[0].description).toBe('Product FAQ');
+    expect(skills[1].description).toBe('Inventory Check');
+  });
+
+  it('includes budget_limits when budget_draft is present', () => {
+    const result = yaml.load(buildVillagePack(baseCard)) as Record<string, unknown>;
+    const constitution = result.constitution as Record<string, unknown>;
+    expect(constitution.budget_limits).toBeDefined();
+  });
+
+  it('omits budget_limits when budget_draft is null', () => {
+    const card: WorldCard = { ...baseCard, budget_draft: null };
+    const result = yaml.load(buildVillagePack(card)) as Record<string, unknown>;
+    const constitution = result.constitution as Record<string, unknown>;
+    expect(constitution.budget_limits).toBeUndefined();
+  });
+});

--- a/src/settlement/village-pack-builder.ts
+++ b/src/settlement/village-pack-builder.ts
@@ -1,1 +1,79 @@
-export {};
+import yaml from 'js-yaml';
+import type { WorldCard } from '../schemas/card';
+
+function slugify(text: string, index: number): string {
+  const slug = text
+    .toLowerCase()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_]+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+  return slug || `skill-${index}`;
+}
+
+interface VillagePack {
+  village: { name: string };
+  constitution: {
+    rules: Array<{ description: string; enforcement: string }>;
+    allowed_permissions: string[];
+    budget_limits?: {
+      max_cost_per_action: number;
+      max_cost_per_day: number;
+      max_cost_per_loop: number;
+    };
+  };
+  chief?: {
+    name: string;
+    role: string;
+    personality: string;
+    permissions: string[];
+  };
+  skills: Array<{ name: string; type: string; description: string }>;
+  laws: never[];
+}
+
+export function buildVillagePack(card: WorldCard): string {
+  const pack: VillagePack = {
+    village: {
+      name: card.goal ?? 'Untitled Village',
+    },
+    constitution: {
+      rules: [
+        ...card.confirmed.hard_rules.map((r) => ({
+          description: r,
+          enforcement: 'hard',
+        })),
+        ...card.confirmed.soft_rules.map((r) => ({
+          description: r,
+          enforcement: 'soft',
+        })),
+      ],
+      allowed_permissions: ['dispatch_task', 'propose_law'],
+    },
+    skills: card.confirmed.must_have.map((item, i) => ({
+      name: slugify(item, i),
+      type: 'generic',
+      description: item,
+    })),
+    laws: [],
+  };
+
+  if (card.budget_draft) {
+    pack.constitution.budget_limits = {
+      max_cost_per_action: card.budget_draft.per_action ?? 0,
+      max_cost_per_day: card.budget_draft.per_day ?? 0,
+      max_cost_per_loop: 50,
+    };
+  }
+
+  if (card.chief_draft) {
+    pack.chief = {
+      name: card.chief_draft.name ?? 'Chief',
+      role: card.chief_draft.role ?? 'leader',
+      personality: card.chief_draft.style ?? 'neutral',
+      permissions: ['manage_skills', 'review_output'],
+    };
+  }
+
+  return yaml.dump(pack, { indent: 2, lineWidth: -1, noRefs: true });
+}


### PR DESCRIPTION
Closes #9

## Summary
- SettlementSchema + enums (Zod)
- classifySettlement() router with card type discrimination
- buildVillagePack() mapping WorldCard fields to Village Pack YAML
- CONTRACT SETTLE-01 compliant (D3 builds draft only, confirmation is E2 scope)

## Test plan
- [x] `bun run build` zero errors
- [x] 15 tests pass: router classification + YAML builder

🤖 Generated with [Claude Code](https://claude.com/claude-code)