### PR TITLE
feat(conductor): add turn handler orchestrating intent → card → strategy → reply

### DIFF
--- a/src/conductor/rhythm.test.ts
+++ b/src/conductor/rhythm.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { pickStrategy } from './rhythm';
+
+describe('pickStrategy', () => {
+  // EXPLORE phase
+  it('explore + new_intent → mirror', () => {
+    expect(pickStrategy('explore', 'new_intent', false)).toBe('mirror');
+  });
+
+  it('explore + add_info → probe', () => {
+    expect(pickStrategy('explore', 'add_info', false)).toBe('probe');
+  });
+
+  it('explore + set_boundary → mirror', () => {
+    expect(pickStrategy('explore', 'set_boundary', false)).toBe('mirror');
+  });
+
+  it('explore + confirm → probe', () => {
+    expect(pickStrategy('explore', 'confirm', false)).toBe('probe');
+  });
+
+  it('explore + question → probe', () => {
+    expect(pickStrategy('explore', 'question', false)).toBe('probe');
+  });
+
+  // FOCUS phase
+  it('focus + confirm + no pending → settle', () => {
+    expect(pickStrategy('focus', 'confirm', false)).toBe('settle');
+  });
+
+  it('focus + confirm + has pending → propose', () => {
+    expect(pickStrategy('focus', 'confirm', true)).toBe('propose');
+  });
+
+  it('focus + modify → confirm', () => {
+    expect(pickStrategy('focus', 'modify', false)).toBe('confirm');
+  });
+
+  it('focus + add_info → propose', () => {
+    expect(pickStrategy('focus', 'add_info', false)).toBe('propose');
+  });
+
+  // SETTLE phase
+  it('settle + settle_signal → settle', () => {
+    expect(pickStrategy('settle', 'settle_signal', false)).toBe('settle');
+  });
+
+  it('settle + confirm → settle', () => {
+    expect(pickStrategy('settle', 'confirm', false)).toBe('settle');
+  });
+
+  it('settle + modify → confirm', () => {
+    expect(pickStrategy('settle', 'modify', false)).toBe('confirm');
+  });
+});

--- a/src/conductor/rhythm.ts
+++ b/src/conductor/rhythm.ts
@@ -1,1 +1,26 @@
-export {};
+import type { Phase } from './state-machine';
+import type { IntentType } from '../schemas/intent';
+import type { Strategy } from '../llm/prompts';
+
+export function pickStrategy(phase: Phase, intentType: IntentType, hasPending: boolean): Strategy {
+  if (phase === 'explore') {
+    if (intentType === 'new_intent') return 'mirror';
+    if (intentType === 'set_boundary') return 'mirror';
+    return 'probe';
+  }
+
+  if (phase === 'focus') {
+    if (intentType === 'confirm' && !hasPending) return 'settle';
+    if (intentType === 'confirm') return 'propose';
+    if (intentType === 'modify') return 'confirm';
+    return 'propose';
+  }
+
+  if (phase === 'settle') {
+    if (intentType === 'settle_signal') return 'settle';
+    if (intentType === 'confirm') return 'settle';
+    return 'confirm';
+  }
+
+  return 'probe';
+}

--- a/src/conductor/turn-handler.test.ts
+++ b/src/conductor/turn-handler.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { applyIntentToCard, createEmptyWorldCard, handleTurn } from './turn-handler';
+import { CardManager } from '../cards/card-manager';
+import type { LLMClient } from '../llm/client';
+import type { Intent } from '../schemas/intent';
+
+// ─── applyIntentToCard Tests ───
+
+describe('applyIntentToCard', () => {
+  it('new_intent sets goal', () => {
+    const card = createEmptyWorldCard();
+    const result = applyIntentToCard(card, {
+      type: 'new_intent',
+      summary: '我想做客服',
+    });
+    expect(result.goal).toBe('我想做客服');
+  });
+
+  it('add_info pushes to must_have (no duplicates)', () => {
+    const card = createEmptyWorldCard();
+    card.confirmed.must_have = ['existing'];
+    const result = applyIntentToCard(card, {
+      type: 'add_info',
+      summary: '補充功能',
+      entities: { f1: 'existing', f2: 'new_feature' },
+    });
+    expect(result.confirmed.must_have).toEqual(['existing', 'new_feature']);
+  });
+
+  it('set_boundary with enforcement=hard adds to hard_rules', () => {
+    const card = createEmptyWorldCard();
+    const result = applyIntentToCard(card, {
+      type: 'set_boundary',
+      summary: '退款必須人工',
+      enforcement: 'hard',
+    });
+    expect(result.confirmed.hard_rules).toContain('退款必須人工');
+  });
+
+  it('set_boundary with enforcement=soft adds to soft_rules', () => {
+    const card = createEmptyWorldCard();
+    const result = applyIntentToCard(card, {
+      type: 'set_boundary',
+      summary: '最好友善',
+      enforcement: 'soft',
+    });
+    expect(result.confirmed.soft_rules).toContain('最好友善');
+  });
+
+  it('style_preference initializes chief_draft and sets style', () => {
+    const card = createEmptyWorldCard();
+    const result = applyIntentToCard(card, {
+      type: 'style_preference',
+      summary: '親切但不隨便',
+    });
+    expect(result.chief_draft).not.toBeNull();
+    expect(result.chief_draft!.style).toBe('親切但不隨便');
+  });
+
+  it('confirm does not change card content (except version)', () => {
+    const card = createEmptyWorldCard();
+    const result = applyIntentToCard(card, {
+      type: 'confirm',
+      summary: '好',
+    });
+    expect(result.goal).toBeNull();
+    expect(result.version).toBe(card.version + 1);
+  });
+
+  it('increments version', () => {
+    const card = createEmptyWorldCard();
+    expect(card.version).toBe(1);
+    const result = applyIntentToCard(card, {
+      type: 'confirm',
+      summary: '好',
+    });
+    expect(result.version).toBe(2);
+  });
+});
+
+// ─── handleTurn Tests ───
+
+describe('handleTurn', () => {
+  const mockParseIntent = vi.fn();
+  const mockGenerateReply = vi.fn();
+
+  const mockLlm = {
+    generateStructured: mockParseIntent,
+    generateText: mockGenerateReply,
+  } as unknown as LLMClient;
+
+  beforeEach(() => {
+    mockParseIntent.mockReset();
+    mockGenerateReply.mockReset();
+  });
+
+  it('first turn creates card and stays explore', async () => {
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'new_intent', summary: '我想做客服' },
+    });
+    mockGenerateReply.mockResolvedValueOnce('好的，你想做什麼樣的客服呢？');
+
+    const mgr = new CardManager();
+    const result = await handleTurn(mockLlm, mgr, 'conv1', '我想做客服', 'explore');
+
+    expect(result.phase).toBe('explore');
+    expect(result.reply).toBe('好的，你想做什麼樣的客服呢？');
+    expect(result.cardVersion).toBeGreaterThanOrEqual(1);
+  });
+
+  it('max 2 LLM calls per turn', async () => {
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'add_info', summary: '產品介紹' },
+    });
+    mockGenerateReply.mockResolvedValueOnce('了解');
+
+    const mgr = new CardManager();
+    await handleTurn(mockLlm, mgr, 'conv1', 'test', 'explore');
+
+    // generateStructured (intent) + generateText (reply) = 2 calls
+    expect(mockParseIntent).toHaveBeenCalledTimes(1);
+    expect(mockGenerateReply).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/conductor/turn-handler.ts
+++ b/src/conductor/turn-handler.ts
@@ -1,1 +1,124 @@
-export {};
+import type { LLMClient } from '../llm/client';
+import type { CardManager } from '../cards/card-manager';
+import { parseIntent } from '../llm/intent-parser';
+import { generateReply } from '../llm/response-gen';
+import { checkTransition, type Phase } from './state-machine';
+import { pickStrategy } from './rhythm';
+import type { WorldCard } from '../schemas/card';
+import type { Intent } from '../schemas/intent';
+import type { Strategy } from '../llm/prompts';
+
+export interface TurnResult {
+  reply: string;
+  intent: Intent;
+  phase: Phase;
+  phaseChanged: boolean;
+  strategy: Strategy;
+  cardVersion: number;
+}
+
+export function createEmptyWorldCard(): WorldCard {
+  return {
+    goal: null,
+    confirmed: { hard_rules: [], soft_rules: [], must_have: [], success_criteria: [] },
+    pending: [],
+    chief_draft: null,
+    budget_draft: null,
+    current_proposal: null,
+    version: 1,
+  };
+}
+
+export function applyIntentToCard(card: WorldCard, intent: Intent): WorldCard {
+  const updated = structuredClone(card);
+
+  switch (intent.type) {
+    case 'new_intent':
+      if (intent.summary) updated.goal = intent.summary;
+      break;
+    case 'add_info':
+      if (intent.entities) {
+        for (const [, value] of Object.entries(intent.entities)) {
+          if (!updated.confirmed.must_have.includes(value)) {
+            updated.confirmed.must_have.push(value);
+          }
+        }
+      }
+      break;
+    case 'set_boundary':
+      if (intent.enforcement === 'hard') {
+        updated.confirmed.hard_rules.push(intent.summary);
+      } else {
+        updated.confirmed.soft_rules.push(intent.summary);
+      }
+      break;
+    case 'add_constraint':
+      updated.confirmed.soft_rules.push(intent.summary);
+      break;
+    case 'style_preference':
+      if (!updated.chief_draft) {
+        updated.chief_draft = { name: null, role: null, style: null };
+      }
+      updated.chief_draft.style = intent.summary;
+      break;
+    case 'confirm':
+    case 'settle_signal':
+    case 'modify':
+    case 'question':
+    case 'off_topic':
+      break;
+  }
+
+  updated.version += 1;
+  return updated;
+}
+
+export async function handleTurn(
+  llm: LLMClient,
+  cardManager: CardManager,
+  conversationId: string,
+  userMessage: string,
+  currentPhase: Phase,
+): Promise<TurnResult> {
+  const currentCard = cardManager.getLatest(conversationId);
+  const cardContent = (currentCard?.content as WorldCard) ?? createEmptyWorldCard();
+  const cardSnapshot = JSON.stringify(cardContent, null, 2);
+
+  // LLM #1: parse intent
+  const intent = await parseIntent(llm, userMessage, cardSnapshot);
+
+  // Update card content based on intent
+  const updatedContent = applyIntentToCard(cardContent, intent);
+
+  // Persist card
+  let cardVersion: number;
+  if (currentCard) {
+    const { card } = cardManager.update(currentCard.id, updatedContent);
+    cardVersion = card.version;
+  } else {
+    const card = cardManager.create(conversationId, 'world', updatedContent);
+    cardVersion = card.version;
+  }
+
+  // Check state transition
+  const transition = checkTransition(currentPhase, updatedContent, intent.type);
+
+  // Pick reply strategy
+  const strategy = pickStrategy(
+    transition.newPhase,
+    intent.type,
+    updatedContent.pending.length > 0,
+  );
+
+  // LLM #2: generate reply
+  const reply = await generateReply(llm, strategy, JSON.stringify(updatedContent, null, 2), userMessage);
+
+  return {
+    reply,
+    intent,
+    phase: transition.newPhase,
+    phaseChanged: transition.reason !== null,
+    strategy,
+    cardVersion,
+  };
+}


### PR DESCRIPTION
Closes #8

## Summary
- pickStrategy(): phase × intent → strategy mapping
- handleTurn(): full turn orchestration (2 LLM calls max, CONTRACT COND-02)
- applyIntentToCard(): intent-based WorldCard updates
- createEmptyWorldCard(): safe initial card

## Test plan
- [x] `bun run build` zero errors
- [x] 33 conductor tests pass (state-machine + rhythm + turn-handler)

🤖 Generated with [Claude Code](https://claude.com/claude-code)