### PR TITLE
fix: address PR review findings from #26 and #27

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # CLAUDE.md
 
 > Volva 開發規範。所有 AI agent 和開發者必須遵守。
+>
+> 環境設定、專案定位、行為準則見 `AGENTS.md`。本文件專注於程式碼規範和 CONTRACT 規則。
 
 ## Tech Stack
 
@@ -99,6 +101,7 @@ async generateStructured<T extends z.ZodType>(options: LLMStructuredOptions<T>) 
 
 ```bash
 bun run build     # tsc --noEmit，零錯誤
+bun run lint      # eslint src/，零錯誤
 bun test          # 所有測試通過
 ```
 
@@ -137,7 +140,7 @@ else console.warn('[parseIntent] fallback:', result.error);
 // ❌ 3 次 LLM 呼叫
 async function handleTurn(/* ... */) {
   const intent = await parseIntent(llm, userMessage, cardSnapshot);   // LLM #1
-  const analysis = await analyzeContext(llm, intent);                 // LLM #3 -- 違規！
+  const analysis = await analyzeContext(llm, intent);                 // ← VIOLATION: 第 3 次 LLM 呼叫
   const reply = await generateReply(llm, strategy, cardStr, msg);     // LLM #2
 }
 

--- a/src/conductor/rhythm.ts
+++ b/src/conductor/rhythm.ts
@@ -17,5 +17,9 @@ export function pickStrategy(phase: Phase, intentType: IntentType, hasPending: b
       if (intentType === 'settle_signal') return 'settle';
       if (intentType === 'confirm') return 'settle';
       return 'confirm';
+    default: {
+      const exhaustiveCheck: never = phase;
+      throw new Error(`Unknown phase: ${String(exhaustiveCheck)}`);
+    }
   }
 }

--- a/src/settlement/router.ts
+++ b/src/settlement/router.ts
@@ -5,22 +5,26 @@ export function classifySettlement(
   cardType: CardType,
   card: AnyCard,
 ): SettlementTarget | null {
-  if (cardType === 'world') {
-    const worldCard = card as WorldCard;
-    if (worldCard.confirmed.hard_rules.length > 0 || worldCard.chief_draft !== null) {
-      return 'village_pack';
+  switch (cardType) {
+    case 'world': {
+      const worldCard = card as WorldCard;
+      if (worldCard.confirmed.hard_rules.length > 0 || worldCard.chief_draft !== null) {
+        return 'village_pack';
+      }
+      return null;
     }
-    return null;
-  }
-
-  if (cardType === 'workflow') {
-    const workflowCard = card as WorkflowCard;
-    if (workflowCard.steps.length > 0) {
-      return 'workflow';
+    case 'workflow': {
+      const workflowCard = card as WorkflowCard;
+      if (workflowCard.steps.length > 0) {
+        return 'workflow';
+      }
+      return null;
     }
-    return null;
+    case 'task':
+      return 'task';
+    default: {
+      const exhaustiveCheck: never = cardType;
+      throw new Error(`Unknown card type: ${String(exhaustiveCheck)}`);
+    }
   }
-
-  // cardType === 'task'
-  return 'task';
 }


### PR DESCRIPTION
## Summary
- CLAUDE.md: add `bun run lint` to Zero Lint Tolerance, clarify COND-02 violation label, cross-reference AGENTS.md
- rhythm.ts + router.ts: add exhaustive-switch `never` guard for future union expansion safety

## Test plan
- [x] `bun run build` zero errors
- [x] `bun run lint` zero errors
- [x] `bun test` 164 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)