### PR TITLE
chore: add lefthook pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.db
 .env
 .tmp/
+lefthook-local.yml

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@evilmartians/lefthook": "^2.1.4",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.13.10",
         "bun-types": "^1.2.5",
@@ -93,6 +94,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@3.0.3", "", {}, "sha512-iM869Pugn9Nsxbh/YHRqYiqd23AmIbxJOcpUMOuWCVNdoQJ5ZtwL6h3t0bcZzJUlC3Dq9jCFCESBZnX0GTv7iQ=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.6.1", "", { "dependencies": { "@eslint/core": "^1.1.1", "levn": "^0.4.1" } }, "sha512-iH1B076HoAshH1mLpHMgwdGeTs0CYwL0SPMkGuSebZrwBp16v415e9NZXg2jtrqPVQjf6IANe2Vtlr5KswtcZQ=="],
+
+    "@evilmartians/lefthook": ["@evilmartians/lefthook@2.1.4", "", { "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "ia32", "arm64", ], "bin": { "lefthook": "bin/index.js" } }, "sha512-OxJ4JgMnGHGsHU9hGH2ge9N+PCtdBKsCpNvQ0bOrIkD+a5noGNrwB3Ms0Ab3xSxYy6QOjSa0kLJ700uAOPxuwA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,14 @@
+pre-commit:
+  parallel: true
+  commands:
+    build:
+      run: bun run build
+    lint:
+      run: bun run lint
+    test:
+      run: bun run test
+
+commit-msg:
+  commands:
+    conventional-commit:
+      run: bash scripts/check-commit-msg.sh {1}

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "build": "tsc --noEmit",
     "dev": "bun run --watch src/index.ts",
-    "test": "vitest run",
+    "test": "bun test",
     "cli": "bun run src/cli.ts",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "postinstall": "lefthook install"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
@@ -17,6 +18,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@evilmartians/lefthook": "^2.1.4",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.13.10",
     "bun-types": "^1.2.5",

--- a/scripts/check-commit-msg.sh
+++ b/scripts/check-commit-msg.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+message=$(head -1 "$1")
+if ! echo "$message" | grep -qE '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: .+$'; then
+  echo "ERROR: Commit message must follow Conventional Commits format."
+  echo "  Format: type(scope): description"
+  echo "  Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert"
+  echo "  Got: $message"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add lefthook with parallel pre-commit hooks (build + lint + test)
- Add commit-msg hook enforcing conventional commits format
- Add `postinstall` script for automatic hook setup on `bun install`
- Fix `test` script from `vitest run` to `bun test` (needed for `bun:sqlite` runtime)

Closes #23

## Test plan
- [x] Pre-commit: build, lint, test run in parallel and all pass
- [x] Commit-msg: conventional commit format validated (bad messages rejected)
- [x] `lefthook-local.yml` in `.gitignore` for local overrides
- [x] Works on Windows with Git Bash

🤖 Generated with [Claude Code](https://claude.com/claude-code)