### PR TITLE
fix: remove redundant version increment in applyIntentToCard

### DIFF
--- a/src/conductor/turn-handler.test.ts
+++ b/src/conductor/turn-handler.test.ts
@@ -56,24 +56,24 @@ describe('applyIntentToCard', () => {
     expect(result.chief_draft!.style).toBe('親切但不隨便');
   });
 
-  it('confirm does not change card content (except version)', () => {
+  it('confirm does not change card content', () => {
     const card = createEmptyWorldCard();
     const result = applyIntentToCard(card, {
       type: 'confirm',
       summary: '好',
     });
     expect(result.goal).toBeNull();
-    expect(result.version).toBe(card.version + 1);
+    expect(result.version).toBe(card.version);
   });
 
-  it('increments version', () => {
+  it('does not increment version (CardManager owns versioning)', () => {
     const card = createEmptyWorldCard();
     expect(card.version).toBe(1);
     const result = applyIntentToCard(card, {
-      type: 'confirm',
-      summary: '好',
+      type: 'new_intent',
+      summary: '測試',
     });
-    expect(result.version).toBe(2);
+    expect(result.version).toBe(1);
   });
 });
 

--- a/src/conductor/turn-handler.ts
+++ b/src/conductor/turn-handler.ts
@@ -69,7 +69,6 @@ export function applyIntentToCard(card: WorldCard, intent: Intent): WorldCard {
       break;
   }
 
-  updated.version += 1;
   return updated;
 }
 


### PR DESCRIPTION
## Summary
- Removed `updated.version += 1` from `applyIntentToCard()` in `src/conductor/turn-handler.ts` since `CardManager.update()` already handles version incrementing (CARD-01)
- Updated two tests in `turn-handler.test.ts` to reflect that `applyIntentToCard` no longer mutates version

## Test plan
- [x] `bun run build` passes (zero tsc errors)
- [x] `bun run lint` passes (zero ESLint errors)
- [x] `bun test` passes (177 tests, 0 failures)

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)