### PR TITLE
fix: make CardManager DB-backed instead of in-memory

### DIFF
--- a/src/cards/card-manager.test.ts
+++ b/src/cards/card-manager.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
+import type { Database } from 'bun:sqlite';
 import { CardManager, computeDiff } from './card-manager';
+import { createDb, initSchema } from '../db';
 import type { WorldCard } from '../schemas/card';
 
 const minimalWorldCard: WorldCard = {
@@ -38,15 +40,21 @@ const fullWorldCard: WorldCard = {
   version: 1,
 };
 
+let db: Database;
+let mgr: CardManager;
+
+beforeEach(() => {
+  db = createDb(':memory:');
+  initSchema(db);
+  // Cards table has FK to conversations — insert a test conversation
+  db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'world_design', 'explore')");
+  db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv2', 'world_design', 'explore')");
+  mgr = new CardManager(db);
+});
+
 // ─── Create Tests ───
 
 describe('CardManager.create', () => {
-  let mgr: CardManager;
-
-  beforeEach(() => {
-    mgr = new CardManager();
-  });
-
   it('creates a WorldCard with version=1', () => {
     const card = mgr.create('conv1', 'world', minimalWorldCard);
     expect(card.version).toBe(1);
@@ -78,12 +86,6 @@ describe('CardManager.create', () => {
 // ─── Update Tests ───
 
 describe('CardManager.update', () => {
-  let mgr: CardManager;
-
-  beforeEach(() => {
-    mgr = new CardManager();
-  });
-
   it('increments version on update', () => {
     const card = mgr.create('conv1', 'world', minimalWorldCard);
     const { card: updated } = mgr.update(card.id, {
@@ -172,13 +174,49 @@ describe('computeDiff', () => {
 
 describe('CardManager edge cases', () => {
   it('getLatest returns null for unknown conversation', () => {
-    const mgr = new CardManager();
     expect(mgr.getLatest('unknown')).toBeNull();
   });
 
   it('diff method works without persisting', () => {
-    const mgr = new CardManager();
     const diff = mgr.diff(minimalWorldCard, fullWorldCard);
     expect(diff.changed).toContain('goal');
+  });
+});
+
+// ─── DB Round-Trip Tests ───
+
+describe('CardManager DB persistence', () => {
+  it('persists cards to DB (round-trip)', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+
+    const row = db.query('SELECT * FROM cards WHERE id = ?').get(card.id) as Record<string, unknown>;
+    expect(row).not.toBeNull();
+    expect(row.conversation_id).toBe('conv1');
+    expect(row.version).toBe(1);
+
+    const content = JSON.parse(row.content as string) as Record<string, unknown>;
+    expect(content.version).toBe(1);
+  });
+
+  it('stores version history in DB', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    mgr.update(card.id, { ...minimalWorldCard, goal: 'v2' });
+
+    const rows = db.query('SELECT * FROM cards WHERE conversation_id = ? ORDER BY version')
+      .all('conv1') as Record<string, unknown>[];
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0].version).toBe(1);
+    expect(rows[1].version).toBe(2);
+  });
+
+  it('getLatest returns the highest version', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    mgr.update(card.id, { ...minimalWorldCard, goal: 'v2' });
+
+    const latest = mgr.getLatest('conv1');
+    expect(latest).not.toBeNull();
+    expect(latest!.version).toBe(2);
+    expect((latest!.content as WorldCard).goal).toBe('v2');
   });
 });

--- a/src/cards/card-manager.ts
+++ b/src/cards/card-manager.ts
@@ -1,3 +1,4 @@
+import type { Database } from 'bun:sqlite';
 import type { CardType, AnyCard, CardDiff, CardEnvelope } from '../schemas/card';
 
 // ─── Diff Logic ───
@@ -73,63 +74,95 @@ export function computeDiff(
 // ─── CardManager ───
 
 export class CardManager {
-  private cards = new Map<string, CardEnvelope>();
-  private conversationIndex = new Map<string, string>();
+  constructor(private db: Database) {}
 
   create(
     conversationId: string,
     type: CardType,
     content: AnyCard,
   ): CardEnvelope {
+    const id = crypto.randomUUID();
     const now = new Date().toISOString();
-    const card: CardEnvelope = {
-      id: crypto.randomUUID(),
+    const mergedContent = { ...content, version: 1 };
+
+    this.db.run(
+      'INSERT INTO cards (id, conversation_id, type, version, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [id, conversationId, type, 1, JSON.stringify(mergedContent), now, now],
+    );
+
+    return {
+      id,
       conversationId,
       type,
-      content: { ...content, version: 1 },
+      content: mergedContent,
       version: 1,
       createdAt: now,
       updatedAt: now,
     };
-    this.cards.set(card.id, card);
-    this.conversationIndex.set(conversationId, card.id);
-    return card;
   }
 
   update(
     cardId: string,
     content: AnyCard,
   ): { card: CardEnvelope; diff: CardDiff } {
-    const existing = this.cards.get(cardId);
-    if (!existing) {
+    const row = this.db
+      .query('SELECT * FROM cards WHERE id = ?')
+      .get(cardId) as Record<string, unknown> | null;
+
+    if (!row) {
       throw new Error(`Card not found: ${cardId}`);
     }
 
-    const newVersion = existing.version + 1;
-    const now = new Date().toISOString();
+    const existingContent = JSON.parse(row.content as string) as AnyCard;
+    const conversationId = row.conversation_id as string;
+    const type = row.type as CardType;
+    const originalCreatedAt = row.created_at as string;
+    const oldVersion = row.version as number;
 
+    const newVersion = oldVersion + 1;
+    const now = new Date().toISOString();
     const mergedContent = { ...content, version: newVersion };
 
     const diff = computeDiff(
-      existing.content as unknown as Record<string, unknown>,
+      existingContent as unknown as Record<string, unknown>,
       mergedContent as unknown as Record<string, unknown>,
     );
 
+    const newId = crypto.randomUUID();
+    this.db.run(
+      'INSERT INTO cards (id, conversation_id, type, version, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+      [newId, conversationId, type, newVersion, JSON.stringify(mergedContent), originalCreatedAt, now],
+    );
+
     const updatedCard: CardEnvelope = {
-      ...existing,
+      id: newId,
+      conversationId,
+      type,
       content: mergedContent,
       version: newVersion,
+      createdAt: originalCreatedAt,
       updatedAt: now,
     };
 
-    this.cards.set(cardId, updatedCard);
     return { card: updatedCard, diff };
   }
 
   getLatest(conversationId: string): CardEnvelope | null {
-    const cardId = this.conversationIndex.get(conversationId);
-    if (!cardId) return null;
-    return this.cards.get(cardId) ?? null;
+    const row = this.db
+      .query('SELECT * FROM cards WHERE conversation_id = ? ORDER BY version DESC LIMIT 1')
+      .get(conversationId) as Record<string, unknown> | null;
+
+    if (!row) return null;
+
+    return {
+      id: row.id as string,
+      conversationId: row.conversation_id as string,
+      type: row.type as CardType,
+      content: JSON.parse(row.content as string) as AnyCard,
+      version: row.version as number,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    };
   }
 
   diff(oldContent: AnyCard, newContent: AnyCard): CardDiff {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ async function runCli() {
   const db = createDb();
   initSchema(db);
   const llm = new LLMClient();
-  const cardManager = new CardManager();
+  const cardManager = new CardManager(db);
   const thyra = new ThyraClient();
 
   const conversationId = crypto.randomUUID();

--- a/src/conductor/turn-handler.test.ts
+++ b/src/conductor/turn-handler.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { applyIntentToCard, createEmptyWorldCard, handleTurn } from './turn-handler';
 import { CardManager } from '../cards/card-manager';
+import { createDb, initSchema } from '../db';
 import type { LLMClient } from '../llm/client';
 
 // ─── applyIntentToCard Tests ───
@@ -100,7 +101,10 @@ describe('handleTurn', () => {
     });
     mockGenerateReply.mockResolvedValueOnce('好的，你想做什麼樣的客服呢？');
 
-    const mgr = new CardManager();
+    const db = createDb(':memory:');
+    initSchema(db);
+    db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'world_design', 'explore')");
+    const mgr = new CardManager(db);
     const result = await handleTurn(mockLlm, mgr, 'conv1', '我想做客服', 'explore');
 
     expect(result.phase).toBe('explore');
@@ -115,7 +119,10 @@ describe('handleTurn', () => {
     });
     mockGenerateReply.mockResolvedValueOnce('了解');
 
-    const mgr = new CardManager();
+    const db = createDb(':memory:');
+    initSchema(db);
+    db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'world_design', 'explore')");
+    const mgr = new CardManager(db);
     await handleTurn(mockLlm, mgr, 'conv1', 'test', 'explore');
 
     // generateStructured (intent) + generateText (reply) = 2 calls

--- a/src/db.ts
+++ b/src/db.ts
@@ -31,7 +31,8 @@ export function initSchema(db: Database): void {
     type TEXT NOT NULL CHECK(type IN ('world','workflow','task')),
     version INTEGER NOT NULL DEFAULT 1,
     content TEXT NOT NULL,
-    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`);
 
   db.run(`CREATE TABLE IF NOT EXISTS settlements (

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ const db = createDb();
 initSchema(db);
 
 const llm = new LLMClient();
-const cardManager = new CardManager();
+const cardManager = new CardManager(db);
 const thyra = new ThyraClient();
 
 const app = new Hono();

--- a/src/routes/e2e.test.ts
+++ b/src/routes/e2e.test.ts
@@ -29,7 +29,7 @@ function createMockThyra() {
 function createTestApp(llm: LLMClient, thyra: ThyraClient) {
   const db = createDb(':memory:');
   initSchema(db);
-  const cardManager = new CardManager();
+  const cardManager = new CardManager(db);
 
   const app = new Hono();
   app.route('/', conversationRoutes({ db, llm, cardManager }));


### PR DESCRIPTION
## Summary
- Replace Map-based in-memory storage with SQLite persistence in CardManager
- Each card version creates a new DB row, enabling version history queries
- Add `updated_at` column to cards table
- Add 3 new DB round-trip tests (persist, version history, getLatest)
- Update all consumers (index.ts, cli.ts, tests) to pass `db` to CardManager

Closes #33

## Test plan
- [x] `bun run build` — zero errors
- [x] `bun run lint` — zero errors  
- [x] `bun test` — 180 tests pass (3 new)
- [x] `bun run knip` — zero findings
- [x] Cards survive across getLatest calls (DB round-trip verified)
- [x] Version history preserved in DB (multiple rows per conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)