### PR TITLE
feat: align Village Pack builder with W1 walkthrough spec

### DIFF
--- a/src/cards/card-manager.test.ts
+++ b/src/cards/card-manager.test.ts
@@ -6,6 +6,7 @@ import type { WorldCard } from '../schemas/card';
 
 const minimalWorldCard: WorldCard = {
   goal: null,
+  target_repo: null,
   confirmed: {
     hard_rules: [],
     soft_rules: [],
@@ -21,9 +22,10 @@ const minimalWorldCard: WorldCard = {
 
 const fullWorldCard: WorldCard = {
   goal: 'Build automated customer service',
+  target_repo: 'github.com/example/repo',
   confirmed: {
-    hard_rules: ['No refunds without human approval'],
-    soft_rules: ['Avoid robotic tone'],
+    hard_rules: [{ description: 'No refunds without human approval', scope: ['*'] }],
+    soft_rules: [{ description: 'Avoid robotic tone', scope: ['*'] }],
     must_have: ['24/7 availability'],
     success_criteria: ['90% satisfaction'],
   },
@@ -155,8 +157,8 @@ describe('computeDiff', () => {
 
   it('detects nested changes', () => {
     const diff = computeDiff(
-      { confirmed: { hard_rules: ['rule1'] } },
-      { confirmed: { hard_rules: ['rule1', 'rule2'] } },
+      { confirmed: { hard_rules: [{ description: 'rule1', scope: ['*'] }] } },
+      { confirmed: { hard_rules: [{ description: 'rule1', scope: ['*'] }, { description: 'rule2', scope: ['*'] }] } },
     );
     expect(diff.changed.some(p => p.includes('hard_rules'))).toBe(true);
   });

--- a/src/conductor/state-machine.test.ts
+++ b/src/conductor/state-machine.test.ts
@@ -9,8 +9,9 @@ function makeCard(opts: {
 }): WorldCard {
   return {
     goal: 'test',
+    target_repo: null,
     confirmed: {
-      hard_rules: opts.hardRules ?? [],
+      hard_rules: (opts.hardRules ?? []).map((r) => ({ description: r, scope: ['*'] })),
       soft_rules: [],
       must_have: opts.mustHave ?? [],
       success_criteria: [],

--- a/src/conductor/turn-handler.test.ts
+++ b/src/conductor/turn-handler.test.ts
@@ -34,7 +34,7 @@ describe('applyIntentToCard', () => {
       summary: '退款必須人工',
       enforcement: 'hard',
     });
-    expect(result.confirmed.hard_rules).toContain('退款必須人工');
+    expect(result.confirmed.hard_rules).toContainEqual({ description: '退款必須人工', scope: ['*'] });
   });
 
   it('set_boundary with enforcement=soft adds to soft_rules', () => {
@@ -44,7 +44,7 @@ describe('applyIntentToCard', () => {
       summary: '最好友善',
       enforcement: 'soft',
     });
-    expect(result.confirmed.soft_rules).toContain('最好友善');
+    expect(result.confirmed.soft_rules).toContainEqual({ description: '最好友善', scope: ['*'] });
   });
 
   it('style_preference initializes chief_draft and sets style', () => {

--- a/src/conductor/turn-handler.ts
+++ b/src/conductor/turn-handler.ts
@@ -20,6 +20,7 @@ export interface TurnResult {
 export function createEmptyWorldCard(): WorldCard {
   return {
     goal: null,
+    target_repo: null,
     confirmed: { hard_rules: [], soft_rules: [], must_have: [], success_criteria: [] },
     pending: [],
     chief_draft: null,
@@ -47,13 +48,13 @@ export function applyIntentToCard(card: WorldCard, intent: Intent): WorldCard {
       break;
     case 'set_boundary':
       if (intent.enforcement === 'hard') {
-        updated.confirmed.hard_rules.push(intent.summary);
+        updated.confirmed.hard_rules.push({ description: intent.summary, scope: ['*'] });
       } else {
-        updated.confirmed.soft_rules.push(intent.summary);
+        updated.confirmed.soft_rules.push({ description: intent.summary, scope: ['*'] });
       }
       break;
     case 'add_constraint':
-      updated.confirmed.soft_rules.push(intent.summary);
+      updated.confirmed.soft_rules.push({ description: intent.summary, scope: ['*'] });
       break;
     case 'style_preference':
       if (!updated.chief_draft) {

--- a/src/schemas/card.test.ts
+++ b/src/schemas/card.test.ts
@@ -25,9 +25,10 @@ describe('CardTypeEnum', () => {
 describe('WorldCardSchema', () => {
   const validWorldCard = {
     goal: 'Build an automated customer service',
+    target_repo: 'github.com/example/repo',
     confirmed: {
-      hard_rules: ['No refunds without human approval'],
-      soft_rules: ['Avoid robotic tone'],
+      hard_rules: [{ description: 'No refunds without human approval', scope: ['*'] }],
+      soft_rules: [{ description: 'Avoid robotic tone', scope: ['*'] }],
       must_have: ['24/7 availability'],
       success_criteria: ['90% satisfaction rate'],
     },
@@ -55,6 +56,7 @@ describe('WorldCardSchema', () => {
   it('parses WorldCard with all nullable fields set to null', () => {
     const result = WorldCardSchema.safeParse({
       goal: null,
+      target_repo: null,
       confirmed: {
         hard_rules: [],
         soft_rules: [],

--- a/src/schemas/card.ts
+++ b/src/schemas/card.ts
@@ -14,11 +14,19 @@ const PendingItemSchema = z.object({
 
 // ─── WorldCard ───
 
+export const RuleSchema = z.object({
+  description: z.string(),
+  scope: z.array(z.string()).default(['*']),
+});
+
+export type Rule = z.infer<typeof RuleSchema>;
+
 export const WorldCardSchema = z.object({
   goal: z.string().nullable(),
+  target_repo: z.string().nullable(),
   confirmed: z.object({
-    hard_rules: z.array(z.string()),
-    soft_rules: z.array(z.string()),
+    hard_rules: z.array(RuleSchema),
+    soft_rules: z.array(RuleSchema),
     must_have: z.array(z.string()),
     success_criteria: z.array(z.string()),
   }),

--- a/src/settlement/router.test.ts
+++ b/src/settlement/router.test.ts
@@ -4,6 +4,7 @@ import type { WorldCard, WorkflowCard, TaskCard } from '../schemas/card';
 
 const emptyWorldCard: WorldCard = {
   goal: null,
+  target_repo: null,
   confirmed: { hard_rules: [], soft_rules: [], must_have: [], success_criteria: [] },
   pending: [],
   chief_draft: null,
@@ -16,7 +17,7 @@ describe('classifySettlement', () => {
   it('WorldCard with hard_rules → village_pack', () => {
     const card: WorldCard = {
       ...emptyWorldCard,
-      confirmed: { ...emptyWorldCard.confirmed, hard_rules: ['rule1'] },
+      confirmed: { ...emptyWorldCard.confirmed, hard_rules: [{ description: 'rule1', scope: ['*'] }] },
     };
     expect(classifySettlement('world', card)).toBe('village_pack');
   });

--- a/src/settlement/village-pack-builder.test.ts
+++ b/src/settlement/village-pack-builder.test.ts
@@ -5,9 +5,10 @@ import type { WorldCard } from '../schemas/card';
 
 const baseCard: WorldCard = {
   goal: 'My Village',
+  target_repo: 'github.com/test/repo',
   confirmed: {
-    hard_rules: ['No refunds'],
-    soft_rules: ['Be polite'],
+    hard_rules: [{ description: 'No refunds', scope: ['billing'] }],
+    soft_rules: [{ description: 'Be polite', scope: ['*'] }],
     must_have: ['Product FAQ', 'Inventory Check'],
     success_criteria: [],
   },
@@ -36,13 +37,34 @@ describe('buildVillagePack', () => {
     expect((result.village as Record<string, unknown>).name).toBe('Untitled Village');
   });
 
+  it('maps target_repo to village.target_repo', () => {
+    const result = yaml.load(buildVillagePack(baseCard)) as Record<string, unknown>;
+    expect((result.village as Record<string, unknown>).target_repo).toBe('github.com/test/repo');
+  });
+
+  it('uses fallback target_repo when null', () => {
+    const card: WorldCard = { ...baseCard, target_repo: null };
+    const result = yaml.load(buildVillagePack(card)) as Record<string, unknown>;
+    expect((result.village as Record<string, unknown>).target_repo).toBe('default');
+  });
+
   it('includes constitution rules from card', () => {
     const result = yaml.load(buildVillagePack(baseCard)) as Record<string, unknown>;
     const constitution = result.constitution as Record<string, unknown>;
-    const rules = constitution.rules as Array<Record<string, string>>;
+    const rules = constitution.rules as Array<Record<string, unknown>>;
     expect(rules).toHaveLength(2);
     expect(rules[0].enforcement).toBe('hard');
+    expect(rules[0].description).toBe('No refunds');
     expect(rules[1].enforcement).toBe('soft');
+    expect(rules[1].description).toBe('Be polite');
+  });
+
+  it('includes scope arrays in rules', () => {
+    const result = yaml.load(buildVillagePack(baseCard)) as Record<string, unknown>;
+    const constitution = result.constitution as Record<string, unknown>;
+    const rules = constitution.rules as Array<Record<string, unknown>>;
+    expect(rules[0].scope).toEqual(['billing']);
+    expect(rules[1].scope).toEqual(['*']);
   });
 
   it('includes chief section when chief_draft is present', () => {
@@ -50,6 +72,12 @@ describe('buildVillagePack', () => {
     const chief = result.chief as Record<string, unknown>;
     expect(chief.name).toBe('Bot');
     expect(chief.personality).toBe('warm');
+  });
+
+  it('chief permissions are dispatch_task and propose_law', () => {
+    const result = yaml.load(buildVillagePack(baseCard)) as Record<string, unknown>;
+    const chief = result.chief as Record<string, unknown>;
+    expect(chief.permissions).toEqual(['dispatch_task', 'propose_law']);
   });
 
   it('omits chief section when chief_draft is null', () => {

--- a/src/settlement/village-pack-builder.ts
+++ b/src/settlement/village-pack-builder.ts
@@ -12,9 +12,9 @@ function slugify(text: string, index: number): string {
 }
 
 interface VillagePack {
-  village: { name: string };
+  village: { name: string; target_repo: string };
   constitution: {
-    rules: Array<{ description: string; enforcement: string }>;
+    rules: Array<{ description: string; enforcement: string; scope: string[] }>;
     allowed_permissions: string[];
     budget_limits?: {
       max_cost_per_action: number;
@@ -36,16 +36,19 @@ export function buildVillagePack(card: WorldCard): string {
   const pack: VillagePack = {
     village: {
       name: card.goal ?? 'Untitled Village',
+      target_repo: card.target_repo ?? 'default',
     },
     constitution: {
       rules: [
         ...card.confirmed.hard_rules.map((r) => ({
-          description: r,
+          description: r.description,
           enforcement: 'hard',
+          scope: r.scope,
         })),
         ...card.confirmed.soft_rules.map((r) => ({
-          description: r,
+          description: r.description,
           enforcement: 'soft',
+          scope: r.scope,
         })),
       ],
       allowed_permissions: ['dispatch_task', 'propose_law'],
@@ -71,7 +74,7 @@ export function buildVillagePack(card: WorldCard): string {
       name: card.chief_draft.name ?? 'Chief',
       role: card.chief_draft.role ?? 'leader',
       personality: card.chief_draft.style ?? 'neutral',
-      permissions: ['manage_skills', 'review_output'],
+      permissions: ['dispatch_task', 'propose_law'],
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `target_repo` (nullable string) to `WorldCard` schema and include it in `buildVillagePack` output
- Change `hard_rules`/`soft_rules` from `string[]` to structured `Rule` objects with `description` and `scope` fields, matching the `CreateConstitutionInput` schema in Thyra
- Fix chief permissions from `['manage_skills', 'review_output']` to `['dispatch_task', 'propose_law']` per W1 walkthrough spec
- Update all WorldCard constructors and test fixtures across the codebase

## Test plan
- [x] `bun run build` passes (zero tsc errors)
- [x] `bun run lint` passes (zero eslint errors)
- [x] `bun test` passes (184 tests, 0 failures)
- [x] `bun run knip` — pre-existing warnings only, no new issues
- [x] New tests: target_repo in YAML output, rule scope arrays, chief permissions

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)