### PR TITLE
feat: persist card diffs to SQLite

### DIFF
--- a/src/cards/card-manager.test.ts
+++ b/src/cards/card-manager.test.ts
@@ -172,6 +172,59 @@ describe('computeDiff', () => {
   });
 });
 
+// ─── Diff History Tests ───
+
+describe('CardManager.getDiffHistory', () => {
+  it('returns empty array for new card', () => {
+    mgr.create('conv1', 'world', minimalWorldCard);
+    const history = mgr.getDiffHistory('conv1');
+    expect(history).toHaveLength(0);
+  });
+
+  it('returns one entry after first update', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    mgr.update(card.id, { ...minimalWorldCard, goal: 'Updated goal' });
+    const history = mgr.getDiffHistory('conv1');
+    expect(history).toHaveLength(1);
+  });
+
+  it('returns entries in version order after multiple updates', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    const { card: v2 } = mgr.update(card.id, { ...minimalWorldCard, goal: 'v2' });
+    mgr.update(v2.id, { ...minimalWorldCard, goal: 'v3' });
+    const history = mgr.getDiffHistory('conv1');
+    expect(history).toHaveLength(2);
+    expect(history[0].fromVersion).toBe(1);
+    expect(history[0].toVersion).toBe(2);
+    expect(history[1].fromVersion).toBe(2);
+    expect(history[1].toVersion).toBe(3);
+  });
+
+  it('diff entries have correct fromVersion/toVersion', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    mgr.update(card.id, { ...minimalWorldCard, goal: 'New goal' });
+    const history = mgr.getDiffHistory('conv1');
+    expect(history[0].fromVersion).toBe(1);
+    expect(history[0].toVersion).toBe(2);
+  });
+
+  it('diff entries contain correct added/removed/changed paths', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    mgr.update(card.id, { ...minimalWorldCard, goal: 'New goal' });
+    const history = mgr.getDiffHistory('conv1');
+    expect(history[0].diff.changed).toContain('goal');
+  });
+
+  it('does not return diffs from other conversations', () => {
+    const card1 = mgr.create('conv1', 'world', minimalWorldCard);
+    const card2 = mgr.create('conv2', 'world', minimalWorldCard);
+    mgr.update(card1.id, { ...minimalWorldCard, goal: 'conv1 goal' });
+    mgr.update(card2.id, { ...minimalWorldCard, goal: 'conv2 goal' });
+    const history = mgr.getDiffHistory('conv1');
+    expect(history).toHaveLength(1);
+  });
+});
+
 // ─── Edge Cases ───
 
 describe('CardManager edge cases', () => {

--- a/src/cards/card-manager.ts
+++ b/src/cards/card-manager.ts
@@ -1,6 +1,15 @@
 import type { Database } from 'bun:sqlite';
 import type { CardType, AnyCard, CardDiff, CardEnvelope } from '../schemas/card';
 
+export interface DiffEntry {
+  id: string;
+  cardId: string;
+  fromVersion: number;
+  toVersion: number;
+  diff: CardDiff;
+  createdAt: string;
+}
+
 // ─── Diff Logic ───
 
 function flattenObject(
@@ -134,6 +143,12 @@ export class CardManager {
       [newId, conversationId, type, newVersion, JSON.stringify(mergedContent), originalCreatedAt, now],
     );
 
+    const diffId = crypto.randomUUID();
+    this.db.run(
+      'INSERT INTO card_diffs (id, card_id, from_version, to_version, diff, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+      [diffId, newId, oldVersion, newVersion, JSON.stringify(diff), now],
+    );
+
     const updatedCard: CardEnvelope = {
       id: newId,
       conversationId,
@@ -170,5 +185,26 @@ export class CardManager {
       oldContent as unknown as Record<string, unknown>,
       newContent as unknown as Record<string, unknown>,
     );
+  }
+
+  getDiffHistory(conversationId: string): DiffEntry[] {
+    const rows = this.db
+      .query(
+        `SELECT cd.id, cd.card_id, cd.from_version, cd.to_version, cd.diff, cd.created_at
+         FROM card_diffs cd
+         JOIN cards c ON cd.card_id = c.id
+         WHERE c.conversation_id = ?
+         ORDER BY cd.from_version ASC`,
+      )
+      .all(conversationId) as Record<string, unknown>[];
+
+    return rows.map((row) => ({
+      id: row.id as string,
+      cardId: row.card_id as string,
+      fromVersion: row.from_version as number,
+      toVersion: row.to_version as number,
+      diff: JSON.parse(row.diff as string) as CardDiff,
+      createdAt: row.created_at as string,
+    }));
   }
 }

--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -20,7 +20,7 @@ describe('DB Layer — initSchema', () => {
     initSchema(db);
   });
 
-  it('creates all 4 tables', () => {
+  it('creates all 5 tables', () => {
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
       .all() as { name: string }[];
@@ -28,6 +28,7 @@ describe('DB Layer — initSchema', () => {
     expect(names).toContain('conversations');
     expect(names).toContain('messages');
     expect(names).toContain('cards');
+    expect(names).toContain('card_diffs');
     expect(names).toContain('settlements');
   });
 
@@ -155,6 +156,35 @@ describe('DB Layer — initSchema', () => {
     expect(() => {
       db.run(
         "INSERT INTO settlements (id, conversation_id, card_id, target, payload) VALUES ('s1', 'c1', 'k1', 'invalid_target', '{}')"
+      );
+    }).toThrow();
+  });
+
+  // ── card_diffs ──
+
+  it('can insert a card_diff with FK', () => {
+    db.run("INSERT INTO conversations (id, mode) VALUES ('c1', 'world_design')");
+    db.run(
+      "INSERT INTO cards (id, conversation_id, type, content) VALUES ('k1', 'c1', 'world', '{}')"
+    );
+    const diff = JSON.stringify({ added: ['goal'], removed: [], changed: [] });
+    db.run(
+      "INSERT INTO card_diffs (id, card_id, from_version, to_version, diff) VALUES ('d1', 'k1', 1, 2, ?)",
+      [diff]
+    );
+    const row = db
+      .prepare("SELECT * FROM card_diffs WHERE id = 'd1'")
+      .get() as Record<string, unknown>;
+    expect(row.card_id).toBe('k1');
+    expect(row.from_version).toBe(1);
+    expect(row.to_version).toBe(2);
+    expect(JSON.parse(row.diff as string)).toHaveProperty('added');
+  });
+
+  it('rejects card_diff with invalid card_id FK', () => {
+    expect(() => {
+      db.run(
+        "INSERT INTO card_diffs (id, card_id, from_version, to_version, diff) VALUES ('d1', 'nonexistent', 1, 2, '{}')"
       );
     }).toThrow();
   });

--- a/src/db.ts
+++ b/src/db.ts
@@ -35,6 +35,15 @@ export function initSchema(db: Database): void {
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`);
 
+  db.run(`CREATE TABLE IF NOT EXISTS card_diffs (
+    id TEXT PRIMARY KEY,
+    card_id TEXT NOT NULL REFERENCES cards(id),
+    from_version INTEGER NOT NULL,
+    to_version INTEGER NOT NULL,
+    diff TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`);
+
   db.run(`CREATE TABLE IF NOT EXISTS settlements (
     id TEXT PRIMARY KEY,
     conversation_id TEXT NOT NULL REFERENCES conversations(id),

--- a/src/routes/cards.ts
+++ b/src/routes/cards.ts
@@ -16,5 +16,12 @@ export function cardRoutes(deps: CardDeps): Hono {
     return ok(c, card);
   });
 
+  // GET /api/conversations/:id/card/diffs
+  app.get('/api/conversations/:id/card/diffs', (c) => {
+    const conversationId = c.req.param('id');
+    const diffs = deps.cardManager.getDiffHistory(conversationId);
+    return ok(c, diffs);
+  });
+
   return app;
 }


### PR DESCRIPTION
## Summary
- Add `card_diffs` table to DB schema (id, card_id, from_version, to_version, diff JSON, created_at)
- Update `CardManager.update()` to INSERT diff into `card_diffs` on every card update
- Add `CardManager.getDiffHistory(conversationId)` method to retrieve all diffs for a conversation
- Add `GET /api/conversations/:id/card/diffs` route
- Add tests for diff persistence, retrieval, FK constraints, and conversation isolation

## Test plan
- [x] `bun run build` passes (zero type errors)
- [x] `bun run lint` passes (zero lint errors)
- [x] `bun test` passes (197 tests, including 8 new diff-related tests)
- [x] `bun run knip` has no new issues (pre-existing only)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)