### PR TITLE
feat: add WorkflowCard and TaskCard turn handling

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -83,6 +83,7 @@ async function runCli() {
       conversationId,
       input,
       phase,
+      'world_design',
     );
     phase = result.phase;
 

--- a/src/conductor/rhythm.ts
+++ b/src/conductor/rhythm.ts
@@ -1,10 +1,17 @@
 import type { Phase } from './state-machine';
 import type { IntentType } from '../schemas/intent';
 import type { Strategy } from '../llm/prompts';
+import type { ConversationMode } from '../schemas/conversation';
 
-export function pickStrategy(phase: Phase, intentType: IntentType, hasPending: boolean): Strategy {
+export function pickStrategy(
+  phase: Phase,
+  intentType: IntentType,
+  hasPending: boolean,
+  mode?: ConversationMode,
+): Strategy {
   switch (phase) {
     case 'explore':
+      if (mode === 'task' && intentType === 'confirm') return 'settle';
       if (intentType === 'new_intent') return 'mirror';
       if (intentType === 'set_boundary') return 'mirror';
       return 'probe';

--- a/src/conductor/state-machine.test.ts
+++ b/src/conductor/state-machine.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import { checkTransition } from './state-machine';
-import type { WorldCard } from '../schemas/card';
+import type { WorldCard, WorkflowCard, TaskCard } from '../schemas/card';
 
-function makeCard(opts: {
+function makeWorldCard(opts: {
   hardRules?: string[];
   mustHave?: string[];
   pendingCount?: number;
@@ -27,102 +27,249 @@ function makeCard(opts: {
   };
 }
 
-// Group 1: EXPLORE → FOCUS
+function makeWorkflowCard(opts: {
+  stepsCount?: number;
+  triggers?: string[];
+  pendingCount?: number;
+}): WorkflowCard {
+  return {
+    name: 'test-workflow',
+    purpose: 'testing',
+    steps: Array.from({ length: opts.stepsCount ?? 0 }, (_, i) => ({
+      order: i,
+      description: `step ${i}`,
+      skill: null,
+      conditions: null,
+    })),
+    confirmed: {
+      triggers: opts.triggers ?? [],
+      exit_conditions: [],
+      failure_handling: [],
+    },
+    pending: Array.from({ length: opts.pendingCount ?? 0 }, (_, i) => ({
+      question: `q${i}`,
+      context: `c${i}`,
+    })),
+    version: 1,
+  };
+}
 
-describe('EXPLORE → FOCUS transitions', () => {
-  it('explore → focus when hard_rule exists and must_have >= 3', () => {
-    const card = makeCard({ hardRules: ['r1'], mustHave: ['a', 'b', 'c'] });
-    const result = checkTransition('explore', card, 'add_info');
+function makeTaskCard(opts: {
+  intent?: string;
+  constraints?: string[];
+}): TaskCard {
+  return {
+    intent: opts.intent ?? '',
+    inputs: {},
+    constraints: opts.constraints ?? [],
+    success_condition: null,
+    version: 1,
+  };
+}
+
+// ─── WorldCard Transitions ───
+
+describe('WorldCard: EXPLORE -> FOCUS transitions', () => {
+  it('explore -> focus when hard_rule exists and must_have >= 3', () => {
+    const card = makeWorldCard({ hardRules: ['r1'], mustHave: ['a', 'b', 'c'] });
+    const result = checkTransition('explore', 'world', card, 'add_info');
     expect(result.newPhase).toBe('focus');
     expect(result.reason).not.toBeNull();
   });
 
-  it('explore → focus on set_boundary when must_have >= 2', () => {
-    const card = makeCard({ mustHave: ['a', 'b'] });
-    const result = checkTransition('explore', card, 'set_boundary');
+  it('explore -> focus on set_boundary when must_have >= 2', () => {
+    const card = makeWorldCard({ mustHave: ['a', 'b'] });
+    const result = checkTransition('explore', 'world', card, 'set_boundary');
     expect(result.newPhase).toBe('focus');
     expect(result.reason).not.toBeNull();
   });
 
   it('explore stays when must_have < 3 and no boundary', () => {
-    const card = makeCard({ mustHave: ['a'] });
-    const result = checkTransition('explore', card, 'add_info');
+    const card = makeWorldCard({ mustHave: ['a'] });
+    const result = checkTransition('explore', 'world', card, 'add_info');
     expect(result.newPhase).toBe('explore');
     expect(result.reason).toBeNull();
   });
 
   it('explore stays when set_boundary but must_have < 2', () => {
-    const card = makeCard({ mustHave: ['a'] });
-    const result = checkTransition('explore', card, 'set_boundary');
+    const card = makeWorldCard({ mustHave: ['a'] });
+    const result = checkTransition('explore', 'world', card, 'set_boundary');
     expect(result.newPhase).toBe('explore');
     expect(result.reason).toBeNull();
   });
 
   it('explore stays on settle_signal (cannot skip focus)', () => {
-    const card = makeCard({});
-    const result = checkTransition('explore', card, 'settle_signal');
+    const card = makeWorldCard({});
+    const result = checkTransition('explore', 'world', card, 'settle_signal');
     expect(result.newPhase).toBe('explore');
     expect(result.reason).toBeNull();
   });
 });
 
-// Group 2: FOCUS → SETTLE
-
-describe('FOCUS → SETTLE transitions', () => {
-  it('focus → settle when pending empty and confirm', () => {
-    const card = makeCard({ pendingCount: 0 });
-    const result = checkTransition('focus', card, 'confirm');
+describe('WorldCard: FOCUS -> SETTLE transitions', () => {
+  it('focus -> settle when pending empty and confirm', () => {
+    const card = makeWorldCard({ pendingCount: 0 });
+    const result = checkTransition('focus', 'world', card, 'confirm');
     expect(result.newPhase).toBe('settle');
     expect(result.reason).not.toBeNull();
   });
 
   it('focus stays when pending not empty and confirm', () => {
-    const card = makeCard({ pendingCount: 2 });
-    const result = checkTransition('focus', card, 'confirm');
+    const card = makeWorldCard({ pendingCount: 2 });
+    const result = checkTransition('focus', 'world', card, 'confirm');
     expect(result.newPhase).toBe('focus');
     expect(result.reason).toBeNull();
   });
 
-  it('focus → settle on explicit settle_signal', () => {
-    const card = makeCard({ pendingCount: 1 });
-    const result = checkTransition('focus', card, 'settle_signal');
+  it('focus -> settle on explicit settle_signal', () => {
+    const card = makeWorldCard({ pendingCount: 1 });
+    const result = checkTransition('focus', 'world', card, 'settle_signal');
     expect(result.newPhase).toBe('settle');
     expect(result.reason).not.toBeNull();
   });
 });
 
-// Group 3: Rollback transitions
-
-describe('Rollback transitions', () => {
-  it('focus → explore on new_intent (rollback)', () => {
-    const card = makeCard({});
-    const result = checkTransition('focus', card, 'new_intent');
+describe('WorldCard: Rollback transitions', () => {
+  it('focus -> explore on new_intent (rollback)', () => {
+    const card = makeWorldCard({});
+    const result = checkTransition('focus', 'world', card, 'new_intent');
     expect(result.newPhase).toBe('explore');
     expect(result.reason).not.toBeNull();
   });
 
-  it('settle → explore on new_intent (new cycle)', () => {
-    const card = makeCard({});
-    const result = checkTransition('settle', card, 'new_intent');
+  it('settle -> explore on new_intent (new cycle)', () => {
+    const card = makeWorldCard({});
+    const result = checkTransition('settle', 'world', card, 'new_intent');
     expect(result.newPhase).toBe('explore');
     expect(result.reason).not.toBeNull();
   });
 });
 
-// Group 4: No-transition cases
-
-describe('No-transition cases', () => {
+describe('WorldCard: No-transition cases', () => {
   it('settle stays on confirm (no transition)', () => {
-    const card = makeCard({});
-    const result = checkTransition('settle', card, 'confirm');
+    const card = makeWorldCard({});
+    const result = checkTransition('settle', 'world', card, 'confirm');
     expect(result.newPhase).toBe('settle');
     expect(result.reason).toBeNull();
   });
 
   it('explore stays on add_info with insufficient card state', () => {
-    const card = makeCard({});
-    const result = checkTransition('explore', card, 'add_info');
+    const card = makeWorldCard({});
+    const result = checkTransition('explore', 'world', card, 'add_info');
     expect(result.newPhase).toBe('explore');
     expect(result.reason).toBeNull();
+  });
+});
+
+// ─── WorkflowCard Transitions ───
+
+describe('WorkflowCard transitions', () => {
+  it('explore -> focus when steps + triggers exist', () => {
+    const card = makeWorkflowCard({ stepsCount: 2, triggers: ['on_message'] });
+    const result = checkTransition('explore', 'workflow', card, 'add_info');
+    expect(result.newPhase).toBe('focus');
+    expect(result.reason).toBe('steps defined + triggers set');
+  });
+
+  it('explore stays when no steps', () => {
+    const card = makeWorkflowCard({ triggers: ['on_message'] });
+    const result = checkTransition('explore', 'workflow', card, 'add_info');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).toBeNull();
+  });
+
+  it('explore stays when no triggers', () => {
+    const card = makeWorkflowCard({ stepsCount: 2 });
+    const result = checkTransition('explore', 'workflow', card, 'add_info');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).toBeNull();
+  });
+
+  it('focus -> settle on confirm with empty pending', () => {
+    const card = makeWorkflowCard({ stepsCount: 1, triggers: ['t1'], pendingCount: 0 });
+    const result = checkTransition('focus', 'workflow', card, 'confirm');
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).not.toBeNull();
+  });
+
+  it('focus -> settle on settle_signal', () => {
+    const card = makeWorkflowCard({ stepsCount: 1, triggers: ['t1'], pendingCount: 1 });
+    const result = checkTransition('focus', 'workflow', card, 'settle_signal');
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).not.toBeNull();
+  });
+
+  it('focus -> explore on new_intent (rollback)', () => {
+    const card = makeWorkflowCard({});
+    const result = checkTransition('focus', 'workflow', card, 'new_intent');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).not.toBeNull();
+  });
+
+  it('settle -> explore on new_intent', () => {
+    const card = makeWorkflowCard({});
+    const result = checkTransition('settle', 'workflow', card, 'new_intent');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).not.toBeNull();
+  });
+});
+
+// ─── TaskCard Transitions ───
+
+describe('TaskCard transitions', () => {
+  it('explore -> settle fast-path on confirm with intent set', () => {
+    const card = makeTaskCard({ intent: 'deploy to prod' });
+    const result = checkTransition('explore', 'task', card, 'confirm');
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).toBe('task intent set + user confirmed');
+  });
+
+  it('explore -> settle fast-path on settle_signal with intent set', () => {
+    const card = makeTaskCard({ intent: 'deploy to prod' });
+    const result = checkTransition('explore', 'task', card, 'settle_signal');
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).toBe('task intent set + user confirmed');
+  });
+
+  it('explore stays on confirm when intent is empty', () => {
+    const card = makeTaskCard({ intent: '' });
+    const result = checkTransition('explore', 'task', card, 'confirm');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).toBeNull();
+  });
+
+  it('explore -> focus when constraints exist but no confirm', () => {
+    const card = makeTaskCard({ intent: 'test', constraints: ['no downtime'] });
+    const result = checkTransition('explore', 'task', card, 'add_info');
+    expect(result.newPhase).toBe('focus');
+    expect(result.reason).toBe('constraints defined');
+  });
+
+  it('focus -> settle on confirm', () => {
+    const card = makeTaskCard({ intent: 'test' });
+    const result = checkTransition('focus', 'task', card, 'confirm');
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).toBe('user confirmed task');
+  });
+
+  it('focus -> settle on settle_signal', () => {
+    const card = makeTaskCard({ intent: 'test' });
+    const result = checkTransition('focus', 'task', card, 'settle_signal');
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).toBe('user confirmed task');
+  });
+
+  it('settle -> explore on new_intent', () => {
+    const card = makeTaskCard({ intent: 'old task' });
+    const result = checkTransition('settle', 'task', card, 'new_intent');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).toBe('new task after settlement');
+  });
+
+  it('focus -> explore on new_intent (rollback)', () => {
+    const card = makeTaskCard({ intent: 'test' });
+    const result = checkTransition('focus', 'task', card, 'new_intent');
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).not.toBeNull();
   });
 });

--- a/src/conductor/state-machine.ts
+++ b/src/conductor/state-machine.ts
@@ -1,4 +1,4 @@
-import type { WorldCard } from '../schemas/card';
+import type { WorldCard, WorkflowCard, TaskCard, AnyCard, CardType } from '../schemas/card';
 import type { IntentType } from '../schemas/intent';
 
 export type { IntentType } from '../schemas/intent';
@@ -10,12 +10,14 @@ export interface TransitionResult {
   reason: string | null;
 }
 
-export function checkTransition(
+// ─── WorldCard Transitions ───
+
+function checkWorldTransition(
   currentPhase: Phase,
   card: WorldCard,
   intentType: IntentType,
 ): TransitionResult {
-  // EXPLORE → FOCUS
+  // EXPLORE -> FOCUS
   if (currentPhase === 'explore') {
     if (card.confirmed.hard_rules.length > 0 && card.confirmed.must_have.length >= 3) {
       return { newPhase: 'focus', reason: 'hard_rule + must_have >= 3' };
@@ -25,7 +27,7 @@ export function checkTransition(
     }
   }
 
-  // FOCUS → SETTLE
+  // FOCUS -> SETTLE
   if (currentPhase === 'focus') {
     if (card.pending.length === 0 && intentType === 'confirm') {
       return { newPhase: 'settle', reason: 'pending empty + user confirmed' };
@@ -35,14 +37,14 @@ export function checkTransition(
     }
   }
 
-  // SETTLE → EXPLORE
+  // SETTLE -> EXPLORE
   if (currentPhase === 'settle') {
     if (intentType === 'new_intent') {
       return { newPhase: 'explore', reason: 'new topic after settlement' };
     }
   }
 
-  // FOCUS → EXPLORE (rollback)
+  // FOCUS -> EXPLORE (rollback)
   if (currentPhase === 'focus') {
     if (intentType === 'new_intent') {
       return { newPhase: 'explore', reason: 'major direction change' };
@@ -50,4 +52,105 @@ export function checkTransition(
   }
 
   return { newPhase: currentPhase, reason: null };
+}
+
+// ─── WorkflowCard Transitions ───
+
+function checkWorkflowTransition(
+  currentPhase: Phase,
+  card: WorkflowCard,
+  intentType: IntentType,
+): TransitionResult {
+  // EXPLORE -> FOCUS
+  if (currentPhase === 'explore') {
+    if (card.steps.length > 0 && card.confirmed.triggers.length > 0) {
+      return { newPhase: 'focus', reason: 'steps defined + triggers set' };
+    }
+  }
+
+  // FOCUS -> SETTLE
+  if (currentPhase === 'focus') {
+    if (card.pending.length === 0 && intentType === 'confirm') {
+      return { newPhase: 'settle', reason: 'pending empty + user confirmed' };
+    }
+    if (intentType === 'settle_signal') {
+      return { newPhase: 'settle', reason: 'user explicit settle signal' };
+    }
+  }
+
+  // SETTLE -> EXPLORE
+  if (currentPhase === 'settle') {
+    if (intentType === 'new_intent') {
+      return { newPhase: 'explore', reason: 'new topic after settlement' };
+    }
+  }
+
+  // FOCUS -> EXPLORE (rollback)
+  if (currentPhase === 'focus') {
+    if (intentType === 'new_intent') {
+      return { newPhase: 'explore', reason: 'major direction change' };
+    }
+  }
+
+  return { newPhase: currentPhase, reason: null };
+}
+
+// ─── TaskCard Transitions ───
+
+function checkTaskTransition(
+  currentPhase: Phase,
+  card: TaskCard,
+  intentType: IntentType,
+): TransitionResult {
+  // EXPLORE -> SETTLE (fast-path)
+  if (currentPhase === 'explore') {
+    if (card.intent !== '' && (intentType === 'confirm' || intentType === 'settle_signal')) {
+      return { newPhase: 'settle', reason: 'task intent set + user confirmed' };
+    }
+    // EXPLORE -> FOCUS
+    if (card.constraints.length > 0 && intentType !== 'confirm' && intentType !== 'settle_signal') {
+      return { newPhase: 'focus', reason: 'constraints defined' };
+    }
+  }
+
+  // FOCUS -> SETTLE
+  if (currentPhase === 'focus') {
+    if (intentType === 'confirm' || intentType === 'settle_signal') {
+      return { newPhase: 'settle', reason: 'user confirmed task' };
+    }
+  }
+
+  // SETTLE -> EXPLORE
+  if (currentPhase === 'settle') {
+    if (intentType === 'new_intent') {
+      return { newPhase: 'explore', reason: 'new task after settlement' };
+    }
+  }
+
+  // FOCUS -> EXPLORE (rollback)
+  if (currentPhase === 'focus') {
+    if (intentType === 'new_intent') {
+      return { newPhase: 'explore', reason: 'major direction change' };
+    }
+  }
+
+  return { newPhase: currentPhase, reason: null };
+}
+
+// ─── Dispatcher ───
+
+export function checkTransition(
+  currentPhase: Phase,
+  cardType: CardType,
+  card: AnyCard,
+  intentType: IntentType,
+): TransitionResult {
+  switch (cardType) {
+    case 'world':
+      return checkWorldTransition(currentPhase, card as WorldCard, intentType);
+    case 'workflow':
+      return checkWorkflowTransition(currentPhase, card as WorkflowCard, intentType);
+    case 'task':
+      return checkTaskTransition(currentPhase, card as TaskCard, intentType);
+  }
 }

--- a/src/conductor/turn-handler.test.ts
+++ b/src/conductor/turn-handler.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { applyIntentToCard, createEmptyWorldCard, handleTurn } from './turn-handler';
+import {
+  applyIntentToCard,
+  applyIntentToWorkflowCard,
+  applyIntentToTaskCard,
+  createEmptyWorldCard,
+  createEmptyWorkflowCard,
+  createEmptyTaskCard,
+  handleTurn,
+} from './turn-handler';
 import { CardManager } from '../cards/card-manager';
 import { createDb, initSchema } from '../db';
 import type { LLMClient } from '../llm/client';
 
-// ─── applyIntentToCard Tests ───
+// ─── applyIntentToCard (WorldCard) Tests ───
 
 describe('applyIntentToCard', () => {
   it('new_intent sets goal', () => {
@@ -78,6 +86,125 @@ describe('applyIntentToCard', () => {
   });
 });
 
+// ─── applyIntentToWorkflowCard Tests ───
+
+describe('applyIntentToWorkflowCard', () => {
+  it('new_intent sets name and purpose', () => {
+    const card = createEmptyWorkflowCard();
+    const result = applyIntentToWorkflowCard(card, {
+      type: 'new_intent',
+      summary: '客服自動回覆流程',
+    });
+    expect(result.name).toBe('客服自動回覆流程');
+    expect(result.purpose).toBe('客服自動回覆流程');
+  });
+
+  it('add_info pushes steps', () => {
+    const card = createEmptyWorkflowCard();
+    const result = applyIntentToWorkflowCard(card, {
+      type: 'add_info',
+      summary: '新增步驟',
+      entities: { s1: '接收訊息', s2: '分類意圖' },
+    });
+    expect(result.steps).toHaveLength(2);
+    expect(result.steps[0]).toMatchObject({ description: '接收訊息', order: 0 });
+    expect(result.steps[1]).toMatchObject({ description: '分類意圖', order: 1 });
+  });
+
+  it('set_boundary hard pushes to triggers', () => {
+    const card = createEmptyWorkflowCard();
+    const result = applyIntentToWorkflowCard(card, {
+      type: 'set_boundary',
+      summary: '收到新訊息時啟動',
+      enforcement: 'hard',
+    });
+    expect(result.confirmed.triggers).toContain('收到新訊息時啟動');
+  });
+
+  it('set_boundary soft pushes to exit_conditions', () => {
+    const card = createEmptyWorkflowCard();
+    const result = applyIntentToWorkflowCard(card, {
+      type: 'set_boundary',
+      summary: '超過 30 秒就中止',
+      enforcement: 'soft',
+    });
+    expect(result.confirmed.exit_conditions).toContain('超過 30 秒就中止');
+  });
+
+  it('add_constraint pushes to failure_handling', () => {
+    const card = createEmptyWorkflowCard();
+    const result = applyIntentToWorkflowCard(card, {
+      type: 'add_constraint',
+      summary: '失敗時通知管理員',
+    });
+    expect(result.confirmed.failure_handling).toContain('失敗時通知管理員');
+  });
+
+  it('confirm only bumps nothing (version unchanged)', () => {
+    const card = createEmptyWorkflowCard();
+    const result = applyIntentToWorkflowCard(card, {
+      type: 'confirm',
+      summary: '好',
+    });
+    expect(result.version).toBe(1);
+    expect(result.steps).toHaveLength(0);
+  });
+});
+
+// ─── applyIntentToTaskCard Tests ───
+
+describe('applyIntentToTaskCard', () => {
+  it('new_intent sets intent', () => {
+    const card = createEmptyTaskCard();
+    const result = applyIntentToTaskCard(card, {
+      type: 'new_intent',
+      summary: '部署到 production',
+    });
+    expect(result.intent).toBe('部署到 production');
+  });
+
+  it('add_info merges inputs', () => {
+    const card = createEmptyTaskCard();
+    card.inputs = { env: 'staging' };
+    const result = applyIntentToTaskCard(card, {
+      type: 'add_info',
+      summary: '補充參數',
+      entities: { branch: 'main', env: 'production' },
+    });
+    expect(result.inputs.branch).toBe('main');
+    expect(result.inputs.env).toBe('production');
+  });
+
+  it('set_boundary pushes to constraints', () => {
+    const card = createEmptyTaskCard();
+    const result = applyIntentToTaskCard(card, {
+      type: 'set_boundary',
+      summary: '不能影響線上服務',
+      enforcement: 'hard',
+    });
+    expect(result.constraints).toContain('不能影響線上服務');
+  });
+
+  it('add_constraint pushes to constraints', () => {
+    const card = createEmptyTaskCard();
+    const result = applyIntentToTaskCard(card, {
+      type: 'add_constraint',
+      summary: '限制 5 分鐘內完成',
+    });
+    expect(result.constraints).toContain('限制 5 分鐘內完成');
+  });
+
+  it('confirm only bumps nothing (version unchanged)', () => {
+    const card = createEmptyTaskCard();
+    const result = applyIntentToTaskCard(card, {
+      type: 'confirm',
+      summary: '好',
+    });
+    expect(result.version).toBe(1);
+    expect(result.constraints).toHaveLength(0);
+  });
+});
+
 // ─── handleTurn Tests ───
 
 describe('handleTurn', () => {
@@ -128,5 +255,47 @@ describe('handleTurn', () => {
     // generateStructured (intent) + generateText (reply) = 2 calls
     expect(mockParseIntent).toHaveBeenCalledTimes(1);
     expect(mockGenerateReply).toHaveBeenCalledTimes(1);
+  });
+
+  it('workflow_design mode creates WorkflowCard on first turn', async () => {
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'new_intent', summary: '自動回覆流程' },
+    });
+    mockGenerateReply.mockResolvedValueOnce('好的，讓我們設計這個流程');
+
+    const db = createDb(':memory:');
+    initSchema(db);
+    db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'workflow_design', 'explore')");
+    const mgr = new CardManager(db);
+    const result = await handleTurn(mockLlm, mgr, 'conv1', '自動回覆流程', 'explore', 'workflow_design');
+
+    expect(result.phase).toBe('explore');
+    expect(result.cardVersion).toBeGreaterThanOrEqual(1);
+
+    const card = mgr.getLatest('conv1');
+    expect(card).not.toBeNull();
+    expect(card!.type).toBe('workflow');
+  });
+
+  it('task mode creates TaskCard on first turn', async () => {
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'new_intent', summary: '部署到 prod' },
+    });
+    mockGenerateReply.mockResolvedValueOnce('了解，準備部署');
+
+    const db = createDb(':memory:');
+    initSchema(db);
+    db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'task', 'explore')");
+    const mgr = new CardManager(db);
+    const result = await handleTurn(mockLlm, mgr, 'conv1', '部署到 prod', 'explore', 'task');
+
+    expect(result.phase).toBe('explore');
+    expect(result.cardVersion).toBeGreaterThanOrEqual(1);
+
+    const card = mgr.getLatest('conv1');
+    expect(card).not.toBeNull();
+    expect(card!.type).toBe('task');
   });
 });

--- a/src/conductor/turn-handler.ts
+++ b/src/conductor/turn-handler.ts
@@ -4,9 +4,10 @@ import { parseIntent } from '../llm/intent-parser';
 import { generateReply } from '../llm/response-gen';
 import { checkTransition, type Phase } from './state-machine';
 import { pickStrategy } from './rhythm';
-import type { WorldCard } from '../schemas/card';
+import type { WorldCard, WorkflowCard, TaskCard, AnyCard, CardType } from '../schemas/card';
 import type { Intent } from '../schemas/intent';
 import type { Strategy } from '../llm/prompts';
+import type { ConversationMode } from '../schemas/conversation';
 
 export interface TurnResult {
   reply: string;
@@ -16,6 +17,8 @@ export interface TurnResult {
   strategy: Strategy;
   cardVersion: number;
 }
+
+// ─── Empty Card Factories ───
 
 export function createEmptyWorldCard(): WorldCard {
   return {
@@ -29,6 +32,53 @@ export function createEmptyWorldCard(): WorldCard {
     version: 1,
   };
 }
+
+export function createEmptyWorkflowCard(): WorkflowCard {
+  return {
+    name: null,
+    purpose: null,
+    steps: [],
+    confirmed: { triggers: [], exit_conditions: [], failure_handling: [] },
+    pending: [],
+    version: 1,
+  };
+}
+
+export function createEmptyTaskCard(): TaskCard {
+  return {
+    intent: '',
+    inputs: {},
+    constraints: [],
+    success_condition: null,
+    version: 1,
+  };
+}
+
+// ─── Mode / CardType Mapping ───
+
+export function modeToCardType(mode: ConversationMode): CardType {
+  switch (mode) {
+    case 'world_design':
+      return 'world';
+    case 'workflow_design':
+      return 'workflow';
+    case 'task':
+      return 'task';
+  }
+}
+
+export function createEmptyCard(mode: ConversationMode): AnyCard {
+  switch (mode) {
+    case 'world_design':
+      return createEmptyWorldCard();
+    case 'workflow_design':
+      return createEmptyWorkflowCard();
+    case 'task':
+      return createEmptyTaskCard();
+  }
+}
+
+// ─── Intent Apply Functions ───
 
 export function applyIntentToCard(card: WorldCard, intent: Intent): WorldCard {
   const updated = structuredClone(card);
@@ -73,22 +123,124 @@ export function applyIntentToCard(card: WorldCard, intent: Intent): WorldCard {
   return updated;
 }
 
+export function applyIntentToWorkflowCard(card: WorkflowCard, intent: Intent): WorkflowCard {
+  const updated = structuredClone(card);
+
+  switch (intent.type) {
+    case 'new_intent':
+      if (intent.summary) {
+        updated.name = intent.summary;
+        updated.purpose = intent.summary;
+      }
+      break;
+    case 'add_info':
+      if (intent.entities) {
+        for (const [, value] of Object.entries(intent.entities)) {
+          updated.steps.push({
+            order: updated.steps.length,
+            description: value,
+            skill: null,
+            conditions: null,
+          });
+        }
+      }
+      break;
+    case 'set_boundary':
+      if (intent.enforcement === 'hard') {
+        updated.confirmed.triggers.push(intent.summary);
+      } else {
+        updated.confirmed.exit_conditions.push(intent.summary);
+      }
+      break;
+    case 'add_constraint':
+      updated.confirmed.failure_handling.push(intent.summary);
+      break;
+    case 'confirm':
+    case 'settle_signal':
+    case 'modify':
+    case 'question':
+    case 'off_topic':
+    case 'style_preference':
+      break;
+  }
+
+  return updated;
+}
+
+export function applyIntentToTaskCard(card: TaskCard, intent: Intent): TaskCard {
+  const updated = structuredClone(card);
+
+  switch (intent.type) {
+    case 'new_intent':
+      if (intent.summary) updated.intent = intent.summary;
+      break;
+    case 'add_info':
+      if (intent.entities) {
+        for (const [key, value] of Object.entries(intent.entities)) {
+          updated.inputs[key] = value;
+        }
+      }
+      break;
+    case 'set_boundary':
+    case 'add_constraint':
+      updated.constraints.push(intent.summary);
+      break;
+    case 'confirm':
+    case 'settle_signal':
+    case 'modify':
+    case 'question':
+    case 'off_topic':
+    case 'style_preference':
+      break;
+  }
+
+  return updated;
+}
+
+export function applyIntent(cardType: CardType, card: AnyCard, intent: Intent): AnyCard {
+  switch (cardType) {
+    case 'world':
+      return applyIntentToCard(card as WorldCard, intent);
+    case 'workflow':
+      return applyIntentToWorkflowCard(card as WorkflowCard, intent);
+    case 'task':
+      return applyIntentToTaskCard(card as TaskCard, intent);
+  }
+}
+
+// ─── hasPending Helper ───
+
+function cardHasPending(cardType: CardType, card: AnyCard): boolean {
+  switch (cardType) {
+    case 'world':
+      return (card as WorldCard).pending.length > 0;
+    case 'workflow':
+      return (card as WorkflowCard).pending.length > 0;
+    case 'task':
+      return false;
+  }
+}
+
+// ─── handleTurn ───
+
 export async function handleTurn(
   llm: LLMClient,
   cardManager: CardManager,
   conversationId: string,
   userMessage: string,
   currentPhase: Phase,
+  mode: ConversationMode = 'world_design',
 ): Promise<TurnResult> {
+  const cardType = modeToCardType(mode);
   const currentCard = cardManager.getLatest(conversationId);
-  const cardContent = currentCard ? (currentCard.content as WorldCard) : createEmptyWorldCard();
+  const cardContent = currentCard ? currentCard.content : createEmptyCard(mode);
   const cardSnapshot = JSON.stringify(cardContent, null, 2);
 
   // LLM #1: parse intent
   const intent = await parseIntent(llm, userMessage, cardSnapshot);
 
   // Update card content based on intent
-  const updatedContent = applyIntentToCard(cardContent, intent);
+  const updatedContent = applyIntent(cardType, cardContent, intent);
 
   // Persist card
   let cardVersion: number;
@@ -96,19 +248,16 @@ export async function handleTurn(
     const { card } = cardManager.update(currentCard.id, updatedContent);
     cardVersion = card.version;
   } else {
-    const card = cardManager.create(conversationId, 'world', updatedContent);
+    const card = cardManager.create(conversationId, cardType, updatedContent);
     cardVersion = card.version;
   }
 
   // Check state transition
-  const transition = checkTransition(currentPhase, updatedContent, intent.type);
+  const transition = checkTransition(currentPhase, cardType, updatedContent, intent.type);
 
   // Pick reply strategy
-  const strategy = pickStrategy(
-    transition.newPhase,
-    intent.type,
-    updatedContent.pending.length > 0,
-  );
+  const hasPending = cardHasPending(cardType, updatedContent);
+  const strategy = pickStrategy(transition.newPhase, intent.type, hasPending, mode);
 
   // LLM #2: generate reply
   const reply = await generateReply(llm, strategy, JSON.stringify(updatedContent, null, 2), userMessage);


### PR DESCRIPTION
## Summary
- Add `applyIntentToWorkflowCard()` and `applyIntentToTaskCard()` pure functions that map Intent types to WorkflowCard/TaskCard fields
- Add `createEmptyWorkflowCard()` and `createEmptyTaskCard()` factories, plus `createEmptyCard()` and `applyIntent()` dispatchers
- Generalize `checkTransition()` to support all three card types with distinct transition rules (WorldCard, WorkflowCard with steps+triggers, TaskCard with fast-path settle)
- Add `mode` parameter to `handleTurn()` and `pickStrategy()` to support workflow_design and task conversation modes
- Update CLI to pass `'world_design'` explicitly

## Test plan
- [x] All existing WorldCard state-machine tests pass (updated to new `checkTransition` signature)
- [x] New WorkflowCard transition tests: explore->focus (steps+triggers), focus->settle, rollback
- [x] New TaskCard transition tests: fast-path settle, explore->focus (constraints), focus->settle, rollback
- [x] New applyIntentToWorkflowCard tests: new_intent, add_info, set_boundary, add_constraint, confirm
- [x] New applyIntentToTaskCard tests: new_intent, add_info, set_boundary, add_constraint, confirm
- [x] handleTurn integration tests for workflow_design and task modes
- [x] `bun run build` (tsc --noEmit) passes
- [x] `bun run lint` (eslint) passes
- [x] `bun test` (217 tests) all pass

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)