### PR TITLE
feat: implement settlement status lifecycle

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,7 +24,7 @@ async function runCli() {
   let phase: Phase = 'explore';
   let turn = 0;
   let awaitingSettleConfirm = false;
-  let pendingYaml: string | null = null;
+  let pendingSettlementId: string | null = null;
 
   console.log('Volva CLI — type your thoughts, q to quit\n');
 
@@ -34,7 +34,7 @@ async function runCli() {
     if (!input) continue;
 
     // Handle settlement confirmation
-    if (awaitingSettleConfirm) {
+    if (awaitingSettleConfirm && pendingSettlementId) {
       turn += 1;
       db.run(
         'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
@@ -43,17 +43,36 @@ async function runCli() {
 
       let settleReply: string;
       if (input === 'y' || input === 'yes') {
-        if (pendingYaml) {
+        const settlement = db
+          .query('SELECT * FROM settlements WHERE id = ? AND status = ?')
+          .get(pendingSettlementId, 'draft') as Record<string, unknown> | null;
+
+        if (settlement) {
+          // Transition: draft -> confirmed
+          db.run(
+            'UPDATE settlements SET status = ? WHERE id = ?',
+            ['confirmed', pendingSettlementId],
+          );
           try {
-            const result = await thyra.applyVillagePack(pendingYaml);
+            const result = await thyra.applyVillagePack(settlement.payload as string);
+            // Transition: confirmed -> applied
+            db.run(
+              'UPDATE settlements SET status = ?, thyra_response = ? WHERE id = ?',
+              ['applied', JSON.stringify(result), pendingSettlementId],
+            );
             settleReply = 'Village Pack applied successfully. ' + JSON.stringify(result);
             console.log('\n' + settleReply);
           } catch (err) {
+            // Transition: confirmed -> failed
+            db.run(
+              'UPDATE settlements SET status = ? WHERE id = ?',
+              ['failed', pendingSettlementId],
+            );
             settleReply = 'Failed to apply Village Pack: ' + String(err);
             console.error('\n' + settleReply);
           }
         } else {
-          settleReply = 'No pending YAML to apply.';
+          settleReply = 'No draft settlement found.';
           console.log('\n' + settleReply);
         }
       } else {
@@ -67,7 +86,7 @@ async function runCli() {
       );
 
       awaitingSettleConfirm = false;
-      pendingYaml = null;
+      pendingSettlementId = null;
       continue;
     }
 
@@ -107,11 +126,16 @@ async function runCli() {
         const target = classifySettlement(card.type, card.content);
         if (target === 'village_pack') {
           const yaml = buildVillagePack(card.content as WorldCard);
+          const settlementId = crypto.randomUUID();
+          db.run(
+            'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+            [settlementId, conversationId, card.id, target, yaml, 'draft'],
+          );
           console.log('\n--- Village Pack YAML ---\n');
           console.log(yaml);
           console.log('\nApply to Thyra? (y/n)');
           awaitingSettleConfirm = true;
-          pendingYaml = yaml;
+          pendingSettlementId = settlementId;
         }
       }
     }

--- a/src/routes/settlements.test.ts
+++ b/src/routes/settlements.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { createDb, initSchema } from '../db';
+import { CardManager } from '../cards/card-manager';
+import { settlementRoutes } from './settlements';
+import type { Database } from 'bun:sqlite';
+import type { ThyraClient } from '../thyra-client/client';
+import type { WorldCard } from '../schemas/card';
+
+function createMockThyra() {
+  return {
+    applyVillagePack: vi.fn(),
+    createVillage: vi.fn(),
+    createConstitution: vi.fn(),
+    createChief: vi.fn(),
+    createSkill: vi.fn(),
+    getHealth: vi.fn(),
+  } as unknown as ThyraClient;
+}
+
+function jsonPost(app: Hono, path: string) {
+  return app.request(path, {
+    method: 'POST',
+    body: JSON.stringify({}),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const WORLD_CARD_CONTENT: WorldCard = {
+  goal: 'Test Village',
+  target_repo: 'test-repo',
+  confirmed: {
+    hard_rules: [{ description: 'No production writes', scope: ['*'] }],
+    soft_rules: [],
+    must_have: ['deploy', 'monitor', 'alert'],
+    success_criteria: ['uptime > 99%'],
+  },
+  pending: [],
+  chief_draft: { name: 'Chief', role: 'leader', style: 'strict' },
+  budget_draft: null,
+  current_proposal: null,
+  version: 1,
+};
+
+describe('Settlement lifecycle', () => {
+  let app: Hono;
+  let db: Database;
+  let cardManager: CardManager;
+  let thyra: ReturnType<typeof createMockThyra>;
+  let conversationId: string;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+    cardManager = new CardManager(db);
+    thyra = createMockThyra();
+
+    app = new Hono();
+    app.route('/', settlementRoutes({ db, cardManager, thyra }));
+
+    // Create conversation in settle phase with a world card
+    conversationId = crypto.randomUUID();
+    db.run(
+      "INSERT INTO conversations (id, mode, phase) VALUES (?, 'world_design', 'settle')",
+      [conversationId],
+    );
+    cardManager.create(conversationId, 'world', WORLD_CARD_CONTENT);
+  });
+
+  // ─── POST /settle ───
+
+  describe('POST /settle', () => {
+    it('creates a draft settlement record', async () => {
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(json.ok).toBe(true);
+
+      const data = json.data as Record<string, unknown>;
+      expect(data.status).toBe('draft');
+      expect(data.id).toBeDefined();
+      expect(data.target).toBe('village_pack');
+      expect(typeof data.payload).toBe('string');
+    });
+
+    it('stores draft in DB without calling Thyra', async () => {
+      await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+
+      const row = db
+        .query('SELECT * FROM settlements WHERE conversation_id = ?')
+        .get(conversationId) as Record<string, unknown> | null;
+
+      expect(row).not.toBeNull();
+      expect(row!.status).toBe('draft');
+      expect(row!.thyra_response).toBeNull();
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- vitest mock assertion
+      expect(thyra.applyVillagePack).not.toHaveBeenCalled();
+    });
+
+    it('rejects if conversation is not in settle phase', async () => {
+      db.run("UPDATE conversations SET phase = 'explore' WHERE id = ?", [conversationId]);
+
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(json.ok).toBe(false);
+
+      const err = json.error as Record<string, unknown>;
+      expect(err.code).toBe('INVALID_STATE');
+    });
+
+    it('rejects if no card found', async () => {
+      const emptyConvId = crypto.randomUUID();
+      db.run(
+        "INSERT INTO conversations (id, mode, phase) VALUES (?, 'world_design', 'settle')",
+        [emptyConvId],
+      );
+
+      const res = await jsonPost(app, `/api/conversations/${emptyConvId}/settle`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(400);
+      expect(json.ok).toBe(false);
+
+      const err = json.error as Record<string, unknown>;
+      expect(err.code).toBe('NO_CARD');
+    });
+
+    it('returns 404 for nonexistent conversation', async () => {
+      const res = await jsonPost(app, '/api/conversations/nonexistent/settle');
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(404);
+      expect(json.ok).toBe(false);
+    });
+  });
+
+  // ─── POST /settle/confirm ───
+
+  describe('POST /settle/confirm', () => {
+    it('applies a draft settlement successfully (draft -> confirmed -> applied)', async () => {
+      // Create draft
+      const settleRes = await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+      const settleJson = (await settleRes.json()) as Record<string, unknown>;
+      const settleData = settleJson.data as Record<string, unknown>;
+      const settlementId = settleData.id as string;
+
+      (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        village_id: 'v-123',
+        created: true,
+      });
+
+      // Confirm
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(json.ok).toBe(true);
+
+      const data = json.data as Record<string, unknown>;
+      expect(data.id).toBe(settlementId);
+      expect(data.status).toBe('applied');
+
+      // Verify DB state
+      const row = db
+        .query('SELECT * FROM settlements WHERE id = ?')
+        .get(settlementId) as Record<string, unknown> | null;
+
+      expect(row!.status).toBe('applied');
+      expect(row!.thyra_response).not.toBeNull();
+    });
+
+    it('returns 404 when no draft exists', async () => {
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(404);
+      expect(json.ok).toBe(false);
+
+      const err = json.error as Record<string, unknown>;
+      expect(err.code).toBe('NO_DRAFT');
+    });
+
+    it('handles Thyra failure (draft -> confirmed -> failed)', async () => {
+      // Create draft
+      await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+
+      (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Thyra is down'),
+      );
+
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(502);
+      expect(json.ok).toBe(false);
+
+      const err = json.error as Record<string, unknown>;
+      expect(err.code).toBe('UPSTREAM_ERROR');
+      expect(err.message).toBe('Thyra is down');
+
+      // Verify DB state is 'failed'
+      const row = db
+        .query('SELECT * FROM settlements WHERE conversation_id = ? ORDER BY created_at DESC LIMIT 1')
+        .get(conversationId) as Record<string, unknown> | null;
+
+      expect(row!.status).toBe('failed');
+    });
+
+    it('rejects double-confirm (already applied settlement has no draft)', async () => {
+      // Create and confirm a draft
+      await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+
+      (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        village_id: 'v-123',
+        created: true,
+      });
+      await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+
+      // Try to confirm again — no draft should exist
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(404);
+      expect(json.ok).toBe(false);
+
+      const err = json.error as Record<string, unknown>;
+      expect(err.code).toBe('NO_DRAFT');
+    });
+
+    it('rejects confirm after failure (failed settlement has no draft)', async () => {
+      // Create draft and let it fail
+      await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+
+      (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('fail'),
+      );
+      await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+
+      // Try to confirm again — no draft should exist
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(404);
+
+      const err = json.error as Record<string, unknown>;
+      expect(err.code).toBe('NO_DRAFT');
+    });
+  });
+
+  // ─── Status transition verification ───
+
+  describe('Status transitions', () => {
+    it('draft -> confirmed -> applied: DB state correct at each step', async () => {
+      // Create draft
+      const settleRes = await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+      const settleJson = (await settleRes.json()) as Record<string, unknown>;
+      const settleData = settleJson.data as Record<string, unknown>;
+      const settlementId = settleData.id as string;
+
+      // Check draft state
+      const draftRow = db
+        .query('SELECT status FROM settlements WHERE id = ?')
+        .get(settlementId) as Record<string, unknown>;
+      expect(draftRow.status).toBe('draft');
+
+      // Confirm with success
+      (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        village_id: 'v-456',
+      });
+      await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+
+      // Check applied state
+      const appliedRow = db
+        .query('SELECT status, thyra_response FROM settlements WHERE id = ?')
+        .get(settlementId) as Record<string, unknown>;
+      expect(appliedRow.status).toBe('applied');
+      expect(appliedRow.thyra_response).not.toBeNull();
+    });
+
+    it('draft -> confirmed -> failed: DB state correct at each step', async () => {
+      // Create draft
+      const settleRes = await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+      const settleJson = (await settleRes.json()) as Record<string, unknown>;
+      const settleData = settleJson.data as Record<string, unknown>;
+      const settlementId = settleData.id as string;
+
+      // Check draft state
+      const draftRow = db
+        .query('SELECT status FROM settlements WHERE id = ?')
+        .get(settlementId) as Record<string, unknown>;
+      expect(draftRow.status).toBe('draft');
+
+      // Confirm with failure
+      (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('timeout'),
+      );
+      await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+
+      // Check failed state
+      const failedRow = db
+        .query('SELECT status, thyra_response FROM settlements WHERE id = ?')
+        .get(settlementId) as Record<string, unknown>;
+      expect(failedRow.status).toBe('failed');
+      expect(failedRow.thyra_response).toBeNull();
+    });
+  });
+});

--- a/src/routes/settlements.ts
+++ b/src/routes/settlements.ts
@@ -16,8 +16,8 @@ export interface SettlementDeps {
 export function settlementRoutes(deps: SettlementDeps): Hono {
   const app = new Hono();
 
-  // POST /api/conversations/:id/settle
-  app.post('/api/conversations/:id/settle', async (c) => {
+  // POST /api/conversations/:id/settle — creates a draft settlement record
+  app.post('/api/conversations/:id/settle', (c) => {
     const conversationId = c.req.param('id');
 
     const conv = deps.db
@@ -50,28 +50,60 @@ export function settlementRoutes(deps: SettlementDeps): Hono {
     if (target === 'village_pack') {
       const yaml = buildVillagePack(card.content as WorldCard);
       const settlementId = crypto.randomUUID();
-      try {
-        const result = await deps.thyra.applyVillagePack(yaml);
-        deps.db.run(
-          'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status, thyra_response) VALUES (?, ?, ?, ?, ?, ?, ?)',
-          [settlementId, conversationId, card.id, target, yaml, 'applied', JSON.stringify(result)],
-        );
-        return ok(c, { target, yaml, status: 'applied', thyra: result });
-      } catch (err) {
-        deps.db.run(
-          'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
-          [settlementId, conversationId, card.id, target, yaml, 'failed'],
-        );
-        return error(
-          c,
-          'UPSTREAM_ERROR',
-          err instanceof Error ? err.message : 'Thyra API failed',
-          502,
-        );
-      }
+      deps.db.run(
+        'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+        [settlementId, conversationId, card.id, target, yaml, 'draft'],
+      );
+      return ok(c, { id: settlementId, target, payload: yaml, status: 'draft' });
     }
 
     return ok(c, { target, status: 'unsupported' });
+  });
+
+  // POST /api/conversations/:id/settle/confirm — confirms a draft settlement
+  app.post('/api/conversations/:id/settle/confirm', async (c) => {
+    const conversationId = c.req.param('id');
+
+    const settlement = deps.db
+      .query(
+        'SELECT * FROM settlements WHERE conversation_id = ? AND status = ? ORDER BY created_at DESC LIMIT 1',
+      )
+      .get(conversationId, 'draft') as Record<string, unknown> | null;
+
+    if (!settlement) {
+      return error(c, 'NO_DRAFT', 'No draft settlement found', 404);
+    }
+
+    const settlementId = settlement.id as string;
+    const payload = settlement.payload as string;
+
+    // Transition: draft -> confirmed
+    deps.db.run(
+      'UPDATE settlements SET status = ? WHERE id = ?',
+      ['confirmed', settlementId],
+    );
+
+    try {
+      const result = await deps.thyra.applyVillagePack(payload);
+      // Transition: confirmed -> applied
+      deps.db.run(
+        'UPDATE settlements SET status = ?, thyra_response = ? WHERE id = ?',
+        ['applied', JSON.stringify(result), settlementId],
+      );
+      return ok(c, { id: settlementId, status: 'applied', thyra: result });
+    } catch (err) {
+      // Transition: confirmed -> failed
+      deps.db.run(
+        'UPDATE settlements SET status = ? WHERE id = ?',
+        ['failed', settlementId],
+      );
+      return error(
+        c,
+        'UPSTREAM_ERROR',
+        err instanceof Error ? err.message : 'Thyra API failed',
+        502,
+      );
+    }
   });
 
   return app;


### PR DESCRIPTION
## Summary
- Refactor `POST /api/conversations/:id/settle` to create draft-only settlement records (no Thyra call), satisfying SETTLE-01 (user confirmation required)
- Add `POST /api/conversations/:id/settle/confirm` endpoint that transitions draft -> confirmed -> applied/failed via Thyra
- Update CLI to use DB-backed settlement records instead of in-memory `pendingYaml` variable
- Add comprehensive tests covering happy path, error paths, double-confirm guard, and status transition verification

## Test plan
- [x] `POST /settle` creates draft record without calling Thyra
- [x] `POST /settle` rejects non-settle phase and missing card
- [x] `POST /settle/confirm` applies draft successfully (draft -> confirmed -> applied)
- [x] `POST /settle/confirm` returns 404 when no draft exists
- [x] `POST /settle/confirm` handles Thyra failure (draft -> confirmed -> failed)
- [x] Double-confirm returns 404 (no draft after applied/failed)
- [x] `bun run build`, `bun run lint`, `bun test`, `bun run knip` all pass

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)