### PR TITLE
feat: implement workflow and task settlement builders

### DIFF
--- a/src/routes/e2e.test.ts
+++ b/src/routes/e2e.test.ts
@@ -521,7 +521,7 @@ describe('GP-2: Full W1 Scenario', () => {
     expect(conv.phase).toBe('settle');
   });
 
-  it('settlement: village pack applied via Thyra', async () => {
+  it('settlement: village pack draft created', async () => {
     const res = await jsonPost(
       app,
       `/api/conversations/${conversationId}/settle`,
@@ -533,16 +533,36 @@ describe('GP-2: Full W1 Scenario', () => {
 
     const data = json.data as Record<string, unknown>;
     expect(data.target).toBe('village_pack');
+    expect(data.status).toBe('draft');
+
+    // YAML contains hard enforcement rule
+    const yamlPayload = data.payload as string;
+    expect(yamlPayload).toContain('enforcement: hard');
+
+    // Settlement record in DB is draft
+    const settlement = db
+      .query('SELECT status FROM settlements WHERE conversation_id = ?')
+      .get(conversationId) as Record<string, unknown>;
+    expect(settlement.status).toBe('draft');
+  });
+
+  it('settlement: village pack applied via confirm', async () => {
+    const res = await jsonPost(
+      app,
+      `/api/conversations/${conversationId}/settle/confirm`,
+      {},
+    );
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(res.status).toBe(200);
+    expect(json.ok).toBe(true);
+
+    const data = json.data as Record<string, unknown>;
     expect(data.status).toBe('applied');
 
     // Thyra called once
     expect((thyra as unknown as Record<string, ReturnType<typeof vi.fn>>).applyVillagePack).toHaveBeenCalledTimes(1);
 
-    // YAML contains hard enforcement rule
-    const yamlPayload = data.yaml as string;
-    expect(yamlPayload).toContain('enforcement: hard');
-
-    // Settlement record in DB
+    // Settlement record in DB is applied
     const settlement = db
       .query('SELECT status FROM settlements WHERE conversation_id = ?')
       .get(conversationId) as Record<string, unknown>;

--- a/src/routes/settlements.ts
+++ b/src/routes/settlements.ts
@@ -5,7 +5,9 @@ import type { CardManager } from '../cards/card-manager';
 import type { ThyraClient } from '../thyra-client/client';
 import { classifySettlement } from '../settlement/router';
 import { buildVillagePack } from '../settlement/village-pack-builder';
-import type { WorldCard } from '../schemas/card';
+import { buildWorkflowSpec } from '../settlement/workflow-spec-builder';
+import { buildTaskSpec } from '../settlement/task-spec-builder';
+import type { WorldCard, WorkflowCard, TaskCard } from '../schemas/card';
 
 export interface SettlementDeps {
   db: Database;
@@ -57,7 +59,24 @@ export function settlementRoutes(deps: SettlementDeps): Hono {
       return ok(c, { id: settlementId, target, payload: yaml, status: 'draft' });
     }
 
-    return ok(c, { target, status: 'unsupported' });
+    if (target === 'workflow') {
+      const yaml = buildWorkflowSpec(card.content as WorkflowCard);
+      const settlementId = crypto.randomUUID();
+      deps.db.run(
+        'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+        [settlementId, conversationId, card.id, target, yaml, 'draft'],
+      );
+      return ok(c, { id: settlementId, target, payload: yaml, status: 'draft' });
+    }
+
+    // target === 'task'
+    const json = buildTaskSpec(card.content as TaskCard);
+    const settlementId = crypto.randomUUID();
+    deps.db.run(
+      'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+      [settlementId, conversationId, card.id, target, json, 'draft'],
+    );
+    return ok(c, { id: settlementId, target, payload: json, status: 'draft' });
   });
 
   // POST /api/conversations/:id/settle/confirm — confirms a draft settlement

--- a/src/settlement/task-spec-builder.test.ts
+++ b/src/settlement/task-spec-builder.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import { buildTaskSpec } from './task-spec-builder';
+import type { TaskCard } from '../schemas/card';
+
+const baseCard: TaskCard = {
+  intent: 'Refactor auth module',
+  inputs: { repo: 'github.com/test/app', branch: 'main' },
+  constraints: ['no breaking changes', 'keep backward compatibility'],
+  success_condition: 'all tests pass with new auth flow',
+  version: 1,
+};
+
+describe('buildTaskSpec', () => {
+  it('produces valid JSON string', () => {
+    const result = buildTaskSpec(baseCard);
+    expect(typeof result).toBe('string');
+    expect(() => JSON.parse(result)).not.toThrow();
+  });
+
+  it('maps intent correctly', () => {
+    const result = JSON.parse(buildTaskSpec(baseCard)) as Record<string, unknown>;
+    expect(result.intent).toBe('Refactor auth module');
+  });
+
+  it('maps inputs correctly', () => {
+    const result = JSON.parse(buildTaskSpec(baseCard)) as Record<string, unknown>;
+    expect(result.inputs).toEqual({ repo: 'github.com/test/app', branch: 'main' });
+  });
+
+  it('maps constraints correctly', () => {
+    const result = JSON.parse(buildTaskSpec(baseCard)) as Record<string, unknown>;
+    expect(result.constraints).toEqual(['no breaking changes', 'keep backward compatibility']);
+  });
+
+  it('maps success_condition correctly', () => {
+    const result = JSON.parse(buildTaskSpec(baseCard)) as Record<string, unknown>;
+    expect(result.success_condition).toBe('all tests pass with new auth flow');
+  });
+
+  it('handles empty inputs', () => {
+    const card: TaskCard = { ...baseCard, inputs: {} };
+    const result = JSON.parse(buildTaskSpec(card)) as Record<string, unknown>;
+    expect(result.inputs).toEqual({});
+  });
+
+  it('handles empty constraints', () => {
+    const card: TaskCard = { ...baseCard, constraints: [] };
+    const result = JSON.parse(buildTaskSpec(card)) as Record<string, unknown>;
+    expect(result.constraints).toEqual([]);
+  });
+
+  it('handles null success_condition', () => {
+    const card: TaskCard = { ...baseCard, success_condition: null };
+    const result = JSON.parse(buildTaskSpec(card)) as Record<string, unknown>;
+    expect(result.success_condition).toBeNull();
+  });
+});

--- a/src/settlement/task-spec-builder.ts
+++ b/src/settlement/task-spec-builder.ts
@@ -1,0 +1,19 @@
+import type { TaskCard } from '../schemas/card';
+
+interface TaskSpec {
+  intent: string;
+  inputs: Record<string, string>;
+  constraints: string[];
+  success_condition: string | null;
+}
+
+export function buildTaskSpec(card: TaskCard): string {
+  const spec: TaskSpec = {
+    intent: card.intent,
+    inputs: card.inputs,
+    constraints: card.constraints,
+    success_condition: card.success_condition,
+  };
+
+  return JSON.stringify(spec, null, 2);
+}

--- a/src/settlement/workflow-spec-builder.test.ts
+++ b/src/settlement/workflow-spec-builder.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import yaml from 'js-yaml';
+import { buildWorkflowSpec } from './workflow-spec-builder';
+import type { WorkflowCard } from '../schemas/card';
+
+const baseCard: WorkflowCard = {
+  name: 'Deploy Pipeline',
+  purpose: 'Automate deployment to production',
+  steps: [
+    { order: 0, description: 'Run tests', skill: 'test-runner', conditions: null },
+    { order: 1, description: 'Build image', skill: 'docker', conditions: 'tests pass' },
+    { order: 2, description: 'Deploy', skill: null, conditions: 'image built' },
+  ],
+  confirmed: {
+    triggers: ['push to main', 'manual trigger'],
+    exit_conditions: ['deployment healthy'],
+    failure_handling: ['rollback to previous version'],
+  },
+  pending: [],
+  version: 2,
+};
+
+describe('buildWorkflowSpec', () => {
+  it('produces valid YAML string', () => {
+    const result = buildWorkflowSpec(baseCard);
+    expect(typeof result).toBe('string');
+    expect(() => yaml.load(result)).not.toThrow();
+  });
+
+  it('maps name to workflow.name', () => {
+    const result = yaml.load(buildWorkflowSpec(baseCard)) as Record<string, unknown>;
+    const workflow = result.workflow as Record<string, unknown>;
+    expect(workflow.name).toBe('Deploy Pipeline');
+  });
+
+  it('uses fallback name when name is null', () => {
+    const card: WorkflowCard = { ...baseCard, name: null };
+    const result = yaml.load(buildWorkflowSpec(card)) as Record<string, unknown>;
+    const workflow = result.workflow as Record<string, unknown>;
+    expect(workflow.name).toBe('Untitled Workflow');
+  });
+
+  it('maps purpose to workflow.purpose', () => {
+    const result = yaml.load(buildWorkflowSpec(baseCard)) as Record<string, unknown>;
+    const workflow = result.workflow as Record<string, unknown>;
+    expect(workflow.purpose).toBe('Automate deployment to production');
+  });
+
+  it('uses empty string when purpose is null', () => {
+    const card: WorkflowCard = { ...baseCard, purpose: null };
+    const result = yaml.load(buildWorkflowSpec(card)) as Record<string, unknown>;
+    const workflow = result.workflow as Record<string, unknown>;
+    expect(workflow.purpose).toBe('');
+  });
+
+  it('includes all steps in order', () => {
+    const result = yaml.load(buildWorkflowSpec(baseCard)) as Record<string, unknown>;
+    const steps = result.steps as Array<Record<string, unknown>>;
+    expect(steps).toHaveLength(3);
+    expect(steps[0].order).toBe(0);
+    expect(steps[0].description).toBe('Run tests');
+    expect(steps[0].skill).toBe('test-runner');
+    expect(steps[1].order).toBe(1);
+    expect(steps[2].order).toBe(2);
+    expect(steps[2].skill).toBeNull();
+  });
+
+  it('handles empty steps array', () => {
+    const card: WorkflowCard = { ...baseCard, steps: [] };
+    const result = yaml.load(buildWorkflowSpec(card)) as Record<string, unknown>;
+    const steps = result.steps as Array<Record<string, unknown>>;
+    expect(steps).toHaveLength(0);
+  });
+
+  it('includes triggers', () => {
+    const result = yaml.load(buildWorkflowSpec(baseCard)) as Record<string, unknown>;
+    expect(result.triggers).toEqual(['push to main', 'manual trigger']);
+  });
+
+  it('includes exit_conditions', () => {
+    const result = yaml.load(buildWorkflowSpec(baseCard)) as Record<string, unknown>;
+    expect(result.exit_conditions).toEqual(['deployment healthy']);
+  });
+
+  it('includes failure_handling', () => {
+    const result = yaml.load(buildWorkflowSpec(baseCard)) as Record<string, unknown>;
+    expect(result.failure_handling).toEqual(['rollback to previous version']);
+  });
+
+  it('handles empty confirmed arrays', () => {
+    const card: WorkflowCard = {
+      ...baseCard,
+      confirmed: { triggers: [], exit_conditions: [], failure_handling: [] },
+    };
+    const result = yaml.load(buildWorkflowSpec(card)) as Record<string, unknown>;
+    expect(result.triggers).toEqual([]);
+    expect(result.exit_conditions).toEqual([]);
+    expect(result.failure_handling).toEqual([]);
+  });
+});

--- a/src/settlement/workflow-spec-builder.ts
+++ b/src/settlement/workflow-spec-builder.ts
@@ -1,0 +1,38 @@
+import yaml from 'js-yaml';
+import type { WorkflowCard } from '../schemas/card';
+
+interface WorkflowSpec {
+  workflow: {
+    name: string;
+    purpose: string;
+  };
+  steps: Array<{
+    order: number;
+    description: string;
+    skill: string | null;
+    conditions: string | null;
+  }>;
+  triggers: string[];
+  exit_conditions: string[];
+  failure_handling: string[];
+}
+
+export function buildWorkflowSpec(card: WorkflowCard): string {
+  const spec: WorkflowSpec = {
+    workflow: {
+      name: card.name ?? 'Untitled Workflow',
+      purpose: card.purpose ?? '',
+    },
+    steps: card.steps.map((s) => ({
+      order: s.order,
+      description: s.description,
+      skill: s.skill,
+      conditions: s.conditions,
+    })),
+    triggers: card.confirmed.triggers,
+    exit_conditions: card.confirmed.exit_conditions,
+    failure_handling: card.confirmed.failure_handling,
+  };
+
+  return yaml.dump(spec, { indent: 2, lineWidth: -1, noRefs: true });
+}


### PR DESCRIPTION
## Summary
- Add `buildWorkflowSpec()` in `src/settlement/workflow-spec-builder.ts` — maps WorkflowCard to YAML (name, purpose, steps, triggers, exit_conditions, failure_handling)
- Add `buildTaskSpec()` in `src/settlement/task-spec-builder.ts` — maps TaskCard to JSON (intent, inputs, constraints, success_condition)
- Wire both builders into `src/routes/settlements.ts`, replacing the `unsupported` fallback so all 3 settlement targets (village_pack, workflow, task) now produce draft records
- Fix pre-existing E2E test failure: update GP-2 settlement test to use draft→confirm lifecycle introduced in #55

## Test plan
- [x] 11 new tests for workflow-spec-builder (YAML output, field mapping, null fallbacks, empty arrays)
- [x] 8 new tests for task-spec-builder (JSON output, field mapping, empty inputs/constraints, null success_condition)
- [x] `bun run build` passes (zero tsc errors)
- [x] `bun run lint` passes (zero eslint errors)
- [x] `bun test` passes (263 tests, 0 failures)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)