### PR TITLE
feat: support existing village loading (W2 scenario)

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,7 @@
     "src/schemas/*.ts",
     "src/llm/client.ts",
     "src/cards/card-manager.ts",
+    "src/cards/village-loader.ts",
     "src/conductor/turn-handler.ts",
     "src/conductor/state-machine.ts",
     "src/settlement/router.ts",

--- a/src/cards/village-loader.test.ts
+++ b/src/cards/village-loader.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import { loadVillageState } from './village-loader';
+import type { VillageData, ActiveConstitutionData, ChiefData } from '../thyra-client/schemas';
+
+function makeVillage(overrides?: Partial<VillageData>): VillageData {
+  return {
+    id: 'v-1',
+    name: 'Test Village',
+    target_repo: 'org/repo',
+    ...overrides,
+  };
+}
+
+function makeConstitution(overrides?: Partial<ActiveConstitutionData>): ActiveConstitutionData {
+  return {
+    id: 'c-1',
+    village_id: 'v-1',
+    rules: [
+      { description: 'No direct DB access', enforcement: 'hard', scope: ['*'] },
+      { description: 'Prefer async', enforcement: 'soft', scope: ['api'] },
+    ],
+    ...overrides,
+  };
+}
+
+function makeChief(overrides?: Partial<ChiefData>): ChiefData {
+  return {
+    id: 'ch-1',
+    village_id: 'v-1',
+    name: 'Support Chief',
+    role: 'support',
+    personality: 'friendly and helpful',
+    ...overrides,
+  };
+}
+
+describe('loadVillageState', () => {
+  it('maps full village data to a complete WorldCard', () => {
+    const village = makeVillage();
+    const constitution = makeConstitution({
+      budget_limits: {
+        max_cost_per_action: 0.5,
+        max_cost_per_day: 10,
+        max_cost_per_loop: 2,
+      },
+    });
+    const chiefs = [makeChief()];
+
+    const card = loadVillageState(village, constitution, chiefs);
+
+    expect(card.goal).toBe('Modify: Test Village');
+    expect(card.target_repo).toBe('org/repo');
+    expect(card.confirmed.hard_rules).toHaveLength(1);
+    expect(card.confirmed.hard_rules[0].description).toBe('[existing] No direct DB access');
+    expect(card.confirmed.hard_rules[0].scope).toEqual(['*']);
+    expect(card.confirmed.soft_rules).toHaveLength(1);
+    expect(card.confirmed.soft_rules[0].description).toBe('[existing] Prefer async');
+    expect(card.confirmed.soft_rules[0].scope).toEqual(['api']);
+    expect(card.confirmed.must_have).toEqual([]);
+    expect(card.confirmed.success_criteria).toEqual([]);
+    expect(card.pending).toEqual([]);
+    expect(card.chief_draft).toEqual({
+      name: 'Support Chief',
+      role: 'support',
+      style: 'friendly and helpful',
+    });
+    expect(card.budget_draft).toEqual({
+      per_action: 0.5,
+      per_day: 10,
+    });
+    expect(card.current_proposal).toBeNull();
+    expect(card.version).toBe(1);
+  });
+
+  it('handles minimal data (no chief, no budget)', () => {
+    const village = makeVillage();
+    const constitution = makeConstitution({
+      rules: [],
+      budget_limits: undefined,
+    });
+    const chiefs: ChiefData[] = [];
+
+    const card = loadVillageState(village, constitution, chiefs);
+
+    expect(card.goal).toBe('Modify: Test Village');
+    expect(card.confirmed.hard_rules).toEqual([]);
+    expect(card.confirmed.soft_rules).toEqual([]);
+    expect(card.chief_draft).toBeNull();
+    expect(card.budget_draft).toBeNull();
+    expect(card.version).toBe(1);
+  });
+
+  it('correctly prefixes rules with [existing]', () => {
+    const constitution = makeConstitution({
+      rules: [
+        { description: 'Rule A', enforcement: 'hard', scope: ['*'] },
+        { description: 'Rule B', enforcement: 'hard', scope: ['api'] },
+        { description: 'Rule C', enforcement: 'soft', scope: ['*'] },
+      ],
+    });
+
+    const card = loadVillageState(makeVillage(), constitution, []);
+
+    expect(card.confirmed.hard_rules).toHaveLength(2);
+    expect(card.confirmed.hard_rules[0].description).toBe('[existing] Rule A');
+    expect(card.confirmed.hard_rules[1].description).toBe('[existing] Rule B');
+    expect(card.confirmed.soft_rules).toHaveLength(1);
+    expect(card.confirmed.soft_rules[0].description).toBe('[existing] Rule C');
+  });
+
+  it('maps chief without optional fields', () => {
+    const chiefs = [makeChief({ role: undefined, personality: undefined })];
+
+    const card = loadVillageState(makeVillage(), makeConstitution({ rules: [] }), chiefs);
+
+    expect(card.chief_draft).toEqual({
+      name: 'Support Chief',
+      role: null,
+      style: null,
+    });
+  });
+});

--- a/src/cards/village-loader.ts
+++ b/src/cards/village-loader.ts
@@ -1,0 +1,52 @@
+import type { VillageData, ActiveConstitutionData, ChiefData } from '../thyra-client/schemas';
+import type { WorldCard } from '../schemas/card';
+
+/**
+ * Maps existing Thyra village data into a pre-populated WorldCard.
+ * Pure function — no side effects, no imports from llm/, conductor/, or settlement/.
+ */
+export function loadVillageState(
+  village: VillageData,
+  constitution: ActiveConstitutionData,
+  chiefs: ChiefData[],
+): WorldCard {
+  const hardRules = constitution.rules
+    .filter((r) => r.enforcement === 'hard')
+    .map((r) => ({ description: `[existing] ${r.description}`, scope: r.scope }));
+
+  const softRules = constitution.rules
+    .filter((r) => r.enforcement === 'soft')
+    .map((r) => ({ description: `[existing] ${r.description}`, scope: r.scope }));
+
+  const firstChief = chiefs.length > 0 ? chiefs[0] : null;
+  const chiefDraft = firstChief
+    ? {
+        name: firstChief.name,
+        role: firstChief.role ?? null,
+        style: firstChief.personality ?? null,
+      }
+    : null;
+
+  const budgetDraft = constitution.budget_limits
+    ? {
+        per_action: constitution.budget_limits.max_cost_per_action,
+        per_day: constitution.budget_limits.max_cost_per_day,
+      }
+    : null;
+
+  return {
+    goal: `Modify: ${village.name}`,
+    target_repo: village.target_repo,
+    confirmed: {
+      hard_rules: hardRules,
+      soft_rules: softRules,
+      must_have: [],
+      success_criteria: [],
+    },
+    pending: [],
+    chief_draft: chiefDraft,
+    budget_draft: budgetDraft,
+    current_proposal: null,
+    version: 1,
+  };
+}

--- a/src/conductor/turn-handler.ts
+++ b/src/conductor/turn-handler.ts
@@ -78,6 +78,30 @@ export function createEmptyCard(mode: ConversationMode): AnyCard {
   }
 }
 
+// ─── Modify Rule Helper ───
+
+function applyModifyRule(updated: WorldCard, intent: Intent): void {
+  if (!intent.entities?.target_rule) return;
+
+  const targetRule = intent.entities.target_rule;
+
+  for (const rule of updated.confirmed.hard_rules) {
+    if (rule.description.includes(targetRule)) {
+      rule.description = `[changed] ${intent.summary}`;
+      return;
+    }
+  }
+
+  for (const rule of updated.confirmed.soft_rules) {
+    if (rule.description.includes(targetRule)) {
+      rule.description = `[changed] ${intent.summary}`;
+      return;
+    }
+  }
+
+  updated.confirmed.soft_rules.push({ description: `[new] ${intent.summary}`, scope: ['*'] });
+}
+
 // ─── Intent Apply Functions ───
 
 export function applyIntentToCard(card: WorldCard, intent: Intent): WorldCard {
@@ -112,9 +136,11 @@ export function applyIntentToCard(card: WorldCard, intent: Intent): WorldCard {
       }
       updated.chief_draft.style = intent.summary;
       break;
+    case 'modify':
+      applyModifyRule(updated, intent);
+      break;
     case 'confirm':
     case 'settle_signal':
-    case 'modify':
     case 'question':
     case 'off_topic':
       break;

--- a/src/routes/conversations.ts
+++ b/src/routes/conversations.ts
@@ -3,12 +3,15 @@ import type { Database } from 'bun:sqlite';
 import { ok, error } from './response';
 import type { LLMClient } from '../llm/client';
 import type { CardManager } from '../cards/card-manager';
+import type { ThyraClient } from '../thyra-client/client';
 import { handleTurn } from '../conductor/turn-handler';
+import { loadVillageState } from '../cards/village-loader';
 
 export interface ConversationDeps {
   db: Database;
   llm: LLMClient;
   cardManager: CardManager;
+  thyra?: ThyraClient;
 }
 
 export function conversationRoutes(deps: ConversationDeps): Hono {
@@ -18,17 +21,55 @@ export function conversationRoutes(deps: ConversationDeps): Hono {
   app.post('/api/conversations', async (c) => {
     const body: Record<string, unknown> = await c.req.json();
     const mode = typeof body.mode === 'string' ? body.mode : 'world_design';
+    const villageId = typeof body.village_id === 'string' ? body.village_id : undefined;
 
     if (!['world_design', 'workflow_design', 'task'].includes(mode)) {
       return error(c, 'INVALID_INPUT', `Invalid mode: ${mode}`, 400);
     }
 
     const id = crypto.randomUUID();
-    deps.db.run(
-      "INSERT INTO conversations (id, mode, phase) VALUES (?, ?, 'explore')",
-      [id, mode],
-    );
-    return ok(c, { id, mode, phase: 'explore' }, 201);
+    let phase: 'explore' | 'focus' | 'settle' = 'explore';
+    let preloaded = false;
+
+    if (villageId && deps.thyra) {
+      try {
+        const [village, constitution, chiefs] = await Promise.all([
+          deps.thyra.getVillage(villageId),
+          deps.thyra.getActiveConstitution(villageId),
+          deps.thyra.getChiefs(villageId),
+        ]);
+
+        const worldCard = loadVillageState(village, constitution, chiefs);
+
+        // Determine starting phase based on loaded card content
+        if (worldCard.confirmed.hard_rules.length > 0 && worldCard.confirmed.must_have.length >= 3) {
+          phase = 'focus';
+        }
+
+        deps.db.run(
+          'INSERT INTO conversations (id, mode, phase, village_id) VALUES (?, ?, ?, ?)',
+          [id, mode, phase, villageId],
+        );
+
+        deps.cardManager.create(id, 'world', worldCard);
+        preloaded = true;
+      } catch (err) {
+        console.error('[conversations] Failed to load village:', err);
+        return error(
+          c,
+          'THYRA_UNAVAILABLE',
+          err instanceof Error ? err.message : 'Failed to load village from Thyra',
+          502,
+        );
+      }
+    } else {
+      deps.db.run(
+        "INSERT INTO conversations (id, mode, phase, village_id) VALUES (?, ?, ?, ?)",
+        [id, mode, phase, villageId ?? null],
+      );
+    }
+
+    return ok(c, { id, mode, phase, village_id: villageId ?? null, preloaded }, 201);
   });
 
   // POST /api/conversations/:id/messages

--- a/src/routes/e2e.test.ts
+++ b/src/routes/e2e.test.ts
@@ -23,6 +23,9 @@ function createMockThyra() {
     createChief: vi.fn(),
     createSkill: vi.fn(),
     getHealth: vi.fn(),
+    getVillage: vi.fn(),
+    getActiveConstitution: vi.fn(),
+    getChiefs: vi.fn(),
   } as unknown as ThyraClient;
 }
 
@@ -32,7 +35,7 @@ function createTestApp(llm: LLMClient, thyra: ThyraClient) {
   const cardManager = new CardManager(db);
 
   const app = new Hono();
-  app.route('/', conversationRoutes({ db, llm, cardManager }));
+  app.route('/', conversationRoutes({ db, llm, cardManager, thyra }));
   app.route('/', cardRoutes({ cardManager }));
   app.route('/', settlementRoutes({ db, cardManager, thyra }));
 
@@ -297,6 +300,219 @@ describe('API-01: Response format', () => {
     const err = json.error as Record<string, unknown>;
     expect(err).toHaveProperty('code');
     expect(err).toHaveProperty('message');
+  });
+});
+
+// ─── W2: Existing Village Loading ───
+
+describe('W2: Existing Village Loading', () => {
+  it('creates conversation with village_id and pre-populated card', async () => {
+    const llm = createMockLlm();
+    const thyra = createMockThyra();
+    const { app, db } = createTestApp(llm, thyra);
+
+    (thyra.getVillage as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: 'v-1', name: 'My Village', target_repo: 'org/repo',
+    });
+    (thyra.getActiveConstitution as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: 'c-1', village_id: 'v-1',
+      rules: [
+        { description: 'No direct DB access', enforcement: 'hard', scope: ['*'] },
+        { description: 'Prefer async', enforcement: 'soft', scope: ['api'] },
+      ],
+    });
+    (thyra.getChiefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { id: 'ch-1', village_id: 'v-1', name: 'Support Chief', role: 'support', personality: 'kind' },
+    ]);
+
+    const res = await jsonPost(app, '/api/conversations', {
+      village_id: 'v-1',
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(201);
+    expect(json.ok).toBe(true);
+
+    const data = json.data as Record<string, unknown>;
+    expect(data.village_id).toBe('v-1');
+    expect(data.preloaded).toBe(true);
+    expect(data.phase).toBe('explore');
+
+    // Verify village_id stored in DB
+    const conv = db
+      .query('SELECT village_id FROM conversations WHERE id = ?')
+      .get(data.id as string) as Record<string, unknown>;
+    expect(conv.village_id).toBe('v-1');
+
+    // Verify card was pre-populated
+    const cardRes = await app.request(`/api/conversations/${data.id as string}/card`);
+    const cardJson = (await cardRes.json()) as Record<string, unknown>;
+    const cardData = cardJson.data as Record<string, unknown>;
+    expect(cardData).not.toBeNull();
+
+    const content = cardData.content as Record<string, unknown>;
+    expect(content.goal).toBe('Modify: My Village');
+    expect(content.target_repo).toBe('org/repo');
+
+    const confirmed = content.confirmed as Record<string, unknown>;
+    const hardRules = confirmed.hard_rules as Record<string, unknown>[];
+    expect(hardRules).toHaveLength(1);
+    expect(hardRules[0].description).toBe('[existing] No direct DB access');
+
+    const softRules = confirmed.soft_rules as Record<string, unknown>[];
+    expect(softRules).toHaveLength(1);
+    expect(softRules[0].description).toBe('[existing] Prefer async');
+
+    const chiefDraft = content.chief_draft as Record<string, unknown>;
+    expect(chiefDraft.name).toBe('Support Chief');
+  });
+
+  it('returns graceful error when Thyra is unavailable', async () => {
+    const llm = createMockLlm();
+    const thyra = createMockThyra();
+    const { app } = createTestApp(llm, thyra);
+
+    (thyra.getVillage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('Connection refused'),
+    );
+
+    const res = await jsonPost(app, '/api/conversations', {
+      village_id: 'v-1',
+    });
+    const json = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(502);
+    expect(json.ok).toBe(false);
+
+    const err = json.error as Record<string, unknown>;
+    expect(err.code).toBe('THYRA_UNAVAILABLE');
+  });
+
+  it('creates normal conversation when no village_id provided', async () => {
+    const llm = createMockLlm();
+    const thyra = createMockThyra();
+    const { app } = createTestApp(llm, thyra);
+
+    const res = await jsonPost(app, '/api/conversations', {});
+    const json = (await res.json()) as Record<string, unknown>;
+
+    expect(res.status).toBe(201);
+    const data = json.data as Record<string, unknown>;
+    expect(data.village_id).toBeNull();
+    expect(data.preloaded).toBe(false);
+  });
+});
+
+// ─── Modify Intent ───
+
+describe('Modify intent in card updates', () => {
+  it('modifies existing rule when target_rule matches', async () => {
+    const llm = createMockLlm();
+    const thyra = createMockThyra();
+    const { app } = createTestApp(llm, thyra);
+
+    // Set up village with existing rules
+    (thyra.getVillage as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: 'v-1', name: 'Village', target_repo: 'repo',
+    });
+    (thyra.getActiveConstitution as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: 'c-1', village_id: 'v-1',
+      rules: [
+        { description: 'No direct DB access', enforcement: 'hard', scope: ['*'] },
+      ],
+    });
+    (thyra.getChiefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+    const createRes = await jsonPost(app, '/api/conversations', {
+      village_id: 'v-1',
+    });
+    const createJson = (await createRes.json()) as Record<string, unknown>;
+    const convData = createJson.data as Record<string, unknown>;
+    const conversationId = convData.id as string;
+
+    // Mock LLM for modify intent
+    (llm.generateStructured as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      data: {
+        type: 'modify',
+        summary: 'Allow read-only DB access',
+        entities: { target_rule: 'No direct DB access' },
+      },
+    });
+    (llm.generateText as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      'Updated the rule.',
+    );
+
+    const msgRes = await jsonPost(
+      app,
+      `/api/conversations/${conversationId}/messages`,
+      { content: 'Change the DB rule to allow read-only access' },
+    );
+    expect(msgRes.status).toBe(200);
+
+    // Check card
+    const cardRes = await app.request(`/api/conversations/${conversationId}/card`);
+    const cardJson = (await cardRes.json()) as Record<string, unknown>;
+    const cardData = cardJson.data as Record<string, unknown>;
+    const content = cardData.content as Record<string, unknown>;
+    const confirmed = content.confirmed as Record<string, unknown>;
+    const hardRules = confirmed.hard_rules as Record<string, unknown>[];
+
+    expect(hardRules).toHaveLength(1);
+    expect(hardRules[0].description).toBe('[changed] Allow read-only DB access');
+  });
+
+  it('adds new rule when target_rule does not match', async () => {
+    const llm = createMockLlm();
+    const thyra = createMockThyra();
+    const { app } = createTestApp(llm, thyra);
+
+    // Set up village with no rules
+    (thyra.getVillage as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: 'v-2', name: 'Village2', target_repo: 'repo2',
+    });
+    (thyra.getActiveConstitution as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      id: 'c-2', village_id: 'v-2', rules: [],
+    });
+    (thyra.getChiefs as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
+
+    const createRes = await jsonPost(app, '/api/conversations', {
+      village_id: 'v-2',
+    });
+    const createJson = (await createRes.json()) as Record<string, unknown>;
+    const convData = createJson.data as Record<string, unknown>;
+    const conversationId = convData.id as string;
+
+    // Mock LLM for modify intent with non-matching target
+    (llm.generateStructured as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      data: {
+        type: 'modify',
+        summary: 'Must use HTTPS',
+        entities: { target_rule: 'nonexistent rule' },
+      },
+    });
+    (llm.generateText as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      'Added new rule.',
+    );
+
+    const msgRes = await jsonPost(
+      app,
+      `/api/conversations/${conversationId}/messages`,
+      { content: 'Add a rule about HTTPS' },
+    );
+    expect(msgRes.status).toBe(200);
+
+    // Check card
+    const cardRes = await app.request(`/api/conversations/${conversationId}/card`);
+    const cardJson = (await cardRes.json()) as Record<string, unknown>;
+    const cardData = cardJson.data as Record<string, unknown>;
+    const content = cardData.content as Record<string, unknown>;
+    const confirmed = content.confirmed as Record<string, unknown>;
+    const softRules = confirmed.soft_rules as Record<string, unknown>[];
+
+    expect(softRules).toHaveLength(1);
+    expect(softRules[0].description).toBe('[new] Must use HTTPS');
   });
 });
 

--- a/src/thyra-client/client.test.ts
+++ b/src/thyra-client/client.test.ts
@@ -72,6 +72,51 @@ describe('URL construction', () => {
     expect(capturedUrl).toBe('http://localhost:3462/api/skills');
   });
 
+  it('getVillage → GET /api/villages/:id', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    const client = new ThyraClient({
+      fetchFn: mockFetch((url, init) => {
+        capturedUrl = url;
+        capturedMethod = init?.method ?? 'GET';
+        return jsonResponse({ ok: true, data: { id: 'v1', name: 'Test', target_repo: 'repo' } });
+      }),
+    });
+    await client.getVillage('v1');
+    expect(capturedUrl).toBe('http://localhost:3462/api/villages/v1');
+    expect(capturedMethod).toBe('GET');
+  });
+
+  it('getActiveConstitution → GET /api/villages/:id/constitutions/active', async () => {
+    let capturedUrl = '';
+    const client = new ThyraClient({
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({
+          ok: true,
+          data: { id: 'c1', village_id: 'v1', rules: [] },
+        });
+      }),
+    });
+    await client.getActiveConstitution('v1');
+    expect(capturedUrl).toBe('http://localhost:3462/api/villages/v1/constitutions/active');
+  });
+
+  it('getChiefs → GET /api/villages/:id/chiefs', async () => {
+    let capturedUrl = '';
+    const client = new ThyraClient({
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({
+          ok: true,
+          data: [{ id: 'ch1', village_id: 'v1', name: 'Chief' }],
+        });
+      }),
+    });
+    await client.getChiefs('v1');
+    expect(capturedUrl).toBe('http://localhost:3462/api/villages/v1/chiefs');
+  });
+
   it('applyVillagePack → POST /api/villages/pack/apply', async () => {
     let capturedUrl = '';
     let capturedBody = '';
@@ -116,6 +161,56 @@ describe('URL construction', () => {
 // ─── Success Response Parsing ───
 
 describe('success response parsing', () => {
+  it('getVillage returns typed VillageData', async () => {
+    const client = new ThyraClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: true, data: { id: 'v1', name: 'Test', target_repo: 'repo' } })
+      ),
+    });
+    const result = await client.getVillage('v1');
+    expect(result).toEqual({ id: 'v1', name: 'Test', target_repo: 'repo' });
+  });
+
+  it('getActiveConstitution returns typed ActiveConstitutionData', async () => {
+    const client = new ThyraClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({
+          ok: true,
+          data: {
+            id: 'c1',
+            village_id: 'v1',
+            rules: [
+              { description: 'No direct DB', enforcement: 'hard', scope: ['*'] },
+            ],
+            budget_limits: { max_cost_per_action: 0.5, max_cost_per_day: 10, max_cost_per_loop: 2 },
+          },
+        })
+      ),
+    });
+    const result = await client.getActiveConstitution('v1');
+    expect(result.id).toBe('c1');
+    expect(result.rules).toHaveLength(1);
+    expect(result.rules[0].enforcement).toBe('hard');
+    expect(result.budget_limits?.max_cost_per_action).toBe(0.5);
+  });
+
+  it('getChiefs returns typed ChiefData array', async () => {
+    const client = new ThyraClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({
+          ok: true,
+          data: [
+            { id: 'ch1', village_id: 'v1', name: 'Chief', role: 'support', personality: 'kind' },
+          ],
+        })
+      ),
+    });
+    const result = await client.getChiefs('v1');
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Chief');
+    expect(result[0].role).toBe('support');
+  });
+
   it('createVillage returns typed VillageData', async () => {
     const client = new ThyraClient({
       fetchFn: mockFetch(() =>

--- a/src/thyra-client/client.ts
+++ b/src/thyra-client/client.ts
@@ -6,12 +6,14 @@ import {
   type CreateSkillInput,
   type VillageData,
   type ConstitutionData,
+  type ActiveConstitutionData,
   type ChiefData,
   type SkillData,
   type PackApplyData,
   type HealthResponse,
   VillageDataSchema,
   ConstitutionDataSchema,
+  ActiveConstitutionDataSchema,
   ChiefDataSchema,
   SkillDataSchema,
   PackApplyDataSchema,
@@ -58,6 +60,18 @@ export class ThyraClient {
 
   async createSkill(input: CreateSkillInput): Promise<SkillData> {
     return this.request('POST', '/api/skills', SkillDataSchema, input);
+  }
+
+  async getVillage(id: string): Promise<VillageData> {
+    return this.request('GET', `/api/villages/${id}`, VillageDataSchema);
+  }
+
+  async getActiveConstitution(villageId: string): Promise<ActiveConstitutionData> {
+    return this.request('GET', `/api/villages/${villageId}/constitutions/active`, ActiveConstitutionDataSchema);
+  }
+
+  async getChiefs(villageId: string): Promise<ChiefData[]> {
+    return this.request('GET', `/api/villages/${villageId}/chiefs`, z.array(ChiefDataSchema));
   }
 
   async applyVillagePack(yaml: string): Promise<PackApplyData> {

--- a/src/thyra-client/schemas.ts
+++ b/src/thyra-client/schemas.ts
@@ -87,10 +87,30 @@ export const ConstitutionDataSchema = z.object({
 });
 export type ConstitutionData = z.infer<typeof ConstitutionDataSchema>;
 
+export const ActiveConstitutionDataSchema = z.object({
+  id: z.string(),
+  village_id: z.string(),
+  rules: z.array(z.object({
+    description: z.string(),
+    enforcement: z.enum(['hard', 'soft']),
+    scope: z.array(z.string()),
+  })),
+  allowed_permissions: z.array(z.string()).optional(),
+  budget_limits: z.object({
+    max_cost_per_action: z.number(),
+    max_cost_per_day: z.number(),
+    max_cost_per_loop: z.number(),
+  }).optional(),
+});
+export type ActiveConstitutionData = z.infer<typeof ActiveConstitutionDataSchema>;
+
 export const ChiefDataSchema = z.object({
   id: z.string(),
   village_id: z.string(),
   name: z.string(),
+  role: z.string().optional(),
+  personality: z.string().optional(),
+  permissions: z.array(z.string()).optional(),
 });
 export type ChiefData = z.infer<typeof ChiefDataSchema>;
 


### PR DESCRIPTION
Adds ThyraClient read APIs, village-to-card loader, conversation init with village_id, and modify intent handling. Closes #43