### PR TITLE
feat: add consecutive-no-modification FOCUS→SETTLE transition

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ async function runCli() {
   let phase: Phase = 'explore';
   let mode: ConversationMode = 'world_design';
   let turn = 0;
+  let nomodStreak = 0;
   let awaitingSettleConfirm = false;
   let pendingSettlementId: string | null = null;
 
@@ -105,8 +106,10 @@ async function runCli() {
       input,
       phase,
       mode,
+      nomodStreak,
     );
     phase = result.phase;
+    nomodStreak = result.nomodStreak;
 
     if (result.detectedMode) {
       mode = result.detectedMode;
@@ -121,12 +124,10 @@ async function runCli() {
       [crypto.randomUUID(), conversationId, 'assistant', result.reply, turn],
     );
 
-    if (result.phaseChanged) {
-      db.run(
-        "UPDATE conversations SET phase = ?, updated_at = datetime('now') WHERE id = ?",
-        [result.phase, conversationId],
-      );
-    }
+    db.run(
+      "UPDATE conversations SET phase = ?, nomod_streak = ?, updated_at = datetime('now') WHERE id = ?",
+      [result.phase, result.nomodStreak, conversationId],
+    );
 
     console.log(`\n[${result.strategy}] ${result.reply}\n`);
 

--- a/src/conductor/state-machine.test.ts
+++ b/src/conductor/state-machine.test.ts
@@ -129,6 +129,61 @@ describe('WorldCard: FOCUS -> SETTLE transitions', () => {
   });
 });
 
+describe('WorldCard: FOCUS -> SETTLE via consecutive no-mod', () => {
+  it('focus -> settle when consecutiveNoModTurns >= 2', () => {
+    const card = makeWorldCard({ pendingCount: 1 });
+    const result = checkTransition('focus', 'world', card, 'add_info', 2);
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).toBe('consecutive 2 turns with no modification');
+  });
+
+  it('focus stays when consecutiveNoModTurns < 2', () => {
+    const card = makeWorldCard({ pendingCount: 1 });
+    const result = checkTransition('focus', 'world', card, 'add_info', 1);
+    expect(result.newPhase).toBe('focus');
+    expect(result.reason).toBeNull();
+  });
+
+  it('explore ignores consecutiveNoModTurns', () => {
+    const card = makeWorldCard({});
+    const result = checkTransition('explore', 'world', card, 'add_info', 5);
+    expect(result.newPhase).toBe('explore');
+    expect(result.reason).toBeNull();
+  });
+});
+
+describe('WorkflowCard: FOCUS -> SETTLE via consecutive no-mod', () => {
+  it('focus -> settle when consecutiveNoModTurns >= 2', () => {
+    const card = makeWorkflowCard({ pendingCount: 1 });
+    const result = checkTransition('focus', 'workflow', card, 'add_info', 2);
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).toBe('consecutive 2 turns with no modification');
+  });
+
+  it('focus stays when consecutiveNoModTurns < 2', () => {
+    const card = makeWorkflowCard({ pendingCount: 1 });
+    const result = checkTransition('focus', 'workflow', card, 'add_info', 1);
+    expect(result.newPhase).toBe('focus');
+    expect(result.reason).toBeNull();
+  });
+});
+
+describe('TaskCard: FOCUS -> SETTLE via consecutive no-mod', () => {
+  it('focus -> settle when consecutiveNoModTurns >= 2', () => {
+    const card = makeTaskCard({ intent: 'test' });
+    const result = checkTransition('focus', 'task', card, 'add_info', 2);
+    expect(result.newPhase).toBe('settle');
+    expect(result.reason).toBe('consecutive 2 turns with no modification');
+  });
+
+  it('focus stays when consecutiveNoModTurns < 2', () => {
+    const card = makeTaskCard({ intent: 'test' });
+    const result = checkTransition('focus', 'task', card, 'add_info', 1);
+    expect(result.newPhase).toBe('focus');
+    expect(result.reason).toBeNull();
+  });
+});
+
 describe('WorldCard: Rollback transitions', () => {
   it('focus -> explore on new_intent (rollback)', () => {
     const card = makeWorldCard({});

--- a/src/conductor/state-machine.ts
+++ b/src/conductor/state-machine.ts
@@ -16,6 +16,7 @@ function checkWorldTransition(
   currentPhase: Phase,
   card: WorldCard,
   intentType: IntentType,
+  consecutiveNoModTurns: number,
 ): TransitionResult {
   // EXPLORE -> FOCUS
   if (currentPhase === 'explore') {
@@ -34,6 +35,9 @@ function checkWorldTransition(
     }
     if (intentType === 'settle_signal') {
       return { newPhase: 'settle', reason: 'user explicit settle signal' };
+    }
+    if (consecutiveNoModTurns >= 2) {
+      return { newPhase: 'settle', reason: 'consecutive 2 turns with no modification' };
     }
   }
 
@@ -60,6 +64,7 @@ function checkWorkflowTransition(
   currentPhase: Phase,
   card: WorkflowCard,
   intentType: IntentType,
+  consecutiveNoModTurns: number,
 ): TransitionResult {
   // EXPLORE -> FOCUS
   if (currentPhase === 'explore') {
@@ -75,6 +80,9 @@ function checkWorkflowTransition(
     }
     if (intentType === 'settle_signal') {
       return { newPhase: 'settle', reason: 'user explicit settle signal' };
+    }
+    if (consecutiveNoModTurns >= 2) {
+      return { newPhase: 'settle', reason: 'consecutive 2 turns with no modification' };
     }
   }
 
@@ -101,6 +109,7 @@ function checkTaskTransition(
   currentPhase: Phase,
   card: TaskCard,
   intentType: IntentType,
+  consecutiveNoModTurns: number,
 ): TransitionResult {
   // EXPLORE -> SETTLE (fast-path)
   if (currentPhase === 'explore') {
@@ -117,6 +126,9 @@ function checkTaskTransition(
   if (currentPhase === 'focus') {
     if (intentType === 'confirm' || intentType === 'settle_signal') {
       return { newPhase: 'settle', reason: 'user confirmed task' };
+    }
+    if (consecutiveNoModTurns >= 2) {
+      return { newPhase: 'settle', reason: 'consecutive 2 turns with no modification' };
     }
   }
 
@@ -144,13 +156,14 @@ export function checkTransition(
   cardType: CardType,
   card: AnyCard,
   intentType: IntentType,
+  consecutiveNoModTurns = 0,
 ): TransitionResult {
   switch (cardType) {
     case 'world':
-      return checkWorldTransition(currentPhase, card as WorldCard, intentType);
+      return checkWorldTransition(currentPhase, card as WorldCard, intentType, consecutiveNoModTurns);
     case 'workflow':
-      return checkWorkflowTransition(currentPhase, card as WorkflowCard, intentType);
+      return checkWorkflowTransition(currentPhase, card as WorkflowCard, intentType, consecutiveNoModTurns);
     case 'task':
-      return checkTaskTransition(currentPhase, card as TaskCard, intentType);
+      return checkTaskTransition(currentPhase, card as TaskCard, intentType, consecutiveNoModTurns);
   }
 }

--- a/src/conductor/turn-handler.test.ts
+++ b/src/conductor/turn-handler.test.ts
@@ -7,6 +7,7 @@ import {
   createEmptyWorkflowCard,
   createEmptyTaskCard,
   handleTurn,
+  isDiffEmpty,
 } from './turn-handler';
 import { CardManager } from '../cards/card-manager';
 import { createDb, initSchema } from '../db';
@@ -382,5 +383,127 @@ describe('handleTurn', () => {
     const card = mgr.getLatest('conv1');
     expect(card).not.toBeNull();
     expect(card!.type).toBe('world');
+  });
+});
+
+// ─── isDiffEmpty Tests ───
+
+describe('isDiffEmpty', () => {
+  it('returns true when diff has no changes except version', () => {
+    expect(isDiffEmpty({ added: [], removed: [], changed: ['version'] })).toBe(true);
+  });
+
+  it('returns true when diff is completely empty', () => {
+    expect(isDiffEmpty({ added: [], removed: [], changed: [] })).toBe(true);
+  });
+
+  it('returns false when diff has added fields', () => {
+    expect(isDiffEmpty({ added: ['goal'], removed: [], changed: [] })).toBe(false);
+  });
+
+  it('returns false when diff has removed fields', () => {
+    expect(isDiffEmpty({ added: [], removed: ['goal'], changed: [] })).toBe(false);
+  });
+
+  it('returns false when diff has changed fields besides version', () => {
+    expect(isDiffEmpty({ added: [], removed: [], changed: ['version', 'goal'] })).toBe(false);
+  });
+});
+
+// ─── nomodStreak tracking in handleTurn ───
+
+describe('handleTurn nomodStreak', () => {
+  const mockParseIntent = vi.fn();
+  const mockGenerateReply = vi.fn();
+
+  const mockLlm = {
+    generateStructured: mockParseIntent,
+    generateText: mockGenerateReply,
+  } as unknown as LLMClient;
+
+  beforeEach(() => {
+    mockParseIntent.mockReset();
+    mockGenerateReply.mockReset();
+  });
+
+  it('increments nomodStreak when diff is empty (confirm intent)', async () => {
+    // First turn to create card
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'new_intent', summary: 'test goal' },
+    });
+    mockGenerateReply.mockResolvedValueOnce('OK');
+
+    const db = createDb(':memory:');
+    initSchema(db);
+    db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'world_design', 'focus')");
+    const mgr = new CardManager(db);
+
+    // Turn 1: create card with content
+    await handleTurn(mockLlm, mgr, 'conv1', 'test goal', 'focus', 'world_design', 0);
+
+    // Turn 2: confirm (no content change) -> nomodStreak should be 1
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'confirm', summary: 'OK' },
+    });
+    mockGenerateReply.mockResolvedValueOnce('confirmed');
+
+    const result2 = await handleTurn(mockLlm, mgr, 'conv1', 'OK', 'focus', 'world_design', 0);
+    expect(result2.nomodStreak).toBe(1);
+  });
+
+  it('resets nomodStreak to 0 when diff has changes', async () => {
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'new_intent', summary: 'initial goal' },
+    });
+    mockGenerateReply.mockResolvedValueOnce('OK');
+
+    const db = createDb(':memory:');
+    initSchema(db);
+    db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'world_design', 'focus')");
+    const mgr = new CardManager(db);
+
+    // Turn 1: create card
+    await handleTurn(mockLlm, mgr, 'conv1', 'initial goal', 'focus', 'world_design', 0);
+
+    // Turn 2: add_info (content changes) with nomodStreak=3 -> should reset to 0
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'add_info', summary: 'more', entities: { f1: 'feature1' } },
+    });
+    mockGenerateReply.mockResolvedValueOnce('got it');
+
+    const result2 = await handleTurn(mockLlm, mgr, 'conv1', 'add feature', 'focus', 'world_design', 3);
+    expect(result2.nomodStreak).toBe(0);
+  });
+
+  it('transitions to settle after 2 consecutive no-mod turns', async () => {
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'new_intent', summary: 'goal' },
+    });
+    mockGenerateReply.mockResolvedValueOnce('OK');
+
+    const db = createDb(':memory:');
+    initSchema(db);
+    db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'world_design', 'focus')");
+    const mgr = new CardManager(db);
+
+    // Turn 1: create card
+    await handleTurn(mockLlm, mgr, 'conv1', 'goal', 'focus', 'world_design', 0);
+
+    // Turn 2: confirm with nomodStreak=1 -> diff empty -> streak becomes 2 -> settle
+    mockParseIntent.mockResolvedValueOnce({
+      ok: true,
+      data: { type: 'question', summary: 'hmm' },
+    });
+    mockGenerateReply.mockResolvedValueOnce('settled');
+
+    const result = await handleTurn(mockLlm, mgr, 'conv1', 'hmm', 'focus', 'world_design', 1);
+    expect(result.nomodStreak).toBe(2);
+    expect(result.phase).toBe('settle');
+    expect(result.phaseChanged).toBe(true);
   });
 });

--- a/src/conductor/turn-handler.ts
+++ b/src/conductor/turn-handler.ts
@@ -4,7 +4,7 @@ import { parseIntent } from '../llm/intent-parser';
 import { generateReply } from '../llm/response-gen';
 import { checkTransition, type Phase } from './state-machine';
 import { pickStrategy } from './rhythm';
-import type { WorldCard, WorkflowCard, TaskCard, AnyCard, CardType } from '../schemas/card';
+import type { WorldCard, WorkflowCard, TaskCard, AnyCard, CardType, CardDiff } from '../schemas/card';
 import type { Intent } from '../schemas/intent';
 import type { Strategy } from '../llm/prompts';
 import type { ConversationMode } from '../schemas/conversation';
@@ -17,6 +17,13 @@ export interface TurnResult {
   strategy: Strategy;
   cardVersion: number;
   detectedMode?: ConversationMode;
+  nomodStreak: number;
+}
+
+export function isDiffEmpty(diff: CardDiff): boolean {
+  return diff.added.length === 0
+    && diff.removed.length === 0
+    && diff.changed.filter(k => k !== 'version').length === 0;
 }
 
 // ─── Empty Card Factories ───
@@ -257,6 +264,7 @@ export async function handleTurn(
   userMessage: string,
   currentPhase: Phase,
   mode: ConversationMode = 'world_design',
+  nomodStreak = 0,
 ): Promise<TurnResult> {
   const currentCard = cardManager.getLatest(conversationId);
   const isFirstTurn = !currentCard;
@@ -280,18 +288,21 @@ export async function handleTurn(
   // Update card content based on intent
   const updatedContent = applyIntent(cardType, effectiveCardContent, intent);
 
-  // Persist card
+  // Persist card and compute diff-based nomod streak
   let cardVersion: number;
+  let newNomodStreak: number;
   if (currentCard) {
-    const { card } = cardManager.update(currentCard.id, updatedContent);
+    const { card, diff } = cardManager.update(currentCard.id, updatedContent);
     cardVersion = card.version;
+    newNomodStreak = isDiffEmpty(diff) ? nomodStreak + 1 : 0;
   } else {
     const card = cardManager.create(conversationId, cardType, updatedContent);
     cardVersion = card.version;
+    newNomodStreak = 0;
   }
 
   // Check state transition
-  const transition = checkTransition(currentPhase, cardType, updatedContent, intent.type);
+  const transition = checkTransition(currentPhase, cardType, updatedContent, intent.type, newNomodStreak);
 
   // Pick reply strategy
   const hasPending = cardHasPending(cardType, updatedContent);
@@ -308,5 +319,6 @@ export async function handleTurn(
     strategy,
     cardVersion,
     ...(detectedMode !== undefined && { detectedMode }),
+    nomodStreak: newNomodStreak,
   };
 }

--- a/src/db.ts
+++ b/src/db.ts
@@ -12,6 +12,7 @@ export function initSchema(db: Database): void {
     mode TEXT NOT NULL CHECK(mode IN ('world_design','workflow_design','task')),
     phase TEXT NOT NULL DEFAULT 'explore' CHECK(phase IN ('explore','focus','settle')),
     village_id TEXT,
+    nomod_streak INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`);

--- a/src/routes/conversations.ts
+++ b/src/routes/conversations.ts
@@ -83,7 +83,7 @@ export function conversationRoutes(deps: ConversationDeps): Hono {
     }
 
     const conv = deps.db
-      .query('SELECT phase, mode FROM conversations WHERE id = ?')
+      .query('SELECT phase, mode, nomod_streak FROM conversations WHERE id = ?')
       .get(conversationId) as Record<string, unknown> | null;
 
     if (!conv) {
@@ -92,6 +92,7 @@ export function conversationRoutes(deps: ConversationDeps): Hono {
 
     const phase = conv.phase as string;
     const mode = conv.mode as string;
+    const nomodStreak = conv.nomod_streak as number;
 
     // Count existing messages to determine turn number
     const turnRow = deps.db
@@ -116,6 +117,7 @@ export function conversationRoutes(deps: ConversationDeps): Hono {
         content,
         phase as 'explore' | 'focus' | 'settle',
         mode as 'world_design' | 'workflow_design' | 'task',
+        nomodStreak,
       );
 
       // Persist assistant reply
@@ -131,12 +133,10 @@ export function conversationRoutes(deps: ConversationDeps): Hono {
         );
       }
 
-      if (result.phase !== phase) {
-        deps.db.run(
-          "UPDATE conversations SET phase = ?, updated_at = datetime('now') WHERE id = ?",
-          [result.phase, conversationId],
-        );
-      }
+      deps.db.run(
+        "UPDATE conversations SET phase = ?, nomod_streak = ?, updated_at = datetime('now') WHERE id = ?",
+        [result.phase, result.nomodStreak, conversationId],
+      );
 
       return ok(c, {
         reply: result.reply,


### PR DESCRIPTION
## Summary
- Add `nomod_streak` column to conversations table for tracking consecutive no-modification turns
- Extend checkTransition() with `consecutiveNoModTurns >= 2` condition for FOCUS→SETTLE (all 3 card types)
- Add isDiffEmpty() helper to detect turns with no meaningful changes
- Wire nomod streak through handleTurn, routes, and CLI
- 15 new tests covering state machine and turn handler

Closes #42

## Test plan
- [x] `bun run build` — zero errors
- [x] `bun run lint` — zero errors
- [x] `bun test` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)