### PR TITLE
feat: support Thyra pack/apply endpoint in ThyraClient

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,7 +63,7 @@ async function runCli() {
               'UPDATE settlements SET status = ?, thyra_response = ? WHERE id = ?',
               ['applied', JSON.stringify(result), pendingSettlementId],
             );
-            settleReply = 'Village Pack applied successfully. ' + JSON.stringify(result);
+            settleReply = `Village Pack applied: village=${result.village_id}, constitution=${result.constitution_id}, chief=${result.chief_id ?? 'none'}, skills=${result.skills.length}`;
             console.log('\n' + settleReply);
           } catch (err) {
             // Transition: confirmed -> failed

--- a/src/routes/e2e.test.ts
+++ b/src/routes/e2e.test.ts
@@ -598,8 +598,11 @@ describe('GP-2: Full W1 Scenario', () => {
 
     // Settlement: thyra mock
     (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      villageId: 'v-123',
+      village_id: 'v-123',
+      constitution_id: 'c-123',
+      chief_id: 'ch-123',
+      skills: [{ id: 's-1', name: 'deploy' }, { id: 's-2', name: 'monitor' }, { id: 's-3', name: 'alert' }],
+      applied: true,
     });
 
     // Create conversation

--- a/src/routes/settlements.test.ts
+++ b/src/routes/settlements.test.ts
@@ -150,7 +150,10 @@ describe('Settlement lifecycle', () => {
 
       (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         village_id: 'v-123',
-        created: true,
+        constitution_id: 'c-1',
+        chief_id: 'ch-1',
+        skills: [{ id: 's-1', name: 'deploy' }],
+        applied: true,
       });
 
       // Confirm
@@ -216,7 +219,10 @@ describe('Settlement lifecycle', () => {
 
       (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         village_id: 'v-123',
-        created: true,
+        constitution_id: 'c-1',
+        chief_id: 'ch-1',
+        skills: [{ id: 's-1', name: 'deploy' }],
+        applied: true,
       });
       await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
 
@@ -270,6 +276,10 @@ describe('Settlement lifecycle', () => {
       // Confirm with success
       (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
         village_id: 'v-456',
+        constitution_id: 'c-2',
+        chief_id: 'ch-2',
+        skills: [{ id: 's-2', name: 'monitor' }],
+        applied: true,
       });
       await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
 

--- a/src/thyra-client/client.test.ts
+++ b/src/thyra-client/client.test.ts
@@ -124,7 +124,7 @@ describe('URL construction', () => {
       fetchFn: mockFetch((url, init) => {
         capturedUrl = url;
         capturedBody = init?.body as string;
-        return jsonResponse({ ok: true, data: { village_id: 'v1', applied: true } });
+        return jsonResponse({ ok: true, data: { village_id: 'v1', constitution_id: 'c1', chief_id: 'ch1', skills: [{ id: 's1', name: 'skill1' }], applied: true } });
       }),
     });
     await client.applyVillagePack('village:\n  name: test');
@@ -209,6 +209,29 @@ describe('success response parsing', () => {
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe('Chief');
     expect(result[0].role).toBe('support');
+  });
+
+  it('applyVillagePack returns typed PackApplyData with all fields', async () => {
+    const client = new ThyraClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({
+          ok: true,
+          data: {
+            village_id: 'v1',
+            constitution_id: 'c1',
+            chief_id: null,
+            skills: [{ id: 's1', name: 'skill1' }],
+            applied: true,
+          },
+        })
+      ),
+    });
+    const result = await client.applyVillagePack('village:\n  name: test');
+    expect(result.village_id).toBe('v1');
+    expect(result.constitution_id).toBe('c1');
+    expect(result.chief_id).toBeNull();
+    expect(result.skills).toHaveLength(1);
+    expect(result.applied).toBe(true);
   });
 
   it('createVillage returns typed VillageData', async () => {

--- a/src/thyra-client/schemas.ts
+++ b/src/thyra-client/schemas.ts
@@ -122,6 +122,12 @@ export type SkillData = z.infer<typeof SkillDataSchema>;
 
 export const PackApplyDataSchema = z.object({
   village_id: z.string(),
+  constitution_id: z.string(),
+  chief_id: z.string().nullable(),
+  skills: z.array(z.object({
+    id: z.string(),
+    name: z.string(),
+  })),
   applied: z.boolean(),
 });
 export type PackApplyData = z.infer<typeof PackApplyDataSchema>;


### PR DESCRIPTION
## Summary
- Updated `PackApplyDataSchema` to include `constitution_id`, `chief_id`, `skills[]`, and `applied` fields matching the Thyra `pack/apply` response contract
- Fixed all test mocks across `client.test.ts`, `settlements.test.ts`, and `e2e.test.ts` to return the correct response shape
- Added a dedicated contract validation test for `applyVillagePack` with nullable `chief_id`
- Improved CLI display message to show structured fields instead of raw JSON

## Test plan
- [x] `bun run build` passes (zero type errors)
- [x] `bun run lint` passes (zero lint errors)
- [x] `bun test` passes (302 tests, 0 failures)
- [ ] Integration test against live Thyra once fagemx/thyra#182 is merged

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)