### PR TITLE
feat: add card version history retrieval APIs

### DIFF
--- a/src/cards/card-manager.test.ts
+++ b/src/cards/card-manager.test.ts
@@ -225,6 +225,62 @@ describe('CardManager.getDiffHistory', () => {
   });
 });
 
+// ─── Version History Tests ───
+
+describe('CardManager.getVersionHistory', () => {
+  it('returns all versions in order', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    const { card: v2 } = mgr.update(card.id, { ...minimalWorldCard, goal: 'v2' });
+    mgr.update(v2.id, { ...minimalWorldCard, goal: 'v3' });
+
+    const history = mgr.getVersionHistory('conv1');
+    expect(history).toHaveLength(3);
+    expect(history[0].version).toBe(1);
+    expect(history[1].version).toBe(2);
+    expect(history[2].version).toBe(3);
+  });
+
+  it('returns empty array for unknown conversation', () => {
+    const history = mgr.getVersionHistory('unknown');
+    expect(history).toHaveLength(0);
+  });
+
+  it('does not include other conversations', () => {
+    mgr.create('conv1', 'world', minimalWorldCard);
+    mgr.create('conv2', 'world', minimalWorldCard);
+
+    const history = mgr.getVersionHistory('conv1');
+    expect(history).toHaveLength(1);
+  });
+});
+
+describe('CardManager.getVersion', () => {
+  it('returns specific version', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    mgr.update(card.id, { ...minimalWorldCard, goal: 'v2 goal' });
+
+    const v1 = mgr.getVersion('conv1', 1);
+    const v2 = mgr.getVersion('conv1', 2);
+
+    expect(v1).not.toBeNull();
+    expect(v1!.version).toBe(1);
+    expect((v1!.content as WorldCard).goal).toBeNull();
+
+    expect(v2).not.toBeNull();
+    expect(v2!.version).toBe(2);
+    expect((v2!.content as WorldCard).goal).toBe('v2 goal');
+  });
+
+  it('returns null for nonexistent version', () => {
+    mgr.create('conv1', 'world', minimalWorldCard);
+    expect(mgr.getVersion('conv1', 99)).toBeNull();
+  });
+
+  it('returns null for unknown conversation', () => {
+    expect(mgr.getVersion('unknown', 1)).toBeNull();
+  });
+});
+
 // ─── Edge Cases ───
 
 describe('CardManager edge cases', () => {

--- a/src/cards/card-manager.ts
+++ b/src/cards/card-manager.ts
@@ -180,6 +180,40 @@ export class CardManager {
     };
   }
 
+  getVersionHistory(conversationId: string): CardEnvelope[] {
+    const rows = this.db
+      .query('SELECT * FROM cards WHERE conversation_id = ? ORDER BY version ASC')
+      .all(conversationId) as Record<string, unknown>[];
+
+    return rows.map((row) => ({
+      id: row.id as string,
+      conversationId: row.conversation_id as string,
+      type: row.type as CardType,
+      content: JSON.parse(row.content as string) as AnyCard,
+      version: row.version as number,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    }));
+  }
+
+  getVersion(conversationId: string, version: number): CardEnvelope | null {
+    const row = this.db
+      .query('SELECT * FROM cards WHERE conversation_id = ? AND version = ?')
+      .get(conversationId, version) as Record<string, unknown> | null;
+
+    if (!row) return null;
+
+    return {
+      id: row.id as string,
+      conversationId: row.conversation_id as string,
+      type: row.type as CardType,
+      content: JSON.parse(row.content as string) as AnyCard,
+      version: row.version as number,
+      createdAt: row.created_at as string,
+      updatedAt: row.updated_at as string,
+    };
+  }
+
   diff(oldContent: AnyCard, newContent: AnyCard): CardDiff {
     return computeDiff(
       oldContent as unknown as Record<string, unknown>,

--- a/src/routes/cards.ts
+++ b/src/routes/cards.ts
@@ -16,6 +16,21 @@ export function cardRoutes(deps: CardDeps): Hono {
     return ok(c, card);
   });
 
+  // GET /api/conversations/:id/card/history
+  app.get('/api/conversations/:id/card/history', (c) => {
+    const conversationId = c.req.param('id');
+    const history = deps.cardManager.getVersionHistory(conversationId);
+    return ok(c, history);
+  });
+
+  // GET /api/conversations/:id/card/version/:version
+  app.get('/api/conversations/:id/card/version/:version', (c) => {
+    const conversationId = c.req.param('id');
+    const version = parseInt(c.req.param('version'), 10);
+    const card = deps.cardManager.getVersion(conversationId, version);
+    return ok(c, card);
+  });
+
   // GET /api/conversations/:id/card/diffs
   app.get('/api/conversations/:id/card/diffs', (c) => {
     const conversationId = c.req.param('id');


### PR DESCRIPTION
## Summary
- Add `getVersionHistory(conversationId)` and `getVersion(conversationId, version)` to CardManager
- Add `GET /api/conversations/:id/card/history` and `GET /api/conversations/:id/card/version/:version` routes
- 6 new tests covering version retrieval, isolation, and edge cases

No new tables needed — leverages existing INSERT-per-version pattern in `cards` table.

Closes #49

## Test plan
- [x] `bun run build` — zero errors
- [x] `bun run lint` — zero errors
- [x] `bun test` — 311 tests pass (6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)