### PR TITLE
feat: add EddaClient for precedent queries

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -15,6 +15,8 @@
     "src/thyra-client/schemas.ts",
     "src/karvi-client/client.ts",
     "src/karvi-client/schemas.ts",
+    "src/edda-client/client.ts",
+    "src/edda-client/schemas.ts",
     "src/routes/*.ts"
   ],
   "project": [

--- a/src/edda-client/client.test.ts
+++ b/src/edda-client/client.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from 'vitest';
+import { EddaClient } from './client';
+import {
+  EddaApiError,
+  EddaNetworkError,
+  EddaHttpError,
+  EddaValidationError,
+} from './schemas';
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  return handler as unknown as typeof fetch;
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// ─── URL Construction ───
+
+describe('URL construction', () => {
+  it('queryDecisions → GET /api/decisions?village_id=...', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    const client = new EddaClient({
+      fetchFn: mockFetch((url, init) => {
+        capturedUrl = url;
+        capturedMethod = init?.method ?? 'GET';
+        return jsonResponse({ ok: true, data: [] });
+      }),
+    });
+    await client.queryDecisions({ village_id: 'v1' });
+    expect(capturedUrl).toBe('http://localhost:3463/api/decisions?village_id=v1');
+    expect(capturedMethod).toBe('GET');
+  });
+
+  it('queryDecisions includes type and limit params', async () => {
+    let capturedUrl = '';
+    const client = new EddaClient({
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true, data: [] });
+      }),
+    });
+    await client.queryDecisions({ village_id: 'v1', type: 'architecture', limit: 5 });
+    expect(capturedUrl).toBe('http://localhost:3463/api/decisions?village_id=v1&type=architecture&limit=5');
+  });
+
+  it('getDecisionOutcomes → GET /api/decisions/:id/outcomes', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    const client = new EddaClient({
+      fetchFn: mockFetch((url, init) => {
+        capturedUrl = url;
+        capturedMethod = init?.method ?? 'GET';
+        return jsonResponse({ ok: true, data: [] });
+      }),
+    });
+    await client.getDecisionOutcomes('d1');
+    expect(capturedUrl).toBe('http://localhost:3463/api/decisions/d1/outcomes');
+    expect(capturedMethod).toBe('GET');
+  });
+
+  it('getHealth → /api/health', async () => {
+    let capturedUrl = '';
+    const client = new EddaClient({
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true });
+      }),
+    });
+    await client.getHealth();
+    expect(capturedUrl).toBe('http://localhost:3463/api/health');
+  });
+
+  it('custom baseUrl is used', async () => {
+    let capturedUrl = '';
+    const client = new EddaClient({
+      baseUrl: 'http://edda:8888',
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true, data: [] });
+      }),
+    });
+    await client.queryDecisions({ village_id: 'v1' });
+    expect(capturedUrl).toBe('http://edda:8888/api/decisions?village_id=v1');
+  });
+});
+
+// ─── Success Response Parsing ───
+
+describe('success response parsing', () => {
+  it('queryDecisions returns typed DecisionData array', async () => {
+    const client = new EddaClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({
+          ok: true,
+          data: [
+            { id: 'd1', village_id: 'v1', type: 'architecture', summary: 'Use microservices', created_at: '2026-01-01T00:00:00Z' },
+            { id: 'd2', village_id: 'v1', type: 'naming', summary: 'Use camelCase', context: 'JS project', created_at: '2026-01-02T00:00:00Z' },
+          ],
+        })
+      ),
+    });
+    const result = await client.queryDecisions({ village_id: 'v1' });
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('d1');
+    expect(result[0].type).toBe('architecture');
+    expect(result[1].context).toBe('JS project');
+  });
+
+  it('queryDecisions returns empty array', async () => {
+    const client = new EddaClient({
+      fetchFn: mockFetch(() => jsonResponse({ ok: true, data: [] })),
+    });
+    const result = await client.queryDecisions({ village_id: 'v1' });
+    expect(result).toEqual([]);
+  });
+
+  it('getDecisionOutcomes returns typed DecisionOutcomeData array', async () => {
+    const client = new EddaClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({
+          ok: true,
+          data: [
+            { id: 'o1', decision_id: 'd1', outcome: 'success', detail: 'Worked well', created_at: '2026-01-03T00:00:00Z' },
+            { id: 'o2', decision_id: 'd1', outcome: 'failure', created_at: '2026-01-04T00:00:00Z' },
+          ],
+        })
+      ),
+    });
+    const result = await client.getDecisionOutcomes('d1');
+    expect(result).toHaveLength(2);
+    expect(result[0].outcome).toBe('success');
+    expect(result[0].detail).toBe('Worked well');
+    expect(result[1].outcome).toBe('failure');
+    expect(result[1].detail).toBeUndefined();
+  });
+});
+
+// ─── Error Handling ───
+
+describe('error handling', () => {
+  it('throws EddaApiError on { ok: false } response', async () => {
+    const client = new EddaClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: false, error: { code: 'NOT_FOUND', message: 'Decision not found' } })
+      ),
+    });
+    await expect(client.queryDecisions({ village_id: 'v1' }))
+      .rejects.toBeInstanceOf(EddaApiError);
+  });
+
+  it('throws EddaHttpError on 4xx', async () => {
+    const client = new EddaClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        new Response('Bad Request', { status: 400, statusText: 'Bad Request' })
+      ),
+    });
+    await expect(client.queryDecisions({ village_id: 'v1' }))
+      .rejects.toBeInstanceOf(EddaHttpError);
+  });
+
+  it('throws EddaValidationError on malformed response', async () => {
+    const client = new EddaClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        jsonResponse({ unexpected: 'format' })
+      ),
+    });
+    await expect(client.queryDecisions({ village_id: 'v1' }))
+      .rejects.toBeInstanceOf(EddaValidationError);
+  });
+
+  it('throws EddaNetworkError on fetch failure', async () => {
+    const client = new EddaClient({
+      retries: 0,
+      fetchFn: mockFetch(() => { throw new TypeError('fetch failed'); }),
+    });
+    await expect(client.queryDecisions({ village_id: 'v1' }))
+      .rejects.toBeInstanceOf(EddaNetworkError);
+  });
+
+  it('getHealth returns { ok: false } on error (does not throw)', async () => {
+    const client = new EddaClient({
+      fetchFn: mockFetch(() => { throw new TypeError('connection refused'); }),
+    });
+    const result = await client.getHealth();
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+// ─── Retry Behavior ───
+
+describe('retry behavior', () => {
+  it('retries on 5xx up to max retries', async () => {
+    let attempts = 0;
+    const client = new EddaClient({
+      retries: 2,
+      fetchFn: mockFetch(() => {
+        attempts++;
+        if (attempts < 3) return new Response('Error', { status: 503, statusText: 'Service Unavailable' });
+        return jsonResponse({ ok: true, data: [] });
+      }),
+    });
+    const result = await client.queryDecisions({ village_id: 'v1' });
+    expect(attempts).toBe(3);
+    expect(result).toEqual([]);
+  });
+
+  it('does not retry on 4xx', async () => {
+    let attempts = 0;
+    const client = new EddaClient({
+      retries: 2,
+      fetchFn: mockFetch(() => {
+        attempts++;
+        return new Response('Not Found', { status: 404, statusText: 'Not Found' });
+      }),
+    });
+    await expect(client.queryDecisions({ village_id: 'v1' }))
+      .rejects.toBeInstanceOf(EddaHttpError);
+    expect(attempts).toBe(1);
+  });
+
+  it('retries on network error', async () => {
+    let attempts = 0;
+    const client = new EddaClient({
+      retries: 1,
+      fetchFn: mockFetch(() => {
+        attempts++;
+        if (attempts < 2) throw new TypeError('fetch failed');
+        return jsonResponse({ ok: true, data: [] });
+      }),
+    });
+    const result = await client.queryDecisions({ village_id: 'v1' });
+    expect(attempts).toBe(2);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/edda-client/client.ts
+++ b/src/edda-client/client.ts
@@ -1,0 +1,144 @@
+import { z } from 'zod';
+import {
+  type QueryDecisionsInput,
+  type DecisionData,
+  type DecisionOutcomeData,
+  type HealthResponse,
+  DecisionDataSchema,
+  DecisionOutcomeDataSchema,
+  HealthResponseSchema,
+  EddaErrorResponseSchema,
+  eddaSuccess,
+  EddaNetworkError,
+  EddaHttpError,
+  EddaValidationError,
+  EddaApiError,
+} from './schemas';
+
+export interface EddaClientOptions {
+  baseUrl?: string;
+  timeout?: number;
+  retries?: number;
+  fetchFn?: typeof fetch;
+}
+
+export class EddaClient {
+  private readonly baseUrl: string;
+  private readonly timeout: number;
+  private readonly retries: number;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: EddaClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? 'http://localhost:3463';
+    this.timeout = options.timeout ?? 10_000;
+    this.retries = options.retries ?? 2;
+    this.fetchFn = options.fetchFn ?? globalThis.fetch;
+  }
+
+  async queryDecisions(input: QueryDecisionsInput): Promise<DecisionData[]> {
+    const params = new URLSearchParams({ village_id: input.village_id });
+    if (input.type !== undefined) params.set('type', input.type);
+    if (input.limit !== undefined) params.set('limit', String(input.limit));
+    return this.request('GET', `/api/decisions?${params.toString()}`, z.array(DecisionDataSchema));
+  }
+
+  async getDecisionOutcomes(decisionId: string): Promise<DecisionOutcomeData[]> {
+    return this.request('GET', `/api/decisions/${decisionId}/outcomes`, z.array(DecisionOutcomeDataSchema));
+  }
+
+  async getHealth(): Promise<HealthResponse> {
+    const url = `${this.baseUrl}/api/health`;
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => { controller.abort(); }, this.timeout);
+      try {
+        const response = await this.fetchFn(url, { signal: controller.signal });
+        const json: unknown = await response.json();
+        const parsed = HealthResponseSchema.safeParse(json);
+        return parsed.success ? parsed.data : { ok: false };
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      return { ok: false };
+    }
+  }
+
+  private async request<T extends z.ZodTypeAny>(
+    method: string,
+    path: string,
+    dataSchema: T,
+    body?: unknown,
+  ): Promise<z.infer<T>> {
+    const response = await this.fetchWithRetry(method, path, body);
+    const json: unknown = await response.json();
+
+    // Check for error response first
+    const errorParsed = EddaErrorResponseSchema.safeParse(json);
+    if (errorParsed.success) {
+      throw new EddaApiError(errorParsed.data.error.code, errorParsed.data.error.message);
+    }
+
+    // Parse success response
+    const successSchema = eddaSuccess(dataSchema);
+    const successParsed = successSchema.safeParse(json);
+    if (!successParsed.success) {
+      throw new EddaValidationError(successParsed.error);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Zod validated, generic inference limitation
+    return successParsed.data.data as z.infer<T>;
+  }
+
+  private async fetchWithRetry(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= this.retries; attempt++) {
+      if (attempt > 0) {
+        await new Promise(resolve => setTimeout(resolve, 100 * Math.pow(2, attempt - 1)));
+      }
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => { controller.abort(); }, this.timeout);
+
+      try {
+        const response = await this.fetchFn(url, {
+          method,
+          headers: { 'Content-Type': 'application/json' },
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const responseBody = await response.text();
+          const error = new EddaHttpError(response.status, response.statusText, responseBody);
+          if (!error.retryable) throw error;
+          lastError = error;
+          continue;
+        }
+
+        return response;
+      } catch (error) {
+        if (error instanceof EddaHttpError) throw error;
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          lastError = new EddaNetworkError(`Request timeout after ${this.timeout}ms`, error);
+          continue;
+        }
+        lastError = new EddaNetworkError(
+          error instanceof Error ? error.message : 'Network error',
+          error,
+        );
+        continue;
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    throw lastError ?? new EddaNetworkError('Request failed after retries');
+  }
+}

--- a/src/edda-client/schemas.ts
+++ b/src/edda-client/schemas.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+
+// ─── Error Classes ───
+
+export class EddaError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'EddaError';
+  }
+}
+
+export class EddaNetworkError extends EddaError {
+  readonly retryable = true as const;
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = 'EddaNetworkError';
+  }
+}
+
+export class EddaHttpError extends EddaError {
+  readonly retryable: boolean;
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly body: string,
+  ) {
+    super(`HTTP ${status}: ${statusText}`);
+    this.name = 'EddaHttpError';
+    this.retryable = status >= 500 || status === 429;
+  }
+}
+
+export class EddaValidationError extends EddaError {
+  readonly retryable = false as const;
+  constructor(public readonly zodError: z.ZodError) {
+    super(`Response validation failed: ${zodError.message}`);
+    this.name = 'EddaValidationError';
+  }
+}
+
+export class EddaApiError extends EddaError {
+  readonly retryable = false as const;
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'EddaApiError';
+  }
+}
+
+// ─── Response Schemas ───
+
+export const EddaErrorResponseSchema = z.object({
+  ok: z.literal(false),
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
+export function eddaSuccess<T extends z.ZodTypeAny>(dataSchema: T) {
+  return z.object({
+    ok: z.literal(true),
+    data: dataSchema,
+  });
+}
+
+// ─── Entity Data Schemas ───
+
+export const DecisionDataSchema = z.object({
+  id: z.string(),
+  village_id: z.string(),
+  type: z.string(),
+  summary: z.string(),
+  context: z.string().optional(),
+  created_at: z.string(),
+});
+export type DecisionData = z.infer<typeof DecisionDataSchema>;
+
+export const DecisionOutcomeDataSchema = z.object({
+  id: z.string(),
+  decision_id: z.string(),
+  outcome: z.enum(['success', 'failure', 'partial']),
+  detail: z.string().optional(),
+  created_at: z.string(),
+});
+export type DecisionOutcomeData = z.infer<typeof DecisionOutcomeDataSchema>;
+
+export const HealthResponseSchema = z.object({
+  ok: z.boolean(),
+});
+export type HealthResponse = z.infer<typeof HealthResponseSchema>;
+
+// ─── Query Input Types ───
+
+export interface QueryDecisionsInput {
+  village_id: string;
+  type?: string;
+  limit?: number;
+}


### PR DESCRIPTION
## Summary
- Add `EddaClient` HTTP wrapper in `src/edda-client/` following the `ThyraClient` pattern
- Implements `queryDecisions`, `getDecisionOutcomes`, and `getHealth` methods
- Full error hierarchy: `EddaError`, `EddaNetworkError`, `EddaHttpError`, `EddaValidationError`, `EddaApiError`
- Zod schemas for `DecisionData`, `DecisionOutcomeData`, and `HealthResponse`
- 16 tests covering URL construction, response parsing, error handling, and retry behavior

## Test plan
- [x] `bun run build` passes (zero tsc errors)
- [x] `bun run lint` passes (zero eslint errors)
- [x] `bun test` passes (414 tests, 0 failures)

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)