### PR TITLE
feat: add KarviClient for pipeline registration

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -13,6 +13,8 @@
     "src/settlement/commerce-spec-builder.ts",
     "src/thyra-client/client.ts",
     "src/thyra-client/schemas.ts",
+    "src/karvi-client/client.ts",
+    "src/karvi-client/schemas.ts",
     "src/routes/*.ts"
   ],
   "project": [

--- a/src/karvi-client/client.test.ts
+++ b/src/karvi-client/client.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect } from 'vitest';
+import { KarviClient } from './client';
+import {
+  KarviApiError,
+  KarviNetworkError,
+  KarviHttpError,
+  KarviValidationError,
+} from './schemas';
+
+function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  return handler as unknown as typeof fetch;
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const sampleStep = { order: 1, type: 'skill', label: 'Review', skill_name: 'code-review', instruction: null };
+const samplePipeline = { name: 'deploy-pipe', steps: [sampleStep] };
+
+// ─── URL Construction ───
+
+describe('URL construction', () => {
+  it('registerPipeline -> POST /api/pipelines', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    const client = new KarviClient({
+      fetchFn: mockFetch((url, init) => {
+        capturedUrl = url;
+        capturedMethod = init?.method ?? 'GET';
+        return jsonResponse({ ok: true, data: samplePipeline });
+      }),
+    });
+    await client.registerPipeline({ name: 'deploy-pipe', steps: [sampleStep] });
+    expect(capturedUrl).toBe('http://localhost:3463/api/pipelines');
+    expect(capturedMethod).toBe('POST');
+  });
+
+  it('listPipelines -> GET /api/pipelines', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    const client = new KarviClient({
+      fetchFn: mockFetch((url, init) => {
+        capturedUrl = url;
+        capturedMethod = init?.method ?? 'GET';
+        return jsonResponse({ ok: true, data: [samplePipeline] });
+      }),
+    });
+    await client.listPipelines();
+    expect(capturedUrl).toBe('http://localhost:3463/api/pipelines');
+    expect(capturedMethod).toBe('GET');
+  });
+
+  it('deletePipeline -> DELETE /api/pipelines/:name', async () => {
+    let capturedUrl = '';
+    let capturedMethod = '';
+    const client = new KarviClient({
+      fetchFn: mockFetch((url, init) => {
+        capturedUrl = url;
+        capturedMethod = init?.method ?? 'GET';
+        return jsonResponse({ ok: true, data: { deleted: true } });
+      }),
+    });
+    await client.deletePipeline('my-pipe');
+    expect(capturedUrl).toBe('http://localhost:3463/api/pipelines/my-pipe');
+    expect(capturedMethod).toBe('DELETE');
+  });
+
+  it('getHealth -> GET /api/health', async () => {
+    let capturedUrl = '';
+    const client = new KarviClient({
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true });
+      }),
+    });
+    await client.getHealth();
+    expect(capturedUrl).toBe('http://localhost:3463/api/health');
+  });
+
+  it('custom baseUrl is respected', async () => {
+    let capturedUrl = '';
+    const client = new KarviClient({
+      baseUrl: 'http://karvi:8080',
+      fetchFn: mockFetch((url) => {
+        capturedUrl = url;
+        return jsonResponse({ ok: true, data: [samplePipeline] });
+      }),
+    });
+    await client.listPipelines();
+    expect(capturedUrl).toBe('http://karvi:8080/api/pipelines');
+  });
+});
+
+// ─── Success Response Parsing ───
+
+describe('success response parsing', () => {
+  it('registerPipeline returns typed PipelineData', async () => {
+    const client = new KarviClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: true, data: samplePipeline })
+      ),
+    });
+    const result = await client.registerPipeline({ name: 'deploy-pipe', steps: [sampleStep] });
+    expect(result.name).toBe('deploy-pipe');
+    expect(result.steps).toHaveLength(1);
+    expect(result.steps[0].type).toBe('skill');
+    expect(result.steps[0].skill_name).toBe('code-review');
+    expect(result.steps[0].instruction).toBeNull();
+  });
+
+  it('listPipelines returns typed PipelineData[]', async () => {
+    const client = new KarviClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: true, data: [samplePipeline, { name: 'other', steps: [] }] })
+      ),
+    });
+    const result = await client.listPipelines();
+    expect(result).toHaveLength(2);
+    expect(result[0].name).toBe('deploy-pipe');
+    expect(result[1].steps).toEqual([]);
+  });
+
+  it('listPipelines returns empty array', async () => {
+    const client = new KarviClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: true, data: [] })
+      ),
+    });
+    const result = await client.listPipelines();
+    expect(result).toEqual([]);
+  });
+
+  it('deletePipeline returns typed DeletePipelineData', async () => {
+    const client = new KarviClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: true, data: { deleted: true } })
+      ),
+    });
+    const result = await client.deletePipeline('my-pipe');
+    expect(result.deleted).toBe(true);
+  });
+});
+
+// ─── Error Handling ───
+
+describe('error handling', () => {
+  it('throws KarviApiError on { ok: false } response', async () => {
+    const client = new KarviClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: false, error: { code: 'NOT_FOUND', message: 'Pipeline not found' } })
+      ),
+    });
+    await expect(client.listPipelines())
+      .rejects.toBeInstanceOf(KarviApiError);
+  });
+
+  it('throws KarviHttpError on 4xx', async () => {
+    const client = new KarviClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        new Response('Bad Request', { status: 400, statusText: 'Bad Request' })
+      ),
+    });
+    await expect(client.registerPipeline({ name: 'x', steps: [] }))
+      .rejects.toBeInstanceOf(KarviHttpError);
+  });
+
+  it('throws KarviValidationError on malformed response', async () => {
+    const client = new KarviClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        jsonResponse({ unexpected: 'format' })
+      ),
+    });
+    await expect(client.listPipelines())
+      .rejects.toBeInstanceOf(KarviValidationError);
+  });
+
+  it('throws KarviNetworkError on fetch failure', async () => {
+    const client = new KarviClient({
+      retries: 0,
+      fetchFn: mockFetch(() => { throw new TypeError('fetch failed'); }),
+    });
+    await expect(client.listPipelines())
+      .rejects.toBeInstanceOf(KarviNetworkError);
+  });
+
+  it('getHealth returns { ok: false } on error (never throws)', async () => {
+    const client = new KarviClient({
+      fetchFn: mockFetch(() => { throw new TypeError('connection refused'); }),
+    });
+    const result = await client.getHealth();
+    expect(result).toEqual({ ok: false });
+  });
+});
+
+// ─── Retry Behavior ───
+
+describe('retry behavior', () => {
+  it('retries on 5xx up to max retries', async () => {
+    let attempts = 0;
+    const client = new KarviClient({
+      retries: 2,
+      fetchFn: mockFetch(() => {
+        attempts++;
+        if (attempts < 3) return new Response('Error', { status: 503, statusText: 'Service Unavailable' });
+        return jsonResponse({ ok: true, data: [samplePipeline] });
+      }),
+    });
+    const result = await client.listPipelines();
+    expect(attempts).toBe(3);
+    expect(result).toHaveLength(1);
+  });
+
+  it('does not retry on 4xx', async () => {
+    let attempts = 0;
+    const client = new KarviClient({
+      retries: 2,
+      fetchFn: mockFetch(() => {
+        attempts++;
+        return new Response('Not Found', { status: 404, statusText: 'Not Found' });
+      }),
+    });
+    await expect(client.listPipelines())
+      .rejects.toBeInstanceOf(KarviHttpError);
+    expect(attempts).toBe(1);
+  });
+
+  it('retries on network error', async () => {
+    let attempts = 0;
+    const client = new KarviClient({
+      retries: 1,
+      fetchFn: mockFetch(() => {
+        attempts++;
+        if (attempts < 2) throw new TypeError('fetch failed');
+        return jsonResponse({ ok: true, data: [samplePipeline] });
+      }),
+    });
+    const result = await client.listPipelines();
+    expect(attempts).toBe(2);
+    expect(result).toHaveLength(1);
+  });
+});

--- a/src/karvi-client/client.ts
+++ b/src/karvi-client/client.ts
@@ -1,0 +1,145 @@
+import { z } from 'zod';
+import {
+  type RegisterPipelineInput,
+  type PipelineData,
+  type DeletePipelineData,
+  type HealthResponse,
+  PipelineDataSchema,
+  DeletePipelineDataSchema,
+  HealthResponseSchema,
+  KarviErrorResponseSchema,
+  karviSuccess,
+  KarviNetworkError,
+  KarviHttpError,
+  KarviValidationError,
+  KarviApiError,
+} from './schemas';
+
+export interface KarviClientOptions {
+  baseUrl?: string;
+  timeout?: number;
+  retries?: number;
+  fetchFn?: typeof fetch;
+}
+
+export class KarviClient {
+  private readonly baseUrl: string;
+  private readonly timeout: number;
+  private readonly retries: number;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: KarviClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? 'http://localhost:3463';
+    this.timeout = options.timeout ?? 10_000;
+    this.retries = options.retries ?? 2;
+    this.fetchFn = options.fetchFn ?? globalThis.fetch;
+  }
+
+  async registerPipeline(input: RegisterPipelineInput): Promise<PipelineData> {
+    return this.request('POST', '/api/pipelines', PipelineDataSchema, input);
+  }
+
+  async listPipelines(): Promise<PipelineData[]> {
+    return this.request('GET', '/api/pipelines', z.array(PipelineDataSchema));
+  }
+
+  async deletePipeline(name: string): Promise<DeletePipelineData> {
+    return this.request('DELETE', `/api/pipelines/${name}`, DeletePipelineDataSchema);
+  }
+
+  async getHealth(): Promise<HealthResponse> {
+    const url = `${this.baseUrl}/api/health`;
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => { controller.abort(); }, this.timeout);
+      try {
+        const response = await this.fetchFn(url, { signal: controller.signal });
+        const json: unknown = await response.json();
+        const parsed = HealthResponseSchema.safeParse(json);
+        return parsed.success ? parsed.data : { ok: false };
+      } finally {
+        clearTimeout(timer);
+      }
+    } catch {
+      return { ok: false };
+    }
+  }
+
+  private async request<T extends z.ZodTypeAny>(
+    method: string,
+    path: string,
+    dataSchema: T,
+    body?: unknown,
+  ): Promise<z.infer<T>> {
+    const response = await this.fetchWithRetry(method, path, body);
+    const json: unknown = await response.json();
+
+    // Check for error response first
+    const errorParsed = KarviErrorResponseSchema.safeParse(json);
+    if (errorParsed.success) {
+      throw new KarviApiError(errorParsed.data.error.code, errorParsed.data.error.message);
+    }
+
+    // Parse success response
+    const successSchema = karviSuccess(dataSchema);
+    const successParsed = successSchema.safeParse(json);
+    if (!successParsed.success) {
+      throw new KarviValidationError(successParsed.error);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Zod validated, generic inference limitation
+    return successParsed.data.data as z.infer<T>;
+  }
+
+  private async fetchWithRetry(
+    method: string,
+    path: string,
+    body?: unknown,
+  ): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= this.retries; attempt++) {
+      if (attempt > 0) {
+        await new Promise(resolve => setTimeout(resolve, 100 * Math.pow(2, attempt - 1)));
+      }
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => { controller.abort(); }, this.timeout);
+
+      try {
+        const response = await this.fetchFn(url, {
+          method,
+          headers: { 'Content-Type': 'application/json' },
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+
+        if (!response.ok) {
+          const responseBody = await response.text();
+          const error = new KarviHttpError(response.status, response.statusText, responseBody);
+          if (!error.retryable) throw error;
+          lastError = error;
+          continue;
+        }
+
+        return response;
+      } catch (error) {
+        if (error instanceof KarviHttpError) throw error;
+        if (error instanceof DOMException && error.name === 'AbortError') {
+          lastError = new KarviNetworkError(`Request timeout after ${this.timeout}ms`, error);
+          continue;
+        }
+        lastError = new KarviNetworkError(
+          error instanceof Error ? error.message : 'Network error',
+          error,
+        );
+        continue;
+      } finally {
+        clearTimeout(timer);
+      }
+    }
+
+    throw lastError ?? new KarviNetworkError('Request failed after retries');
+  }
+}

--- a/src/karvi-client/schemas.ts
+++ b/src/karvi-client/schemas.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+
+// ─── Error Classes ───
+
+export class KarviError extends Error {
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = 'KarviError';
+  }
+}
+
+export class KarviNetworkError extends KarviError {
+  readonly retryable = true as const;
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = 'KarviNetworkError';
+  }
+}
+
+export class KarviHttpError extends KarviError {
+  readonly retryable: boolean;
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly body: string,
+  ) {
+    super(`HTTP ${status}: ${statusText}`);
+    this.name = 'KarviHttpError';
+    this.retryable = status >= 500 || status === 429;
+  }
+}
+
+export class KarviValidationError extends KarviError {
+  readonly retryable = false as const;
+  constructor(public readonly zodError: z.ZodError) {
+    super(`Response validation failed: ${zodError.message}`);
+    this.name = 'KarviValidationError';
+  }
+}
+
+export class KarviApiError extends KarviError {
+  readonly retryable = false as const;
+  constructor(
+    public readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'KarviApiError';
+  }
+}
+
+// ─── Response Schemas ───
+
+export const KarviErrorResponseSchema = z.object({
+  ok: z.literal(false),
+  error: z.object({
+    code: z.string(),
+    message: z.string(),
+  }),
+});
+
+export function karviSuccess<T extends z.ZodTypeAny>(dataSchema: T) {
+  return z.object({
+    ok: z.literal(true),
+    data: dataSchema,
+  });
+}
+
+// ─── Entity Data Schemas ───
+
+export const PipelineStepDataSchema = z.object({
+  order: z.number(),
+  type: z.string(),
+  label: z.string(),
+  skill_name: z.string().nullable(),
+  instruction: z.string().nullable(),
+});
+export type PipelineStepData = z.infer<typeof PipelineStepDataSchema>;
+
+export const PipelineDataSchema = z.object({
+  name: z.string(),
+  steps: z.array(PipelineStepDataSchema),
+});
+export type PipelineData = z.infer<typeof PipelineDataSchema>;
+
+export const DeletePipelineDataSchema = z.object({
+  deleted: z.boolean(),
+});
+export type DeletePipelineData = z.infer<typeof DeletePipelineDataSchema>;
+
+export const HealthResponseSchema = z.object({
+  ok: z.boolean(),
+});
+export type HealthResponse = z.infer<typeof HealthResponseSchema>;
+
+// ─── Input Schemas ───
+
+export const RegisterPipelineInputSchema = z.object({
+  name: z.string().min(1),
+  steps: z.array(z.object({
+    order: z.number(),
+    type: z.string(),
+    label: z.string(),
+    skill_name: z.string().nullable(),
+    instruction: z.string().nullable(),
+  })),
+});
+export type RegisterPipelineInput = z.infer<typeof RegisterPipelineInputSchema>;


### PR DESCRIPTION
Adds KarviClient HTTP wrapper with registerPipeline, listPipelines, deletePipeline, getHealth. 17 tests. Closes #73