### PR TITLE
feat: register pipelines to Karvi on settlement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { createDb, initSchema } from './db';
 import { LLMClient } from './llm/client';
 import { CardManager } from './cards/card-manager';
 import { ThyraClient } from './thyra-client/client';
+import { KarviClient } from './karvi-client/client';
 import { conversationRoutes } from './routes/conversations';
 import { cardRoutes } from './routes/cards';
 import { settlementRoutes } from './routes/settlements';
@@ -13,12 +14,13 @@ initSchema(db);
 const llm = new LLMClient();
 const cardManager = new CardManager(db);
 const thyra = new ThyraClient();
+const karvi = new KarviClient();
 
 const app = new Hono();
 
-app.route('/', conversationRoutes({ db, llm, cardManager }));
+app.route('/', conversationRoutes({ db, llm, cardManager, thyra }));
 app.route('/', cardRoutes({ cardManager }));
-app.route('/', settlementRoutes({ db, cardManager, thyra }));
+app.route('/', settlementRoutes({ db, cardManager, thyra, karvi }));
 
 export default {
   port: 3460,

--- a/src/routes/e2e.test.ts
+++ b/src/routes/e2e.test.ts
@@ -7,6 +7,7 @@ import { cardRoutes } from './cards';
 import { settlementRoutes } from './settlements';
 import type { LLMClient } from '../llm/client';
 import type { ThyraClient } from '../thyra-client/client';
+import type { KarviClient } from '../karvi-client/client';
 
 function createMockLlm() {
   return {
@@ -30,15 +31,25 @@ function createMockThyra() {
   } as unknown as ThyraClient;
 }
 
+function createMockKarvi() {
+  return {
+    registerPipeline: vi.fn(),
+    listPipelines: vi.fn(),
+    deletePipeline: vi.fn(),
+    getHealth: vi.fn(),
+  } as unknown as KarviClient;
+}
+
 function createTestApp(llm: LLMClient, thyra: ThyraClient) {
   const db = createDb(':memory:');
   initSchema(db);
   const cardManager = new CardManager(db);
+  const karvi = createMockKarvi();
 
   const app = new Hono();
   app.route('/', conversationRoutes({ db, llm, cardManager, thyra }));
   app.route('/', cardRoutes({ cardManager }));
-  app.route('/', settlementRoutes({ db, cardManager, thyra }));
+  app.route('/', settlementRoutes({ db, cardManager, thyra, karvi }));
 
   return { app, db, cardManager };
 }

--- a/src/routes/settlements.test.ts
+++ b/src/routes/settlements.test.ts
@@ -5,7 +5,8 @@ import { CardManager } from '../cards/card-manager';
 import { settlementRoutes } from './settlements';
 import type { Database } from 'bun:sqlite';
 import type { ThyraClient } from '../thyra-client/client';
-import type { WorldCard } from '../schemas/card';
+import type { KarviClient } from '../karvi-client/client';
+import type { WorldCard, PipelineCard } from '../schemas/card';
 
 function createMockThyra() {
   return {
@@ -16,6 +17,15 @@ function createMockThyra() {
     createSkill: vi.fn(),
     getHealth: vi.fn(),
   } as unknown as ThyraClient;
+}
+
+function createMockKarvi() {
+  return {
+    registerPipeline: vi.fn(),
+    listPipelines: vi.fn(),
+    deletePipeline: vi.fn(),
+    getHealth: vi.fn(),
+  } as unknown as KarviClient;
 }
 
 function jsonPost(app: Hono, path: string) {
@@ -44,11 +54,48 @@ const WORLD_CARD_CONTENT: WorldCard = {
   version: 1,
 };
 
+const PIPELINE_CARD_CONTENT: PipelineCard = {
+  name: 'Daily Report Pipeline',
+  steps: [
+    {
+      order: 0,
+      type: 'skill',
+      label: 'Fetch data',
+      skill_name: 'data-fetcher',
+      instruction: 'Pull daily metrics',
+      revision_target: null,
+      max_revision_cycles: null,
+      condition: null,
+      on_true: null,
+      on_false: null,
+    },
+    {
+      order: 1,
+      type: 'gate',
+      label: 'Quality check',
+      skill_name: null,
+      instruction: 'Verify data completeness',
+      revision_target: null,
+      max_revision_cycles: null,
+      condition: 'data.rows > 0',
+      on_true: 'continue',
+      on_false: 'abort',
+    },
+  ],
+  schedule: 'daily',
+  proposed_skills: [
+    { name: 'data-fetcher', type: 'retrieval', description: 'Fetches daily metrics' },
+  ],
+  pending: [],
+  version: 1,
+};
+
 describe('Settlement lifecycle', () => {
   let app: Hono;
   let db: Database;
   let cardManager: CardManager;
   let thyra: ReturnType<typeof createMockThyra>;
+  let karvi: ReturnType<typeof createMockKarvi>;
   let conversationId: string;
 
   beforeEach(() => {
@@ -56,9 +103,10 @@ describe('Settlement lifecycle', () => {
     initSchema(db);
     cardManager = new CardManager(db);
     thyra = createMockThyra();
+    karvi = createMockKarvi();
 
     app = new Hono();
-    app.route('/', settlementRoutes({ db, cardManager, thyra }));
+    app.route('/', settlementRoutes({ db, cardManager, thyra, karvi }));
 
     // Create conversation in settle phase with a world card
     conversationId = crypto.randomUUID();
@@ -318,6 +366,151 @@ describe('Settlement lifecycle', () => {
         .get(settlementId) as Record<string, unknown>;
       expect(failedRow.status).toBe('failed');
       expect(failedRow.thyra_response).toBeNull();
+    });
+  });
+});
+
+// ─── Pipeline Settlement ───
+
+describe('Pipeline settlement lifecycle', () => {
+  let app: Hono;
+  let db: Database;
+  let cardManager: CardManager;
+  let thyra: ReturnType<typeof createMockThyra>;
+  let karvi: ReturnType<typeof createMockKarvi>;
+  let conversationId: string;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+    cardManager = new CardManager(db);
+    thyra = createMockThyra();
+    karvi = createMockKarvi();
+
+    app = new Hono();
+    app.route('/', settlementRoutes({ db, cardManager, thyra, karvi }));
+
+    // Create conversation in settle phase with a pipeline card
+    conversationId = crypto.randomUUID();
+    db.run(
+      "INSERT INTO conversations (id, mode, phase) VALUES (?, 'pipeline_design', 'settle')",
+      [conversationId],
+    );
+    cardManager.create(conversationId, 'pipeline', PIPELINE_CARD_CONTENT);
+  });
+
+  describe('POST /settle (pipeline)', () => {
+    it('creates a draft settlement with YAML payload', async () => {
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(json.ok).toBe(true);
+
+      const data = json.data as Record<string, unknown>;
+      expect(data.status).toBe('draft');
+      expect(data.target).toBe('pipeline');
+
+      const payload = data.payload as string;
+      expect(payload).toContain('Daily Report Pipeline');
+      expect(payload).toContain('data-fetcher');
+      expect(payload).toContain('Quality check');
+    });
+
+    it('stores draft in DB without calling Karvi', async () => {
+      await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+
+      const row = db
+        .query('SELECT * FROM settlements WHERE conversation_id = ?')
+        .get(conversationId) as Record<string, unknown> | null;
+
+      expect(row).not.toBeNull();
+      expect(row!.status).toBe('draft');
+      expect(row!.target).toBe('pipeline');
+
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- vitest mock assertion
+      expect(karvi.registerPipeline).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /settle/confirm (pipeline)', () => {
+    it('calls karvi.registerPipeline with correct shape', async () => {
+      // Create draft
+      await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+
+      (karvi.registerPipeline as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        name: 'Daily Report Pipeline',
+        steps: [
+          { order: 0, type: 'skill', label: 'Fetch data', skill_name: 'data-fetcher', instruction: 'Pull daily metrics' },
+          { order: 1, type: 'gate', label: 'Quality check', skill_name: null, instruction: 'Verify data completeness' },
+        ],
+      });
+
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(200);
+      expect(json.ok).toBe(true);
+
+      const data = json.data as Record<string, unknown>;
+      expect(data.status).toBe('applied');
+
+      // Verify Karvi was called with correct input
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- vitest mock assertion
+      expect(karvi.registerPipeline).toHaveBeenCalledTimes(1);
+      const callArg = (karvi.registerPipeline as ReturnType<typeof vi.fn>).mock.calls[0][0] as Record<string, unknown>;
+      expect(callArg.name).toBe('Daily Report Pipeline');
+      const steps = callArg.steps as Array<Record<string, unknown>>;
+      expect(steps).toHaveLength(2);
+      expect(steps[0].label).toBe('Fetch data');
+      expect(steps[0].skill_name).toBe('data-fetcher');
+      expect(steps[1].label).toBe('Quality check');
+
+      // Thyra should NOT have been called
+      // eslint-disable-next-line @typescript-eslint/unbound-method -- vitest mock assertion
+      expect(thyra.applyVillagePack).not.toHaveBeenCalled();
+    });
+
+    it('handles Karvi failure (confirmed -> failed, 502)', async () => {
+      await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+
+      (karvi.registerPipeline as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+        new Error('Karvi is down'),
+      );
+
+      const res = await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+      const json = (await res.json()) as Record<string, unknown>;
+
+      expect(res.status).toBe(502);
+      expect(json.ok).toBe(false);
+
+      const err = json.error as Record<string, unknown>;
+      expect(err.code).toBe('UPSTREAM_ERROR');
+      expect(err.message).toBe('Karvi is down');
+
+      // DB status is 'failed'
+      const row = db
+        .query('SELECT status FROM settlements WHERE conversation_id = ? ORDER BY created_at DESC LIMIT 1')
+        .get(conversationId) as Record<string, unknown>;
+      expect(row.status).toBe('failed');
+    });
+
+    it('DB state is applied with thyra_response after success', async () => {
+      await jsonPost(app, `/api/conversations/${conversationId}/settle`);
+
+      (karvi.registerPipeline as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        name: 'Daily Report Pipeline',
+        steps: [],
+      });
+
+      await jsonPost(app, `/api/conversations/${conversationId}/settle/confirm`);
+
+      const row = db
+        .query('SELECT status, thyra_response FROM settlements WHERE conversation_id = ? ORDER BY created_at DESC LIMIT 1')
+        .get(conversationId) as Record<string, unknown>;
+
+      expect(row.status).toBe('applied');
+      expect(row.thyra_response).not.toBeNull();
     });
   });
 });

--- a/src/routes/settlements.ts
+++ b/src/routes/settlements.ts
@@ -1,20 +1,24 @@
 import { Hono } from 'hono';
+import yaml from 'js-yaml';
 import type { Database } from 'bun:sqlite';
 import { ok, error } from './response';
 import type { CardManager } from '../cards/card-manager';
 import type { ThyraClient } from '../thyra-client/client';
+import type { KarviClient } from '../karvi-client/client';
 import { classifySettlement } from '../settlement/router';
 import { buildVillagePack } from '../settlement/village-pack-builder';
 import { buildWorkflowSpec } from '../settlement/workflow-spec-builder';
 import { buildTaskSpec } from '../settlement/task-spec-builder';
 import { buildCommerceSpec } from '../settlement/commerce-spec-builder';
 import { buildOrgHierarchy } from '../settlement/org-hierarchy-builder';
-import type { WorldCard, WorkflowCard, TaskCard, CommerceCard, OrgCard } from '../schemas/card';
+import { buildPipelineSpec } from '../settlement/pipeline-spec-builder';
+import type { WorldCard, WorkflowCard, TaskCard, PipelineCard, CommerceCard, OrgCard } from '../schemas/card';
 
 export interface SettlementDeps {
   db: Database;
   cardManager: CardManager;
   thyra: ThyraClient;
+  karvi: KarviClient;
 }
 
 export function settlementRoutes(deps: SettlementDeps): Hono {
@@ -91,6 +95,16 @@ export function settlementRoutes(deps: SettlementDeps): Hono {
       return ok(c, { id: settlementId, target, payload: yamlStr, status: 'draft' });
     }
 
+    if (target === 'pipeline') {
+      const yamlStr = buildPipelineSpec(card.content as PipelineCard);
+      const settlementId = crypto.randomUUID();
+      deps.db.run(
+        'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+        [settlementId, conversationId, card.id, target, yamlStr, 'draft'],
+      );
+      return ok(c, { id: settlementId, target, payload: yamlStr, status: 'draft' });
+    }
+
     // target === 'task'
     const json = buildTaskSpec(card.content as TaskCard);
     const settlementId = crypto.randomUUID();
@@ -118,6 +132,8 @@ export function settlementRoutes(deps: SettlementDeps): Hono {
     const settlementId = settlement.id as string;
     const payload = settlement.payload as string;
 
+    const target = settlement.target as string;
+
     // Transition: draft -> confirmed
     deps.db.run(
       'UPDATE settlements SET status = ? WHERE id = ?',
@@ -125,13 +141,47 @@ export function settlementRoutes(deps: SettlementDeps): Hono {
     );
 
     try {
-      const result = await deps.thyra.applyVillagePack(payload);
+      let result: unknown;
+
+      switch (target) {
+        case 'village_pack':
+          result = await deps.thyra.applyVillagePack(payload);
+          break;
+        case 'pipeline': {
+          const spec = yaml.load(payload) as {
+            pipeline: { name: string };
+            steps: Array<{
+              order: number;
+              type: string;
+              label: string;
+              skill_name: string | null;
+              instruction: string | null;
+            }>;
+          };
+          result = await deps.karvi.registerPipeline({
+            name: spec.pipeline.name,
+            steps: spec.steps.map((s) => ({
+              order: s.order,
+              type: s.type,
+              label: s.label,
+              skill_name: s.skill_name,
+              instruction: s.instruction,
+            })),
+          });
+          break;
+        }
+        default:
+          // workflow, task, adapter_config, market_init, org_hierarchy — not yet wired to external service
+          result = { applied: true };
+          break;
+      }
+
       // Transition: confirmed -> applied
       deps.db.run(
         'UPDATE settlements SET status = ?, thyra_response = ? WHERE id = ?',
         ['applied', JSON.stringify(result), settlementId],
       );
-      return ok(c, { id: settlementId, status: 'applied', thyra: result });
+      return ok(c, { id: settlementId, status: 'applied', result });
     } catch (err) {
       // Transition: confirmed -> failed
       deps.db.run(
@@ -141,7 +191,7 @@ export function settlementRoutes(deps: SettlementDeps): Hono {
       return error(
         c,
         'UPSTREAM_ERROR',
-        err instanceof Error ? err.message : 'Thyra API failed',
+        err instanceof Error ? err.message : 'Upstream API failed',
         502,
       );
     }


### PR DESCRIPTION
## Summary
- Add KarviClient to SettlementDeps and wire in index.ts
- Pipeline settle creates draft with YAML payload
- Confirm endpoint branches by target: village_pack→Thyra, pipeline→Karvi, default→applied
- Pipeline settlement lifecycle tests (draft, confirm, Karvi failure)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)