### PR TITLE
feat(decision): add Zod schemas for decision pipeline shared types

### DIFF
--- a/src/schemas/decision.test.ts
+++ b/src/schemas/decision.test.ts
@@ -1,0 +1,490 @@
+import { describe, it, expect } from 'vitest';
+import {
+  RegimeEnum,
+  RealizationFormEnum,
+  WorldFormEnum,
+  IntentRouteSchema,
+  FixedElementSchema,
+  UnresolvedElementSchema,
+  PathCheckResultSchema,
+  RealizationCandidateSchema,
+  GovernanceWorldCandidateSchema,
+  ProbeableFormSchema,
+  SignalPacketSchema,
+  EvaluatorInputSchema,
+  EvaluatorOutputSchema,
+  CommitMemoSchema,
+  EconomicCommitMemoSchema,
+  GovernanceCommitMemoSchema,
+} from './decision';
+
+// ─── Enum Tests ───
+
+describe('RegimeEnum', () => {
+  it('accepts all 6 regime values', () => {
+    const values = ['economic', 'capability', 'leverage', 'expression', 'governance', 'identity'];
+    for (const v of values) {
+      expect(RegimeEnum.safeParse(v).success).toBe(true);
+    }
+    expect(RegimeEnum.options).toHaveLength(6);
+  });
+
+  it('rejects invalid regime', () => {
+    expect(RegimeEnum.safeParse('finance').success).toBe(false);
+  });
+});
+
+describe('RealizationFormEnum', () => {
+  it('has exactly 10 values', () => {
+    expect(RealizationFormEnum.options).toHaveLength(10);
+  });
+
+  it('accepts valid values', () => {
+    expect(RealizationFormEnum.safeParse('service').success).toBe(true);
+    expect(RealizationFormEnum.safeParse('world').success).toBe(true);
+    expect(RealizationFormEnum.safeParse('community_format').success).toBe(true);
+  });
+
+  it('rejects invalid values', () => {
+    expect(RealizationFormEnum.safeParse('app').success).toBe(false);
+  });
+});
+
+describe('WorldFormEnum', () => {
+  it('has exactly 6 values', () => {
+    expect(WorldFormEnum.options).toHaveLength(6);
+  });
+
+  it('accepts valid values', () => {
+    expect(WorldFormEnum.safeParse('market').success).toBe(true);
+    expect(WorldFormEnum.safeParse('night_engine').success).toBe(true);
+  });
+
+  it('rejects invalid values', () => {
+    expect(WorldFormEnum.safeParse('kingdom').success).toBe(false);
+  });
+});
+
+// ─── Section 2: Intent Router ───
+
+describe('IntentRouteSchema', () => {
+  const validRoute = {
+    primaryRegime: 'economic',
+    confidence: 0.85,
+    signals: ['pricing mention'],
+    rationale: ['user discussed revenue'],
+    keyUnknowns: ['target market'],
+    suggestedFollowups: ['ask about pricing'],
+  };
+
+  it('parses valid intent route', () => {
+    const result = IntentRouteSchema.safeParse(validRoute);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses with optional secondaryRegimes', () => {
+    const result = IntentRouteSchema.safeParse({
+      ...validRoute,
+      secondaryRegimes: ['capability', 'leverage'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects confidence > 1', () => {
+    const result = IntentRouteSchema.safeParse({ ...validRoute, confidence: 1.5 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects confidence < 0', () => {
+    const result = IntentRouteSchema.safeParse({ ...validRoute, confidence: -0.1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid primaryRegime', () => {
+    const result = IntentRouteSchema.safeParse({ ...validRoute, primaryRegime: 'finance' });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing required fields', () => {
+    const result = IntentRouteSchema.safeParse({ primaryRegime: 'economic' });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Section 3: Path Check ───
+
+describe('FixedElementSchema', () => {
+  it('parses valid fixed element', () => {
+    const result = FixedElementSchema.safeParse({ kind: 'intent', value: 'sell courses' });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid kind', () => {
+    const result = FixedElementSchema.safeParse({ kind: 'unknown', value: 'test' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('UnresolvedElementSchema', () => {
+  it('parses valid unresolved element', () => {
+    const result = UnresolvedElementSchema.safeParse({
+      kind: 'domain',
+      reason: 'not specified',
+      severity: 'blocking',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid severity', () => {
+    const result = UnresolvedElementSchema.safeParse({
+      kind: 'domain',
+      reason: 'not specified',
+      severity: 'critical',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('PathCheckResultSchema', () => {
+  const validResult = {
+    certainty: 'medium',
+    route: 'space-builder',
+    fixedElements: [{ kind: 'intent', value: 'sell courses' }],
+    unresolvedElements: [{ kind: 'domain', reason: 'unclear', severity: 'blocking' }],
+    recommendedNextStep: 'ask about domain',
+  };
+
+  it('parses valid path check result', () => {
+    const result = PathCheckResultSchema.safeParse(validResult);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses with optional whyNotReady and whyReady', () => {
+    const result = PathCheckResultSchema.safeParse({
+      ...validResult,
+      whyNotReady: ['missing domain'],
+      whyReady: ['intent is clear'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid route', () => {
+    const result = PathCheckResultSchema.safeParse({ ...validResult, route: 'invalid-route' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts all 3 route values', () => {
+    for (const route of ['space-builder', 'forge-fast-path', 'space-builder-then-forge']) {
+      const result = PathCheckResultSchema.safeParse({ ...validResult, route });
+      expect(result.success).toBe(true);
+    }
+  });
+});
+
+// ─── Section 4: Space Builder ───
+
+describe('RealizationCandidateSchema', () => {
+  const validCandidate = {
+    id: 'cand-1',
+    regime: 'economic',
+    form: 'service',
+    description: 'Consulting service',
+    whyThisCandidate: ['market demand'],
+    assumptions: ['target exists'],
+    timeToSignal: 'short',
+    notes: ['first candidate'],
+  };
+
+  it('parses valid candidate', () => {
+    const result = RealizationCandidateSchema.safeParse(validCandidate);
+    expect(result.success).toBe(true);
+  });
+
+  it('parses with optional fields', () => {
+    const result = RealizationCandidateSchema.safeParse({
+      ...validCandidate,
+      domain: 'education',
+      vehicle: 'online platform',
+      worldForm: 'market',
+      probeReadinessHints: ['has audience'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid form', () => {
+    const result = RealizationCandidateSchema.safeParse({ ...validCandidate, form: 'app' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('GovernanceWorldCandidateSchema', () => {
+  const validGovCandidate = {
+    id: 'gov-1',
+    regime: 'governance',
+    form: 'world',
+    description: 'A governance world',
+    whyThisCandidate: ['governance need'],
+    assumptions: ['community exists'],
+    timeToSignal: 'long',
+    notes: [],
+    worldForm: 'town',
+    stateDensity: 'medium',
+    changeClarity: 'high',
+    governancePressure: 'low',
+    outcomeVisibility: 'medium',
+    cycleability: 'high',
+    likelyMinimumWorldShape: ['basic rules'],
+    mainRisks: ['low participation'],
+  };
+
+  it('parses valid governance world candidate', () => {
+    const result = GovernanceWorldCandidateSchema.safeParse(validGovCandidate);
+    expect(result.success).toBe(true);
+  });
+
+  it('requires worldForm (not optional)', () => {
+    const withoutWorldForm = Object.fromEntries(
+      Object.entries(validGovCandidate).filter(([k]) => k !== 'worldForm'),
+    );
+    const result = GovernanceWorldCandidateSchema.safeParse(withoutWorldForm);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing governance-specific fields', () => {
+    const without = Object.fromEntries(
+      Object.entries(validGovCandidate).filter(([k]) => k !== 'stateDensity'),
+    );
+    const result = GovernanceWorldCandidateSchema.safeParse(without);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── Section 5: Probe-Commit ───
+
+describe('ProbeableFormSchema', () => {
+  const validForm = {
+    candidateId: 'cand-1',
+    regime: 'economic',
+    hypothesis: 'People will pay for this',
+    testTarget: 'freelancers',
+    judge: 'conversion rate',
+    cheapestBelievableProbe: 'landing page test',
+    disconfirmers: ['no signups'],
+  };
+
+  it('parses valid probeable form', () => {
+    const result = ProbeableFormSchema.safeParse(validForm);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing fields', () => {
+    const without = Object.fromEntries(
+      Object.entries(validForm).filter(([k]) => k !== 'hypothesis'),
+    );
+    const result = ProbeableFormSchema.safeParse(without);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('SignalPacketSchema', () => {
+  const validSignal = {
+    candidateId: 'cand-1',
+    probeId: 'probe-1',
+    regime: 'economic',
+    signalType: 'willingness_to_pay',
+    strength: 'moderate',
+    evidence: ['3 out of 5 said yes'],
+    interpretation: 'moderate interest',
+    nextQuestions: ['what price point?'],
+  };
+
+  it('parses valid signal packet', () => {
+    const result = SignalPacketSchema.safeParse(validSignal);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts any string for signalType', () => {
+    const result = SignalPacketSchema.safeParse({
+      ...validSignal,
+      signalType: 'custom_regime_signal',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid strength', () => {
+    const result = SignalPacketSchema.safeParse({ ...validSignal, strength: 'very_strong' });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('EvaluatorInputSchema', () => {
+  it('parses valid evaluator input', () => {
+    const result = EvaluatorInputSchema.safeParse({
+      candidate: {
+        id: 'c1', regime: 'economic', form: 'service',
+        description: 'test', whyThisCandidate: [], assumptions: [],
+        timeToSignal: 'short', notes: [],
+      },
+      probeableForm: {
+        candidateId: 'c1', regime: 'economic',
+        hypothesis: 'h', testTarget: 't', judge: 'j',
+        cheapestBelievableProbe: 'p', disconfirmers: [],
+      },
+      signals: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts optional context as record', () => {
+    const result = EvaluatorInputSchema.safeParse({
+      candidate: {
+        id: 'c1', regime: 'economic', form: 'service',
+        description: 'test', whyThisCandidate: [], assumptions: [],
+        timeToSignal: 'short', notes: [],
+      },
+      probeableForm: {
+        candidateId: 'c1', regime: 'economic',
+        hypothesis: 'h', testTarget: 't', judge: 'j',
+        cheapestBelievableProbe: 'p', disconfirmers: [],
+      },
+      signals: [],
+      context: { key: 'value', nested: { a: 1 } },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('EvaluatorOutputSchema', () => {
+  const validOutput = {
+    verdict: 'commit',
+    rationale: ['strong signal'],
+    evidenceUsed: ['probe result'],
+    unresolvedRisks: ['market size unknown'],
+    recommendedNextStep: ['build MVP'],
+  };
+
+  it('parses valid evaluator output', () => {
+    const result = EvaluatorOutputSchema.safeParse(validOutput);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts optional handoffNotes', () => {
+    const result = EvaluatorOutputSchema.safeParse({
+      ...validOutput,
+      handoffNotes: ['pass to forge'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid verdict', () => {
+    const result = EvaluatorOutputSchema.safeParse({ ...validOutput, verdict: 'approve' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts all 3 verdict values', () => {
+    for (const verdict of ['commit', 'hold', 'discard']) {
+      const result = EvaluatorOutputSchema.safeParse({ ...validOutput, verdict });
+      expect(result.success).toBe(true);
+    }
+  });
+});
+
+describe('CommitMemoSchema', () => {
+  const validMemo = {
+    candidateId: 'cand-1',
+    regime: 'economic',
+    verdict: 'commit',
+    rationale: ['strong signal'],
+    evidenceUsed: ['probe-1'],
+    unresolvedRisks: [],
+    whatForgeShouldBuild: ['landing page'],
+    whatForgeMustNotBuild: ['full platform'],
+    recommendedNextStep: ['validate pricing'],
+  };
+
+  it('parses valid commit memo', () => {
+    const result = CommitMemoSchema.safeParse(validMemo);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing required fields', () => {
+    const without = Object.fromEntries(
+      Object.entries(validMemo).filter(([k]) => k !== 'whatForgeShouldBuild'),
+    );
+    const result = CommitMemoSchema.safeParse(without);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('EconomicCommitMemoSchema', () => {
+  const validEconMemo = {
+    candidateId: 'cand-1',
+    regime: 'economic',
+    verdict: 'commit',
+    rationale: ['signal'],
+    evidenceUsed: ['probe'],
+    unresolvedRisks: [],
+    whatForgeShouldBuild: ['mvp'],
+    whatForgeMustNotBuild: [],
+    recommendedNextStep: ['launch'],
+    buyerHypothesis: 'freelancers need this',
+    painHypothesis: 'manual process is slow',
+    paymentEvidence: ['3 said would pay'],
+    whyThisVehicleNow: ['market timing'],
+    nextSignalAfterBuild: ['conversion rate'],
+  };
+
+  it('parses valid economic commit memo', () => {
+    const result = EconomicCommitMemoSchema.safeParse(validEconMemo);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing economic-specific fields', () => {
+    const without = Object.fromEntries(
+      Object.entries(validEconMemo).filter(([k]) => k !== 'buyerHypothesis'),
+    );
+    const result = EconomicCommitMemoSchema.safeParse(without);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('GovernanceCommitMemoSchema', () => {
+  const validGovMemo = {
+    candidateId: 'cand-1',
+    regime: 'governance',
+    verdict: 'commit',
+    rationale: ['signal'],
+    evidenceUsed: ['probe'],
+    unresolvedRisks: [],
+    whatForgeShouldBuild: ['world skeleton'],
+    whatForgeMustNotBuild: [],
+    recommendedNextStep: ['design first cycle'],
+    selectedWorldForm: 'town',
+    minimumWorldShape: ['basic rules', 'entry criteria'],
+    stateDensityAssessment: 'medium',
+    governancePressureAssessment: 'low',
+    firstCycleDesign: ['setup phase'],
+    thyraHandoffRequirements: ['world snapshot schema'],
+  };
+
+  it('parses valid governance commit memo', () => {
+    const result = GovernanceCommitMemoSchema.safeParse(validGovMemo);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid selectedWorldForm', () => {
+    const result = GovernanceCommitMemoSchema.safeParse({
+      ...validGovMemo,
+      selectedWorldForm: 'kingdom',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing governance-specific fields', () => {
+    const without = Object.fromEntries(
+      Object.entries(validGovMemo).filter(([k]) => k !== 'selectedWorldForm'),
+    );
+    const result = GovernanceCommitMemoSchema.safeParse(without);
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/schemas/decision.ts
+++ b/src/schemas/decision.ts
@@ -1,0 +1,312 @@
+import { z } from 'zod';
+
+// ─── Section 1: Base Types ───
+
+export const RegimeEnum = z.enum([
+  'economic', 'capability', 'leverage', 'expression', 'governance', 'identity',
+]);
+export type Regime = z.infer<typeof RegimeEnum>;
+
+// ─── Section 2: Intent Router ───
+
+export const IntentRouteSchema = z.object({
+  primaryRegime: RegimeEnum,
+  secondaryRegimes: z.array(RegimeEnum).optional(),
+  confidence: z.number().min(0).max(1),
+  signals: z.array(z.string()),
+  rationale: z.array(z.string()),
+  keyUnknowns: z.array(z.string()),
+  suggestedFollowups: z.array(z.string()),
+});
+export type IntentRoute = z.infer<typeof IntentRouteSchema>;
+
+// ─── Section 3: Path Check ───
+
+const FixedElementKindEnum = z.enum(['intent', 'domain', 'form', 'buyer', 'loop', 'build_target']);
+
+export const FixedElementSchema = z.object({
+  kind: FixedElementKindEnum,
+  value: z.string(),
+});
+export type FixedElement = z.infer<typeof FixedElementSchema>;
+
+const UnresolvedElementKindEnum = z.enum(['domain', 'form', 'buyer', 'loop', 'build_target', 'signal']);
+
+export const UnresolvedElementSchema = z.object({
+  kind: UnresolvedElementKindEnum,
+  reason: z.string(),
+  severity: z.enum(['blocking', 'important', 'nice_to_have']),
+});
+export type UnresolvedElement = z.infer<typeof UnresolvedElementSchema>;
+
+export const PathCheckResultSchema = z.object({
+  certainty: z.enum(['low', 'medium', 'high']),
+  route: z.enum(['space-builder', 'forge-fast-path', 'space-builder-then-forge']),
+  fixedElements: z.array(FixedElementSchema),
+  unresolvedElements: z.array(UnresolvedElementSchema),
+  whyNotReady: z.array(z.string()).optional(),
+  whyReady: z.array(z.string()).optional(),
+  recommendedNextStep: z.string(),
+});
+export type PathCheckResult = z.infer<typeof PathCheckResultSchema>;
+
+// ─── Section 4: Space Builder ───
+
+export const RealizationFormEnum = z.enum([
+  'service', 'productized_service', 'tool', 'workflow_pack', 'learning_path',
+  'practice_loop', 'medium', 'world', 'operator_model', 'community_format',
+]);
+export type RealizationForm = z.infer<typeof RealizationFormEnum>;
+
+export const WorldFormEnum = z.enum([
+  'market', 'commons', 'town', 'port', 'night_engine', 'managed_knowledge_field',
+]);
+export type WorldForm = z.infer<typeof WorldFormEnum>;
+
+const TimeToSignalEnum = z.enum(['short', 'medium', 'long']);
+
+export const RealizationCandidateSchema = z.object({
+  id: z.string(),
+  regime: RegimeEnum,
+  form: RealizationFormEnum,
+  domain: z.string().optional(),
+  vehicle: z.string().optional(),
+  worldForm: WorldFormEnum.optional(),
+  description: z.string(),
+  whyThisCandidate: z.array(z.string()),
+  assumptions: z.array(z.string()),
+  probeReadinessHints: z.array(z.string()).optional(),
+  timeToSignal: TimeToSignalEnum,
+  notes: z.array(z.string()),
+});
+export type RealizationCandidate = z.infer<typeof RealizationCandidateSchema>;
+
+const ThreeLevelEnum = z.enum(['low', 'medium', 'high']);
+
+export const GovernanceWorldCandidateSchema = RealizationCandidateSchema.extend({
+  worldForm: WorldFormEnum,
+  stateDensity: ThreeLevelEnum,
+  changeClarity: ThreeLevelEnum,
+  governancePressure: ThreeLevelEnum,
+  outcomeVisibility: ThreeLevelEnum,
+  cycleability: ThreeLevelEnum,
+  likelyMinimumWorldShape: z.array(z.string()),
+  mainRisks: z.array(z.string()),
+});
+export type GovernanceWorldCandidate = z.infer<typeof GovernanceWorldCandidateSchema>;
+
+// ─── Section 5: Probe-Commit ───
+
+export const ProbeableFormSchema = z.object({
+  candidateId: z.string(),
+  regime: RegimeEnum,
+  hypothesis: z.string(),
+  testTarget: z.string(),
+  judge: z.string(),
+  cheapestBelievableProbe: z.string(),
+  disconfirmers: z.array(z.string()),
+});
+export type ProbeableForm = z.infer<typeof ProbeableFormSchema>;
+
+const SignalStrengthEnum = z.enum(['weak', 'moderate', 'strong']);
+
+export const SignalPacketSchema = z.object({
+  candidateId: z.string(),
+  probeId: z.string(),
+  regime: RegimeEnum,
+  signalType: z.string(),
+  strength: SignalStrengthEnum,
+  evidence: z.array(z.string()),
+  negativeEvidence: z.array(z.string()).optional(),
+  interpretation: z.string(),
+  nextQuestions: z.array(z.string()),
+});
+export type SignalPacket = z.infer<typeof SignalPacketSchema>;
+
+export const EvaluatorInputSchema = z.object({
+  candidate: RealizationCandidateSchema,
+  probeableForm: ProbeableFormSchema,
+  signals: z.array(SignalPacketSchema),
+  context: z.record(z.string(), z.unknown()).optional(),
+});
+export type EvaluatorInput = z.infer<typeof EvaluatorInputSchema>;
+
+const VerdictEnum = z.enum(['commit', 'hold', 'discard']);
+
+export const EvaluatorOutputSchema = z.object({
+  verdict: VerdictEnum,
+  rationale: z.array(z.string()),
+  evidenceUsed: z.array(z.string()),
+  unresolvedRisks: z.array(z.string()),
+  recommendedNextStep: z.array(z.string()),
+  handoffNotes: z.array(z.string()).optional(),
+});
+export type EvaluatorOutput = z.infer<typeof EvaluatorOutputSchema>;
+
+export const CommitMemoSchema = z.object({
+  candidateId: z.string(),
+  regime: RegimeEnum,
+  verdict: VerdictEnum,
+  rationale: z.array(z.string()),
+  evidenceUsed: z.array(z.string()),
+  unresolvedRisks: z.array(z.string()),
+  whatForgeShouldBuild: z.array(z.string()),
+  whatForgeMustNotBuild: z.array(z.string()),
+  recommendedNextStep: z.array(z.string()),
+});
+export type CommitMemo = z.infer<typeof CommitMemoSchema>;
+
+export const EconomicCommitMemoSchema = CommitMemoSchema.extend({
+  buyerHypothesis: z.string(),
+  painHypothesis: z.string(),
+  paymentEvidence: z.array(z.string()),
+  whyThisVehicleNow: z.array(z.string()),
+  nextSignalAfterBuild: z.array(z.string()),
+});
+export type EconomicCommitMemo = z.infer<typeof EconomicCommitMemoSchema>;
+
+export const GovernanceCommitMemoSchema = CommitMemoSchema.extend({
+  selectedWorldForm: WorldFormEnum,
+  minimumWorldShape: z.array(z.string()),
+  stateDensityAssessment: ThreeLevelEnum,
+  governancePressureAssessment: ThreeLevelEnum,
+  firstCycleDesign: z.array(z.string()),
+  thyraHandoffRequirements: z.array(z.string()),
+});
+export type GovernanceCommitMemo = z.infer<typeof GovernanceCommitMemoSchema>;
+
+// ─── Section 6: Canonical Cycle (type-only, no Zod for v0) ───
+
+export type WorldMode = 'setup' | 'open' | 'peak' | 'managed' | 'cooldown' | 'closed';
+export type CycleMode = 'normal' | 'peak' | 'incident' | 'shutdown';
+
+export type CanonicalVerdict =
+  | 'approved' | 'approved_with_constraints' | 'rejected'
+  | 'simulation_required' | 'escalated' | 'deferred';
+
+export type ChangeProposalStatus =
+  | 'draft' | 'proposed' | 'judged' | 'approved' | 'approved_with_constraints'
+  | 'rejected' | 'simulation_required' | 'escalated' | 'deferred'
+  | 'applied' | 'cancelled' | 'rolled_back'
+  | 'outcome_window_open' | 'outcome_closed' | 'archived';
+
+export type ChangeKindMVP =
+  | 'adjust_stall_capacity' | 'adjust_spotlight_weight'
+  | 'throttle_entry' | 'pause_event' | 'modify_pricing_rule';
+
+export type ChangeKind = ChangeKindMVP
+  | 'resume_event' | 'reassign_zone_priority'
+  | 'tighten_safety_threshold' | 'relax_safety_threshold'
+  | 'law_patch' | 'chief_permission_patch';
+
+export type OutcomeVerdict = 'beneficial' | 'neutral' | 'harmful' | 'inconclusive';
+export type OutcomeRecommendation = 'reinforce' | 'retune' | 'watch' | 'rollback' | 'do_not_repeat';
+
+export type LayerResult = {
+  passed: boolean;
+  issues: string[];
+  verdict: CanonicalVerdict;
+};
+
+export type SimulationPlan = {
+  mode: 'dry_run' | 'shadow' | 'counterfactual';
+  durationMinutes: number;
+  watchedMetrics: string[];
+};
+
+export type JudgmentReport = {
+  id: string;
+  proposalId: string;
+  cycleId: string;
+  layerResults: {
+    structural: LayerResult;
+    invariants: LayerResult;
+    constitution: LayerResult;
+    contextual: LayerResult;
+  };
+  finalVerdict: CanonicalVerdict;
+  finalRiskClass: 'low' | 'medium' | 'high';
+  constraints?: string[];
+  simulationPlan?: SimulationPlan;
+  escalationTarget?: string;
+  rollbackRequirements: string[];
+  rationale: string;
+  createdAt: string;
+};
+
+export type Concern = {
+  kind: string;
+  severity: 'low' | 'medium' | 'high' | 'critical';
+  targetId?: string;
+  summary: string;
+};
+
+export type PulseFrame = {
+  id: string;
+  worldId: string;
+  cycleId?: string;
+  healthScore: number;
+  mode: WorldMode;
+  stability: 'stable' | 'unstable' | 'critical';
+  dominantConcerns: Concern[];
+  metrics: Record<string, number>;
+  timestamp: string;
+};
+
+export type ExpectedEffectResult = {
+  metric: string;
+  baseline: number;
+  observed: number;
+  delta: number;
+  matched: boolean;
+};
+
+export type SideEffectResult = {
+  metric: string;
+  baseline: number;
+  observed: number;
+  delta: number;
+  severity: 'negligible' | 'minor' | 'significant';
+};
+
+export type OutcomeReport = {
+  id: string;
+  appliedChangeId: string;
+  outcomeWindowId: string;
+  primaryObjectiveMet: boolean;
+  expectedEffects: ExpectedEffectResult[];
+  sideEffects: SideEffectResult[];
+  verdict: OutcomeVerdict;
+  recommendation: OutcomeRecommendation;
+  notes: string[];
+  createdAt: string;
+};
+
+export type PrecedentRecord = {
+  id: string;
+  worldId: string;
+  worldType: string;
+  proposalId: string;
+  changeKind: ChangeKind;
+  cycleId: string;
+  context: string;
+  decision: string;
+  outcome: OutcomeVerdict;
+  recommendation: OutcomeRecommendation;
+  lessonsLearned: string[];
+  contextTags: string[];
+  createdAt: string;
+};
+
+export type GovernanceAdjustment = {
+  id: string;
+  worldId: string;
+  triggeredBy: string;
+  adjustmentType: 'law_threshold' | 'chief_permission' | 'chief_style' | 'risk_policy' | 'simulation_policy';
+  target: string;
+  before: string;
+  after: string;
+  rationale: string;
+  status: 'proposed' | 'approved' | 'applied' | 'rejected';
+  createdAt: string;
+};


### PR DESCRIPTION
## Summary
- Add comprehensive Zod schemas for all decision pipeline shared types
- Cover Sections 1-5 of shared-types.md (Regime, IntentRoute, PathCheckResult, RealizationCandidate, ProbeableForm, SignalPacket, EvaluatorOutput, CommitMemo, etc.)
- Section 6 canonical cycle types as type-only exports (Thyra-owned)
- Full test coverage for schema validation

Closes #96

## Test plan
- [ ] All Zod schemas parse valid data correctly
- [ ] Schemas reject invalid/malformed data
- [ ] Enum values match shared-types.md spec
- [ ] `bun run build && bun run lint && bun test` all pass

Generated with [Claude Code](https://claude.com/claude-code)
