### PR TITLE
feat(skills): add lifecycle DB schema + stage tracking

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -182,4 +182,31 @@ export function initSchema(db: Database): void {
     payload_json TEXT NOT NULL DEFAULT '{}',
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`);
+
+  // ─── Skill Lifecycle Tables ───
+
+  db.run(`CREATE TABLE IF NOT EXISTS skill_instances (
+    id TEXT PRIMARY KEY,
+    skill_id TEXT NOT NULL,
+    name TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'draft'
+      CHECK(status IN ('draft','sandbox','promoted','core','deprecated','superseded')),
+    current_stage TEXT NOT NULL DEFAULT 'capture'
+      CHECK(current_stage IN ('capture','crystallize','package','route','execute','verify','learn','govern')),
+    run_count INTEGER NOT NULL DEFAULT 0,
+    success_count INTEGER NOT NULL DEFAULT 0,
+    last_used_at TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`);
+
+  db.run(`CREATE TABLE IF NOT EXISTS skill_runs (
+    id TEXT PRIMARY KEY,
+    skill_instance_id TEXT NOT NULL REFERENCES skill_instances(id),
+    conversation_id TEXT,
+    outcome TEXT NOT NULL CHECK(outcome IN ('success','failure','partial')),
+    duration_ms INTEGER,
+    notes TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`);
 }

--- a/src/skills/lifecycle.test.ts
+++ b/src/skills/lifecycle.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { Database } from 'bun:sqlite';
+import { createDb, initSchema } from '../db';
+import { advanceStage } from './lifecycle';
+import type { LifecycleStage } from '../schemas/skill-object';
+
+describe('lifecycle DB tables', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+  });
+
+  it('creates skill_instances table', () => {
+    const row = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='skill_instances'",
+      )
+      .get() as Record<string, unknown> | null;
+    expect(row).not.toBeNull();
+    expect(row!.name).toBe('skill_instances');
+  });
+
+  it('creates skill_runs table', () => {
+    const row = db
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='skill_runs'",
+      )
+      .get() as Record<string, unknown> | null;
+    expect(row).not.toBeNull();
+    expect(row!.name).toBe('skill_runs');
+  });
+
+  it('inserts and queries a skill_instance', () => {
+    db.prepare(
+      `INSERT INTO skill_instances (id, skill_id, name) VALUES (?, ?, ?)`,
+    ).run('si-1', 'sk-abc', 'test-skill');
+
+    const row = db
+      .prepare('SELECT * FROM skill_instances WHERE id = ?')
+      .get('si-1') as Record<string, unknown> | null;
+
+    expect(row).not.toBeNull();
+    expect(row!.skill_id).toBe('sk-abc');
+    expect(row!.name).toBe('test-skill');
+    expect(row!.status).toBe('draft');
+    expect(row!.current_stage).toBe('capture');
+    expect(row!.run_count).toBe(0);
+    expect(row!.success_count).toBe(0);
+  });
+
+  it('inserts a skill_run with FK to skill_instance', () => {
+    db.prepare(
+      `INSERT INTO skill_instances (id, skill_id, name) VALUES (?, ?, ?)`,
+    ).run('si-1', 'sk-abc', 'test-skill');
+
+    db.prepare(
+      `INSERT INTO skill_runs (id, skill_instance_id, conversation_id, outcome, duration_ms) VALUES (?, ?, ?, ?, ?)`,
+    ).run('sr-1', 'si-1', 'conv-1', 'success', 1200);
+
+    const row = db
+      .prepare('SELECT * FROM skill_runs WHERE id = ?')
+      .get('sr-1') as Record<string, unknown> | null;
+
+    expect(row).not.toBeNull();
+    expect(row!.skill_instance_id).toBe('si-1');
+    expect(row!.outcome).toBe('success');
+    expect(row!.duration_ms).toBe(1200);
+  });
+
+  it('rejects invalid status in skill_instances', () => {
+    expect(() => {
+      db.prepare(
+        `INSERT INTO skill_instances (id, skill_id, name, status) VALUES (?, ?, ?, ?)`,
+      ).run('si-bad', 'sk-abc', 'bad', 'invalid_status');
+    }).toThrow();
+  });
+
+  it('rejects invalid outcome in skill_runs', () => {
+    db.prepare(
+      `INSERT INTO skill_instances (id, skill_id, name) VALUES (?, ?, ?)`,
+    ).run('si-1', 'sk-abc', 'test-skill');
+
+    expect(() => {
+      db.prepare(
+        `INSERT INTO skill_runs (id, skill_instance_id, outcome) VALUES (?, ?, ?)`,
+      ).run('sr-bad', 'si-1', 'unknown');
+    }).toThrow();
+  });
+});
+
+describe('advanceStage', () => {
+  const stages: LifecycleStage[] = [
+    'capture',
+    'crystallize',
+    'package',
+    'route',
+    'execute',
+    'verify',
+    'learn',
+    'govern',
+  ];
+
+  it('allows forward progression for each consecutive pair', () => {
+    for (let i = 0; i < stages.length - 1; i++) {
+      const result = advanceStage(stages[i], stages[i + 1]);
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toContain('Advanced from');
+    }
+  });
+
+  it('allows cyclic: learn -> execute', () => {
+    const result = advanceStage('learn', 'execute');
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toContain('Cyclic');
+  });
+
+  it('allows govern -> execute re-entry', () => {
+    const result = advanceStage('govern', 'execute');
+    expect(result.allowed).toBe(true);
+    expect(result.reason).toContain('governance');
+  });
+
+  it('allows full cyclic loop: execute -> verify -> learn -> execute', () => {
+    const r1 = advanceStage('execute', 'verify');
+    expect(r1.allowed).toBe(true);
+
+    const r2 = advanceStage('verify', 'learn');
+    expect(r2.allowed).toBe(true);
+
+    const r3 = advanceStage('learn', 'execute');
+    expect(r3.allowed).toBe(true);
+  });
+
+  it('rejects skipping stages: capture -> execute', () => {
+    const result = advanceStage('capture', 'execute');
+    expect(result.allowed).toBe(false);
+    expect(result.reason).toContain('Cannot transition');
+  });
+
+  it('rejects backward non-cyclic: verify -> capture', () => {
+    const result = advanceStage('verify', 'capture');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('rejects same stage: execute -> execute', () => {
+    const result = advanceStage('execute', 'execute');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('rejects backward: package -> crystallize', () => {
+    const result = advanceStage('package', 'crystallize');
+    expect(result.allowed).toBe(false);
+  });
+
+  it('rejects skipping from route to govern', () => {
+    const result = advanceStage('route', 'govern');
+    expect(result.allowed).toBe(false);
+  });
+});

--- a/src/skills/lifecycle.ts
+++ b/src/skills/lifecycle.ts
@@ -1,0 +1,52 @@
+import type { LifecycleStage } from '../schemas/skill-object';
+
+const STAGE_ORDER: LifecycleStage[] = [
+  'capture',
+  'crystallize',
+  'package',
+  'route',
+  'execute',
+  'verify',
+  'learn',
+  'govern',
+];
+
+/**
+ * Validates whether a stage transition is allowed.
+ *
+ * Rules:
+ * - Linear forward progression (next stage only)
+ * - Cyclic loop: execute -> verify -> learn -> execute (stages 5-7)
+ * - Govern -> execute re-entry (after governance review)
+ * - All other transitions rejected
+ */
+export function advanceStage(
+  current: LifecycleStage,
+  target: LifecycleStage,
+): { allowed: boolean; reason: string } {
+  const currentIdx = STAGE_ORDER.indexOf(current);
+  const targetIdx = STAGE_ORDER.indexOf(target);
+
+  // Forward progression: next stage in order
+  if (targetIdx === currentIdx + 1) {
+    return { allowed: true, reason: `Advanced from ${current} to ${target}` };
+  }
+
+  // Cyclic: learn -> execute (re-enter execution loop)
+  if (current === 'learn' && target === 'execute') {
+    return { allowed: true, reason: 'Cyclic: re-entering execute from learn' };
+  }
+
+  // Govern -> execute (re-entry after governance review)
+  if (current === 'govern' && target === 'execute') {
+    return {
+      allowed: true,
+      reason: 'Re-entering execute after governance',
+    };
+  }
+
+  return {
+    allowed: false,
+    reason: `Cannot transition from ${current} to ${target}`,
+  };
+}


### PR DESCRIPTION
Add skill_instances and skill_runs tables. Implement advanceStage with linear progression, cyclic execute-verify-learn loop, and govern-to-execute re-entry. Closes #123