### PR TITLE
feat(containers): implement container transitions + World spawn

### DIFF
--- a/src/containers/transitions.test.ts
+++ b/src/containers/transitions.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import { checkContainerTransition, spawnFromWorld } from './transitions';
+import type { Container } from './types';
+
+describe('checkContainerTransition', () => {
+  describe('allowed transitions', () => {
+    const allowedCases: [Container, Container][] = [
+      ['shape', 'skill'],
+      ['shape', 'world'],
+      ['shape', 'task'],
+      ['shape', 'harvest'],
+      ['task', 'harvest'],
+      ['skill', 'review'],
+      ['skill', 'harvest'],
+      ['review', 'skill'],
+      ['review', 'task'],
+      ['review', 'harvest'],
+    ];
+
+    it.each(allowedCases)('%s -> %s is allowed', (from, to) => {
+      const result = checkContainerTransition(from, to, 'test reason');
+      expect(result.allowed).toBe(true);
+      expect(result.newContainer).toBe(to);
+      expect(result.reason).toBe('test reason');
+    });
+  });
+
+  describe('same-container transition (no-op)', () => {
+    const containers: Container[] = ['world', 'shape', 'skill', 'task', 'review', 'harvest'];
+
+    it.each(containers)('%s -> %s is allowed (no-op)', (container) => {
+      const result = checkContainerTransition(container, container, 'ignored');
+      expect(result.allowed).toBe(true);
+      expect(result.newContainer).toBe(container);
+      expect(result.reason).toBe('No transition needed');
+    });
+  });
+
+  describe('disallowed transitions', () => {
+    const disallowedCases: [Container, Container][] = [
+      // World has no exit transitions
+      ['world', 'shape'],
+      ['world', 'skill'],
+      ['world', 'task'],
+      ['world', 'review'],
+      ['world', 'harvest'],
+      // Harvest is terminal
+      ['harvest', 'shape'],
+      ['harvest', 'world'],
+      ['harvest', 'skill'],
+      ['harvest', 'task'],
+      ['harvest', 'review'],
+      // Task can only go to harvest
+      ['task', 'shape'],
+      ['task', 'skill'],
+      ['task', 'world'],
+      ['task', 'review'],
+      // Skill can only go to review or harvest
+      ['skill', 'shape'],
+      ['skill', 'world'],
+      ['skill', 'task'],
+      // Shape cannot go to review
+      ['shape', 'review'],
+      // Review cannot go to world or shape
+      ['review', 'world'],
+      ['review', 'shape'],
+    ];
+
+    it.each(disallowedCases)('%s -> %s is disallowed', (from, to) => {
+      const result = checkContainerTransition(from, to, 'test reason');
+      expect(result.allowed).toBe(false);
+      expect(result.newContainer).toBe(from);
+      expect(result.reason).toContain('not allowed');
+    });
+  });
+});
+
+describe('spawnFromWorld', () => {
+  it('spawns shape from world', () => {
+    const result = spawnFromWorld('world-1', 'shape', 'fuzzy sub-problem');
+    expect(result).not.toBeNull();
+    expect(result!.parentWorld).toBe('world-1');
+    expect(result!.childContainer).toBe('shape');
+    expect(result!.childId).toMatch(/^world-1:shape:\d+$/);
+    expect(result!.reason).toBe('fuzzy sub-problem');
+  });
+
+  it('spawns task from world', () => {
+    const result = spawnFromWorld('world-1', 'task', 'bounded work item');
+    expect(result).not.toBeNull();
+    expect(result!.childContainer).toBe('task');
+  });
+
+  it('spawns skill from world', () => {
+    const result = spawnFromWorld('world-1', 'skill', 'known capability');
+    expect(result).not.toBeNull();
+    expect(result!.childContainer).toBe('skill');
+  });
+
+  it('spawns review from world', () => {
+    const result = spawnFromWorld('world-1', 'review', 'investigate');
+    expect(result).not.toBeNull();
+    expect(result!.childContainer).toBe('review');
+  });
+
+  it('spawns harvest from world', () => {
+    const result = spawnFromWorld('world-1', 'harvest', 'capture pattern');
+    expect(result).not.toBeNull();
+    expect(result!.childContainer).toBe('harvest');
+  });
+
+  it('cannot spawn world (no recursive worlds)', () => {
+    const result = spawnFromWorld('world-1', 'world', 'nested world');
+    expect(result).toBeNull();
+  });
+});

--- a/src/containers/transitions.ts
+++ b/src/containers/transitions.ts
@@ -1,0 +1,87 @@
+import type { Container } from './types';
+
+export interface TransitionResult {
+  allowed: boolean;
+  newContainer: Container;
+  reason: string;
+}
+
+export interface SpawnResult {
+  parentWorld: string;
+  childContainer: Container;
+  childId: string;
+  reason: string;
+}
+
+/**
+ * Valid container transitions (replace current container).
+ *
+ * From spec Section 5:
+ * - Shape  -> Skill, World, Task, Harvest
+ * - Task   -> Harvest
+ * - Skill  -> Review, Harvest
+ * - Review -> Skill, Task, Harvest
+ * - World  -> (no exit transitions, uses spawn)
+ * - Harvest -> (terminal)
+ */
+const VALID_TRANSITIONS: Record<string, Container[]> = {
+  shape: ['skill', 'world', 'task', 'harvest'],
+  task: ['harvest'],
+  skill: ['review', 'harvest'],
+  review: ['skill', 'task', 'harvest'],
+  // world and harvest have no exit transitions
+};
+
+/**
+ * Containers that World can spawn. World cannot spawn World (no recursion in v0).
+ */
+const SPAWNABLE_CONTAINERS: Container[] = ['shape', 'task', 'skill', 'review', 'harvest'];
+
+/**
+ * Check whether a container transition from `current` to `proposed` is allowed.
+ *
+ * Same-container "transition" is always allowed (no-op).
+ * World has no exit transitions; Harvest is terminal.
+ */
+export function checkContainerTransition(
+  current: Container,
+  proposed: Container,
+  reason: string,
+): TransitionResult {
+  if (current === proposed) {
+    return { allowed: true, newContainer: current, reason: 'No transition needed' };
+  }
+  const valid = VALID_TRANSITIONS[current] ?? [];
+  if (valid.includes(proposed)) {
+    return { allowed: true, newContainer: proposed, reason };
+  }
+  return {
+    allowed: false,
+    newContainer: current,
+    reason: `Transition ${current} \u2192 ${proposed} not allowed`,
+  };
+}
+
+/**
+ * Spawn a child container from a World.
+ *
+ * World is a persistent environment that spawns child containers instead of
+ * transitioning. Cannot spawn World (no recursive worlds in v0).
+ *
+ * Returns null if the child container type is not spawnable.
+ */
+export function spawnFromWorld(
+  worldId: string,
+  childContainer: Container,
+  reason: string,
+): SpawnResult | null {
+  if (!SPAWNABLE_CONTAINERS.includes(childContainer)) {
+    return null;
+  }
+  return {
+    parentWorld: worldId,
+    childContainer,
+    childId: `${worldId}:${childContainer}:${Date.now()}`,
+    reason,
+  };
+}


### PR DESCRIPTION
## Summary
- VALID_TRANSITIONS table per spec
- checkContainerTransition validates current → proposed
- spawnFromWorld with parentWorld link
- World spawn only, Harvest terminal

Closes #122

## Test plan
- [x] 27 tests, all allowed/disallowed transitions + spawn
- [x] `bun run build && bun run lint && bun test` pass (865 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)