### PR TITLE
feat: add secondary indexes on high-frequency query columns

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -42,6 +42,18 @@ describe('DB Layer — initSchema', () => {
     expect(names).toContain('decision_events');
   });
 
+  it('creates secondary indexes on high-frequency columns', () => {
+    const indexes = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%' ORDER BY name")
+      .all() as { name: string }[];
+    const names = indexes.map((i) => i.name);
+    expect(names).toContain('idx_cards_conv_version');
+    expect(names).toContain('idx_messages_conv_turn');
+    expect(names).toContain('idx_card_diffs_card');
+    expect(names).toContain('idx_decision_sessions_status');
+    expect(names).toContain('idx_candidate_records_session');
+  });
+
   it('is idempotent (can call initSchema twice)', () => {
     expect(() => { initSchema(db); }).not.toThrow();
   });

--- a/src/db.ts
+++ b/src/db.ts
@@ -209,4 +209,12 @@ export function initSchema(db: Database): void {
     notes TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`);
+
+  // ─── Secondary Indexes ───
+
+  db.run('CREATE INDEX IF NOT EXISTS idx_cards_conv_version ON cards(conversation_id, version)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_messages_conv_turn ON messages(conversation_id, turn)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_card_diffs_card ON card_diffs(card_id)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_decision_sessions_status ON decision_sessions(status)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_candidate_records_session ON candidate_records(session_id)');
 }


### PR DESCRIPTION
## Summary

- Add 5 `CREATE INDEX IF NOT EXISTS` statements to `initSchema()` in `src/db.ts` targeting high-frequency query columns
- Add test to verify all 5 indexes are created after schema initialization
- Indexes: `cards(conversation_id, version)`, `messages(conversation_id, turn)`, `card_diffs(card_id)`, `decision_sessions(status)`, `candidate_records(session_id)`

Closes #171

## Test plan

- [x] New test `creates secondary indexes on high-frequency columns` verifies all 5 indexes exist via `sqlite_master`
- [x] Existing idempotency test covers `IF NOT EXISTS` safety on re-run
- [x] `bun run build` passes (zero type errors)
- [x] `bun run lint` passes (zero lint errors)
- [x] `bun test src/db.test.ts` -- all 55 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)