### PR TITLE
feat(skills): implement crystallize + package (generate skeleton)

### DIFF
--- a/src/skills/crystallizer.test.ts
+++ b/src/skills/crystallizer.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import { crystallize } from './crystallizer';
+import type { SkillCandidate } from './harvest';
+import { SkillObjectSchema } from '../schemas/skill-object';
+
+// ─── Test Fixtures ───
+
+const FULL_CANDIDATE: SkillCandidate = {
+  name: 'deploy-service',
+  summary: 'Deploy a service to staging/production with smoke tests',
+  problemShapes: ['need to deploy a service safely'],
+  desiredOutcomes: ['service running in target environment'],
+  nonGoals: ['infrastructure provisioning'],
+  triggerWhen: ['user requests deploy of specific service'],
+  doNotTriggerWhen: ['no artifact specified', 'target env unclear'],
+  methodOutline: ['build artifact', 'deploy to staging', 'run smoke tests', 'promote to prod'],
+  observedGotchas: ['healthcheck green does not mean checkout path safe'],
+};
+
+const CANDIDATE_NO_ANTI_TRIGGERS: SkillCandidate = {
+  name: 'code-review',
+  summary: 'Review code for quality and correctness',
+  problemShapes: ['code needs review before merge'],
+  desiredOutcomes: ['reviewed code with actionable feedback'],
+  nonGoals: ['automated fixing'],
+  triggerWhen: ['PR opened for review'],
+  doNotTriggerWhen: [],
+  methodOutline: ['read diff', 'check for issues', 'leave comments'],
+  observedGotchas: ['style nits distract from logic errors'],
+};
+
+const CANDIDATE_NO_ANTI_NO_GOTCHAS: SkillCandidate = {
+  name: 'quick-search',
+  summary: 'Search codebase for patterns',
+  problemShapes: ['need to find code references'],
+  desiredOutcomes: ['list of matching files'],
+  nonGoals: ['refactoring'],
+  triggerWhen: ['user asks to find something in code'],
+  doNotTriggerWhen: [],
+  methodOutline: ['grep codebase'],
+  observedGotchas: [],
+};
+
+const CANDIDATE_ALL_EMPTY_FALLBACKS: SkillCandidate = {
+  name: 'bare-skill',
+  summary: 'Minimal skill with no extras',
+  problemShapes: ['generic problem'],
+  desiredOutcomes: ['generic outcome'],
+  nonGoals: [],
+  triggerWhen: ['always'],
+  doNotTriggerWhen: [],
+  methodOutline: ['do the thing'],
+  observedGotchas: [],
+};
+
+// ─── Tests ───
+
+describe('crystallize', () => {
+  it('produces output that passes SkillObjectSchema.safeParse', () => {
+    const result = crystallize(FULL_CANDIDATE);
+
+    const parsed = SkillObjectSchema.safeParse(result.skillObject);
+    expect(parsed.success).toBe(true);
+  });
+
+  it('sets status to draft', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.skillObject.status).toBe('draft');
+  });
+
+  it('sets currentStage to crystallize', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.skillObject.lifecycle?.currentStage).toBe('crystallize');
+  });
+
+  it('generates a kebab-case id from candidate name', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.skillObject.id).toBe('skill.deploy-service');
+  });
+
+  it('populates routing.doNotTriggerWhen from candidate', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.skillObject.routing.doNotTriggerWhen).toEqual([
+      'no artifact specified',
+      'target env unclear',
+    ]);
+  });
+
+  it('derives doNotTriggerWhen from gotchas when candidate.doNotTriggerWhen is empty', () => {
+    const result = crystallize(CANDIDATE_NO_ANTI_TRIGGERS);
+    expect(result.skillObject.routing.doNotTriggerWhen.length).toBeGreaterThan(0);
+    expect(result.skillObject.routing.doNotTriggerWhen[0]).toBe(
+      'style nits distract from logic errors',
+    );
+  });
+
+  it('derives doNotTriggerWhen from nonGoals when gotchas also empty', () => {
+    const result = crystallize(CANDIDATE_NO_ANTI_NO_GOTCHAS);
+    expect(result.skillObject.routing.doNotTriggerWhen.length).toBeGreaterThan(0);
+    expect(result.skillObject.routing.doNotTriggerWhen[0]).toBe('refactoring');
+  });
+
+  it('falls back to placeholder when all sources are empty', () => {
+    const result = crystallize(CANDIDATE_ALL_EMPTY_FALLBACKS);
+    expect(result.skillObject.routing.doNotTriggerWhen.length).toBeGreaterThan(0);
+    expect(result.skillObject.routing.doNotTriggerWhen[0]).toContain(
+      'not yet defined',
+    );
+  });
+
+  it('doNotTriggerWhen is never empty regardless of input', () => {
+    const candidates = [
+      FULL_CANDIDATE,
+      CANDIDATE_NO_ANTI_TRIGGERS,
+      CANDIDATE_NO_ANTI_NO_GOTCHAS,
+      CANDIDATE_ALL_EMPTY_FALLBACKS,
+    ];
+    for (const candidate of candidates) {
+      const result = crystallize(candidate);
+      expect(result.skillObject.routing.doNotTriggerWhen.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('produces valid yaml string', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.yaml).toContain('kind: SkillObject');
+    expect(result.yaml).toContain('deploy-service');
+  });
+
+  it('SKILL.md contains When to Use section', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.skillMd).toContain('## When to Use');
+    expect(result.skillMd).toContain('user requests deploy of specific service');
+  });
+
+  it('SKILL.md contains When NOT to Use section', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.skillMd).toContain('## When NOT to Use');
+    expect(result.skillMd).toContain('no artifact specified');
+  });
+
+  it('SKILL.md contains Method section', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.skillMd).toContain('## Method');
+    expect(result.skillMd).toContain('1. build artifact');
+  });
+
+  it('SKILL.md contains Known Gotchas section', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.skillMd).toContain('## Known Gotchas');
+    expect(result.skillMd).toContain('healthcheck green');
+  });
+
+  it('maps candidate fields to correct SkillObject sections', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    expect(result.skillObject.identity.summary).toBe(FULL_CANDIDATE.summary);
+    expect(result.skillObject.purpose.problemShapes).toEqual(FULL_CANDIDATE.problemShapes);
+    expect(result.skillObject.purpose.desiredOutcomes).toEqual(FULL_CANDIDATE.desiredOutcomes);
+    expect(result.skillObject.purpose.nonGoals).toEqual(FULL_CANDIDATE.nonGoals);
+    expect(result.skillObject.routing.triggerWhen).toEqual(FULL_CANDIDATE.triggerWhen);
+    expect(result.skillObject.contract.successCriteria).toEqual(FULL_CANDIDATE.desiredOutcomes);
+  });
+
+  it('all 12 sections are populated in the output', () => {
+    const result = crystallize(FULL_CANDIDATE);
+    const obj = result.skillObject;
+    expect(obj.identity).toBeDefined();
+    expect(obj.purpose).toBeDefined();
+    expect(obj.routing).toBeDefined();
+    expect(obj.contract).toBeDefined();
+    expect(obj.package).toBeDefined();
+    expect(obj.environment).toBeDefined();
+    expect(obj.dispatch).toBeDefined();
+    expect(obj.verification).toBeDefined();
+    expect(obj.memory).toBeDefined();
+    expect(obj.governance).toBeDefined();
+    expect(obj.telemetry).toBeDefined();
+    expect(obj.lifecycle).toBeDefined();
+  });
+});

--- a/src/skills/crystallizer.ts
+++ b/src/skills/crystallizer.ts
@@ -1,0 +1,191 @@
+import type { SkillCandidate } from './harvest';
+import type { SkillObject } from '../schemas/skill-object';
+import { SkillObjectSchema } from '../schemas/skill-object';
+import { serializeSkillObject } from './yaml-parser';
+
+// ─── Result Type ───
+
+export interface CrystallizeResult {
+  yaml: string;
+  skillMd: string;
+  skillObject: SkillObject;
+}
+
+// ─── Helpers ───
+
+function toKebabCase(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function deriveAntiTriggers(candidate: SkillCandidate): string[] {
+  if (candidate.doNotTriggerWhen.length > 0) {
+    return candidate.doNotTriggerWhen;
+  }
+  // Derive from observedGotchas if available
+  if (candidate.observedGotchas.length > 0) {
+    return [candidate.observedGotchas[0]];
+  }
+  // Fall back to nonGoals
+  if (candidate.nonGoals.length > 0) {
+    return [candidate.nonGoals[0]];
+  }
+  return ['not yet defined — must be filled before promotion'];
+}
+
+function generateSkillMd(candidate: SkillCandidate, antiTriggers: string[]): string {
+  return `# ${candidate.name}
+
+${candidate.summary}
+
+## When to Use
+
+${candidate.triggerWhen.map((t) => `- ${t}`).join('\n')}
+
+## When NOT to Use
+
+${antiTriggers.map((t) => `- ${t}`).join('\n')}
+
+## Method
+
+${candidate.methodOutline.map((step, i) => `${i + 1}. ${step}`).join('\n')}
+
+## Known Gotchas
+
+${candidate.observedGotchas.map((g) => `- ${g}`).join('\n')}
+`;
+}
+
+// ─── Main Function ───
+
+export function crystallize(candidate: SkillCandidate): CrystallizeResult {
+  const kebab = toKebabCase(candidate.name);
+  const antiTriggers = deriveAntiTriggers(candidate);
+
+  const skillObject: SkillObject = {
+    kind: 'SkillObject',
+    apiVersion: 'volva.ai/v0',
+    id: `skill.${kebab}`,
+    name: candidate.name,
+    version: '0.1.0',
+    status: 'draft',
+    identity: {
+      summary: candidate.summary,
+      owners: { human: [], agent: [] },
+      domain: '',
+      tags: [],
+      maturity: 'emerging',
+      riskTier: 'low',
+    },
+    purpose: {
+      problemShapes: candidate.problemShapes,
+      desiredOutcomes: candidate.desiredOutcomes,
+      nonGoals: candidate.nonGoals,
+      notFor: [],
+    },
+    routing: {
+      description: candidate.summary,
+      triggerWhen: candidate.triggerWhen,
+      doNotTriggerWhen: antiTriggers,
+      priority: 50,
+      conflictsWith: [],
+      mayChainTo: [],
+    },
+    contract: {
+      inputs: { required: [], optional: [] },
+      outputs: { primary: [], secondary: [] },
+      successCriteria: candidate.desiredOutcomes,
+      failureModes: [],
+    },
+    package: {
+      root: `skills/${kebab}/`,
+      entryFile: 'SKILL.md',
+      references: [],
+      scripts: [],
+      assets: [],
+      config: { schemaFile: 'config.schema.json', dataFile: 'config.json' },
+      hooks: [],
+      localState: {
+        enabled: true,
+        stablePath: `\${SKILL_DATA}/${kebab}/`,
+        files: [],
+      },
+    },
+    environment: {
+      toolsRequired: [],
+      toolsOptional: [],
+      permissions: {
+        filesystem: { read: true, write: false },
+        network: { read: false, write: false },
+        process: { spawn: false },
+        secrets: { read: [] },
+      },
+      externalSideEffects: false,
+      executionMode: 'advisory',
+    },
+    dispatch: {
+      mode: 'local',
+      targetSelection: { repoPolicy: 'explicit', runtimeOptions: [] },
+      workerClass: [],
+      handoff: { inputArtifacts: [], outputArtifacts: [] },
+      executionPolicy: {
+        sync: false,
+        retries: 1,
+        timeoutMinutes: 30,
+        escalationOnFailure: true,
+      },
+      approval: { requireHumanBeforeDispatch: false, requireHumanBeforeMerge: true },
+    },
+    verification: {
+      smokeChecks: [],
+      assertions: [],
+      humanCheckpoints: [],
+      outcomeSignals: [],
+    },
+    memory: {
+      localMemoryPolicy: {
+        canStore: [],
+        cannotStore: ['secrets', 'unrelated-user-data'],
+      },
+      precedentWriteback: { enabled: true, target: 'edda', when: [] },
+    },
+    governance: {
+      mutability: {
+        agentMayEdit: [],
+        agentMayPropose: [],
+        humanApprovalRequired: [],
+        forbiddenWithoutHuman: [],
+      },
+      reviewPolicy: { requiredReviewers: ['owner'] },
+      promotionGates: [],
+      rollbackPolicy: { allowed: true, rollbackOn: [] },
+      supersession: { supersedes: [], supersededBy: null },
+    },
+    telemetry: {
+      track: [{ metric: 'run_count' }, { metric: 'success_count' }, { metric: 'last_used_at' }],
+      thresholds: { promotion_min_success: 3, retirement_idle_days: 90 },
+      reporting: { target: 'edda', frequency: 'on_governance' },
+    },
+    lifecycle: {
+      createdFrom: [],
+      currentStage: 'crystallize',
+      promotionPath: ['draft', 'sandbox', 'promoted', 'core'],
+      retirementCriteria: [],
+      lastReviewedAt: null,
+    },
+  };
+
+  // Validate output against schema
+  const parsed = SkillObjectSchema.safeParse(skillObject);
+  if (!parsed.success) {
+    throw new Error(`crystallize produced invalid SkillObject: ${parsed.error.message}`);
+  }
+
+  const yaml = serializeSkillObject(parsed.data);
+  const skillMd = generateSkillMd(candidate, antiTriggers);
+
+  return { yaml, skillMd, skillObject: parsed.data };
+}


### PR DESCRIPTION
Closes #127 - crystallize converts SkillCandidate to valid SkillObject + SKILL.md with sensible defaults. doNotTriggerWhen never empty (Gate 3). All 920 tests pass.