### PR TITLE
feat(decision): implement economic + governance regime evaluators

### DIFF
--- a/src/decision/evaluators/economic.ts
+++ b/src/decision/evaluators/economic.ts
@@ -1,0 +1,65 @@
+import type { EvaluatorInput, EvaluatorOutput } from '../../schemas/decision';
+import { EvaluatorOutputSchema } from '../../schemas/decision';
+import type { LLMClient } from '../../llm/client';
+import { defaultHoldOutput } from './types';
+
+const ECONOMIC_EVALUATOR_PROMPT = `You are an economic regime evaluator for a decision system.
+
+Your job is to assess whether a realization candidate has received enough real-world economic authorization (buyer / payment-adjacent signals) to justify committing to a build phase.
+
+You must evaluate 4 signals:
+
+A. **Buyer shape exists**: Is there a specific buyer type, pain point, and context — not just an abstract market?
+B. **Payment-adjacent signal exists**: Has there been price conversation, trial willingness, booking requests, or small payment?
+C. **Delivery looks possible**: Can the user actually fulfill what would be offered?
+D. **Build is now the bottleneck**: Would building unlock the next signal, or should more market probing happen first?
+
+Verdict rules:
+- **commit**: At least one buyer willing to discuss actual delivery; value proposition survives scrutiny; acquisition friction is reasonable; build would improve next signal quality.
+- **hold**: Interest exists but not yet payment-adjacent; buyer shape is unstable; worth another probe round but not a build.
+- **discard**: Signals are vague interest only; value proposition collapses under specifics; must build extensively before knowing if it sells; no edge over consensus paths.
+
+Output a JSON object with: verdict, rationale, evidenceUsed, unresolvedRisks, recommendedNextStep, and optionally handoffNotes.`;
+
+function buildEconomicPrompt(input: EvaluatorInput): string {
+  const candidateStr = JSON.stringify(input.candidate, null, 2);
+  const probeStr = JSON.stringify(input.probeableForm, null, 2);
+  const signalsStr = input.signals.length > 0
+    ? JSON.stringify(input.signals, null, 2)
+    : 'No signals collected yet.';
+
+  return `Evaluate this candidate under the ECONOMIC regime.
+
+## Candidate
+${candidateStr}
+
+## Probeable Form
+${probeStr}
+
+## Collected Signals
+${signalsStr}
+
+Assess the 4 economic signals (buyer shape, payment-adjacent signal, delivery feasibility, build-is-bottleneck) and produce your verdict.`;
+}
+
+export async function evaluateEconomic(
+  llm: LLMClient,
+  input: EvaluatorInput,
+): Promise<EvaluatorOutput> {
+  try {
+    const result = await llm.generateStructured({
+      system: ECONOMIC_EVALUATOR_PROMPT,
+      messages: [{ role: 'user', content: buildEconomicPrompt(input) }],
+      schema: EvaluatorOutputSchema,
+      schemaDescription: 'Economic evaluator verdict with rationale, evidenceUsed, unresolvedRisks, recommendedNextStep',
+    });
+
+    if (!result.ok) {
+      return defaultHoldOutput('Economic evaluation failed: ' + result.error);
+    }
+
+    return result.data;
+  } catch (error) {
+    return defaultHoldOutput(error instanceof Error ? error.message : 'Unknown error');
+  }
+}

--- a/src/decision/evaluators/governance.ts
+++ b/src/decision/evaluators/governance.ts
@@ -1,0 +1,65 @@
+import type { EvaluatorInput, EvaluatorOutput } from '../../schemas/decision';
+import { EvaluatorOutputSchema } from '../../schemas/decision';
+import type { LLMClient } from '../../llm/client';
+import { defaultHoldOutput } from './types';
+
+const GOVERNANCE_EVALUATOR_PROMPT = `You are a governance regime evaluator for a decision system.
+
+Your job is to assess whether a realization candidate has enough world density, closure mechanisms, and consequence observability to justify instantiating it as a live governed world.
+
+You must evaluate 4 signals:
+
+A. **Minimum world has shape**: Are state, change, role, and metrics defined — not just a topic or aesthetic?
+B. **One closure exists**: Can the full governance cycle run: observe -> propose -> judge -> apply -> outcome -> precedent?
+C. **Consequences are visible**: Does changing the world produce observable, measurable results?
+D. **Build will instantiate a world, not a dashboard**: Is this genuine governance with state and pressure, not just a tool with world aesthetics?
+
+Verdict rules:
+- **commit**: Minimum world shape exists; at least one closure cycle can run; pulse/outcome/precedent are real; what's missing is instantiation, not more imagination.
+- **hold**: World form is promising but closure is incomplete — e.g., outcome visibility is unclear or governance pressure is not yet defined.
+- **discard**: Essentially a tool wearing world aesthetics; or an aesthetic shell without governance density.
+
+Output a JSON object with: verdict, rationale, evidenceUsed, unresolvedRisks, recommendedNextStep, and optionally handoffNotes.`;
+
+function buildGovernancePrompt(input: EvaluatorInput): string {
+  const candidateStr = JSON.stringify(input.candidate, null, 2);
+  const probeStr = JSON.stringify(input.probeableForm, null, 2);
+  const signalsStr = input.signals.length > 0
+    ? JSON.stringify(input.signals, null, 2)
+    : 'No signals collected yet.';
+
+  return `Evaluate this candidate under the GOVERNANCE regime.
+
+## Candidate
+${candidateStr}
+
+## Probeable Form
+${probeStr}
+
+## Collected Signals
+${signalsStr}
+
+Assess the 4 governance signals (world shape, closure existence, consequence visibility, world-not-dashboard) and produce your verdict.`;
+}
+
+export async function evaluateGovernance(
+  llm: LLMClient,
+  input: EvaluatorInput,
+): Promise<EvaluatorOutput> {
+  try {
+    const result = await llm.generateStructured({
+      system: GOVERNANCE_EVALUATOR_PROMPT,
+      messages: [{ role: 'user', content: buildGovernancePrompt(input) }],
+      schema: EvaluatorOutputSchema,
+      schemaDescription: 'Governance evaluator verdict with rationale, evidenceUsed, unresolvedRisks, recommendedNextStep',
+    });
+
+    if (!result.ok) {
+      return defaultHoldOutput('Governance evaluation failed: ' + result.error);
+    }
+
+    return result.data;
+  } catch (error) {
+    return defaultHoldOutput(error instanceof Error ? error.message : 'Unknown error');
+  }
+}

--- a/src/decision/evaluators/types.ts
+++ b/src/decision/evaluators/types.ts
@@ -1,0 +1,16 @@
+import type { EvaluatorInput, EvaluatorOutput } from '../../schemas/decision';
+import type { LLMClient } from '../../llm/client';
+
+export interface Evaluator {
+  evaluate(llm: LLMClient, input: EvaluatorInput): Promise<EvaluatorOutput>;
+}
+
+export function defaultHoldOutput(reason: string): EvaluatorOutput {
+  return {
+    verdict: 'hold',
+    rationale: ['Evaluation could not complete: ' + reason],
+    evidenceUsed: [],
+    unresolvedRisks: ['Evaluation incomplete'],
+    recommendedNextStep: ['Retry evaluation with more context'],
+  };
+}


### PR DESCRIPTION
## Summary
- evaluateEconomic: buyer/payment/delivery/bottleneck signals
- evaluateGovernance: density/closure/consequence/instantiation
- LLM + Zod (LLM-01), try/catch (LLM-02), defaultHoldOutput fallback

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)