### PR TITLE
feat(decision): implement commit memo generation + Track E tests

### DIFF
--- a/src/decision/commit-memo.test.ts
+++ b/src/decision/commit-memo.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from 'vitest';
+import { buildCommitMemo } from './commit-memo';
+import type {
+  EvaluatorOutput,
+  RealizationCandidate,
+  EconomicCommitMemo,
+  GovernanceCommitMemo,
+} from '../schemas/decision';
+
+function makeCandidate(overrides: Partial<RealizationCandidate> = {}): RealizationCandidate {
+  return {
+    id: 'cand-1',
+    regime: 'economic',
+    form: 'service',
+    description: 'Consulting service for small businesses',
+    whyThisCandidate: ['Strong buyer demand', 'Low competition'],
+    assumptions: ['Buyers will pay $500/month', 'Pain is acute enough'],
+    probeReadinessHints: ['Landing page ready'],
+    timeToSignal: 'short',
+    notes: ['Focus on onboarding flow'],
+    ...overrides,
+  };
+}
+
+function makeEvaluatorOutput(overrides: Partial<EvaluatorOutput> = {}): EvaluatorOutput {
+  return {
+    verdict: 'commit',
+    rationale: ['Strong buyer signals', 'Payment willingness observed'],
+    evidenceUsed: ['buyer interview confirmed pain', 'payment discussion started'],
+    unresolvedRisks: ['Churn risk unknown'],
+    recommendedNextStep: ['Build MVP landing page', 'Run first paid pilot'],
+    handoffNotes: ['Buyer segment is SMB owners'],
+    ...overrides,
+  };
+}
+
+describe('buildCommitMemo', () => {
+  describe('economic regime', () => {
+    it('builds EconomicCommitMemo with all 5 specialized fields', () => {
+      const candidate = makeCandidate({ regime: 'economic' });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.regime).toBe('economic');
+      expect(memo.candidateId).toBe('cand-1');
+      expect(memo.verdict).toBe('commit');
+
+      const econ = memo as EconomicCommitMemo;
+      expect(econ.buyerHypothesis).toBeDefined();
+      expect(econ.buyerHypothesis.length).toBeGreaterThan(0);
+      expect(econ.painHypothesis).toBeDefined();
+      expect(econ.painHypothesis.length).toBeGreaterThan(0);
+      expect(econ.paymentEvidence).toBeDefined();
+      expect(econ.whyThisVehicleNow).toEqual(candidate.whyThisCandidate);
+      expect(econ.nextSignalAfterBuild).toEqual(output.recommendedNextStep);
+    });
+
+    it('filters paymentEvidence to only payment-related items', () => {
+      const candidate = makeCandidate({ regime: 'economic' });
+      const output = makeEvaluatorOutput({
+        evidenceUsed: ['buyer confirmed pain', 'payment of $100 received', 'general interest noted'],
+      });
+
+      const memo = buildCommitMemo(output, candidate) as EconomicCommitMemo;
+
+      expect(memo.paymentEvidence).toContain('payment of $100 received');
+      expect(memo.paymentEvidence).not.toContain('general interest noted');
+    });
+  });
+
+  describe('governance regime', () => {
+    it('builds GovernanceCommitMemo with all 6 specialized fields', () => {
+      const candidate = makeCandidate({
+        regime: 'governance',
+        worldForm: 'commons',
+      });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.regime).toBe('governance');
+
+      const gov = memo as GovernanceCommitMemo;
+      expect(gov.selectedWorldForm).toBe('commons');
+      expect(gov.minimumWorldShape).toBeDefined();
+      expect(gov.stateDensityAssessment).toBeDefined();
+      expect(gov.governancePressureAssessment).toBeDefined();
+      expect(gov.firstCycleDesign).toBeDefined();
+      expect(gov.firstCycleDesign.length).toBeGreaterThan(0);
+      expect(gov.thyraHandoffRequirements).toBeDefined();
+      expect(gov.thyraHandoffRequirements.length).toBeGreaterThan(0);
+    });
+
+    it('defaults selectedWorldForm to market when not specified', () => {
+      const candidate = makeCandidate({
+        regime: 'governance',
+        worldForm: undefined,
+      });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate) as GovernanceCommitMemo;
+
+      expect(memo.selectedWorldForm).toBe('market');
+    });
+  });
+
+  describe('unknown/other regime', () => {
+    it('returns base CommitMemo without specialization for capability regime', () => {
+      const candidate = makeCandidate({ regime: 'capability' });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.regime).toBe('capability');
+      expect(memo.candidateId).toBe('cand-1');
+      expect('buyerHypothesis' in memo).toBe(false);
+      expect('selectedWorldForm' in memo).toBe(false);
+    });
+  });
+
+  describe('whatForgeShouldBuild', () => {
+    it('is always populated from recommendedNextStep and handoffNotes', () => {
+      const candidate = makeCandidate({ regime: 'economic' });
+      const output = makeEvaluatorOutput({
+        recommendedNextStep: ['Build landing page'],
+        handoffNotes: ['Target SMB segment'],
+      });
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.whatForgeShouldBuild.length).toBeGreaterThan(0);
+      expect(memo.whatForgeShouldBuild).toContain('Build landing page');
+      expect(memo.whatForgeShouldBuild).toContain('Target SMB segment');
+    });
+
+    it('provides fallback when no steps or notes exist', () => {
+      const candidate = makeCandidate({ regime: 'capability' });
+      const output = makeEvaluatorOutput({
+        recommendedNextStep: [],
+        handoffNotes: undefined,
+      });
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.whatForgeShouldBuild.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('whatForgeMustNotBuild', () => {
+    it('is always populated', () => {
+      const candidate = makeCandidate({ regime: 'economic' });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.whatForgeMustNotBuild.length).toBeGreaterThan(0);
+    });
+
+    it('includes economic-specific warning for economic regime', () => {
+      const candidate = makeCandidate({ regime: 'economic' });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.whatForgeMustNotBuild).toContain('Full product before buyer validation');
+    });
+
+    it('includes governance-specific warning for governance regime', () => {
+      const candidate = makeCandidate({ regime: 'governance', worldForm: 'market' });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.whatForgeMustNotBuild).toContain('Dashboard instead of world');
+    });
+  });
+
+  describe('verdict', () => {
+    it('matches evaluator output verdict', () => {
+      const candidate = makeCandidate({ regime: 'economic' });
+
+      for (const verdict of ['commit', 'hold', 'discard'] as const) {
+        const output = makeEvaluatorOutput({ verdict });
+        const memo = buildCommitMemo(output, candidate);
+        expect(memo.verdict).toBe(verdict);
+      }
+    });
+  });
+});

--- a/src/decision/commit-memo.ts
+++ b/src/decision/commit-memo.ts
@@ -1,0 +1,187 @@
+import type {
+  CommitMemo,
+  EconomicCommitMemo,
+  GovernanceCommitMemo,
+  EvaluatorOutput,
+  RealizationCandidate,
+  GovernanceWorldCandidate,
+} from '../schemas/decision';
+
+// ─── Helper Functions ───
+
+const PAYMENT_KEYWORDS = ['payment', 'pay', 'price', 'pricing', 'buyer', 'purchase', 'revenue', 'subscription', 'fee', 'cost', 'invoice', 'transaction'];
+
+function isPaymentRelated(evidence: string): boolean {
+  const lower = evidence.toLowerCase();
+  return PAYMENT_KEYWORDS.some((kw) => lower.includes(kw));
+}
+
+function deriveWhatToBuild(output: EvaluatorOutput, candidate: RealizationCandidate): string[] {
+  const items: string[] = [];
+
+  for (const step of output.recommendedNextStep) {
+    items.push(step);
+  }
+
+  if (output.handoffNotes) {
+    for (const note of output.handoffNotes) {
+      items.push(note);
+    }
+  }
+
+  if (items.length === 0) {
+    items.push(`Build ${candidate.form} for ${candidate.description}`);
+  }
+
+  return items;
+}
+
+function deriveWhatNotToBuild(output: EvaluatorOutput, candidate: RealizationCandidate): string[] {
+  if (candidate.regime === 'economic') {
+    return ['Full product before buyer validation', ...output.unresolvedRisks.map((r) => `Do not build around unresolved: ${r}`)];
+  }
+  if (candidate.regime === 'governance') {
+    return ['Dashboard instead of world', ...output.unresolvedRisks.map((r) => `Do not build around unresolved: ${r}`)];
+  }
+  return output.unresolvedRisks.map((r) => `Do not build around unresolved: ${r}`);
+}
+
+function extractBuyerHypothesis(output: EvaluatorOutput, candidate: RealizationCandidate): string {
+  const parts: string[] = [];
+  parts.push(candidate.description);
+  for (const assumption of candidate.assumptions) {
+    if (assumption.toLowerCase().includes('buyer') || assumption.toLowerCase().includes('customer') || assumption.toLowerCase().includes('user')) {
+      parts.push(assumption);
+    }
+  }
+  for (const evidence of output.evidenceUsed) {
+    if (evidence.toLowerCase().includes('buyer')) {
+      parts.push(evidence);
+    }
+  }
+  return parts.join('; ');
+}
+
+function extractPainHypothesis(output: EvaluatorOutput, candidate: RealizationCandidate): string {
+  const parts: string[] = [];
+  for (const reason of candidate.whyThisCandidate) {
+    parts.push(reason);
+  }
+  for (const assumption of candidate.assumptions) {
+    if (assumption.toLowerCase().includes('pain') || assumption.toLowerCase().includes('problem') || assumption.toLowerCase().includes('struggle')) {
+      parts.push(assumption);
+    }
+  }
+  return parts.length > 0 ? parts.join('; ') : candidate.description;
+}
+
+function extractCycleDesign(output: EvaluatorOutput): string[] {
+  const items: string[] = [];
+  for (const step of output.recommendedNextStep) {
+    items.push(step);
+  }
+  if (items.length === 0) {
+    items.push('Define first governance cycle');
+  }
+  return items;
+}
+
+function extractThyraRequirements(output: EvaluatorOutput, candidate: RealizationCandidate): string[] {
+  const items: string[] = [];
+  for (const note of candidate.notes) {
+    items.push(note);
+  }
+  for (const assumption of candidate.assumptions) {
+    items.push(assumption);
+  }
+  if (output.handoffNotes) {
+    for (const note of output.handoffNotes) {
+      items.push(note);
+    }
+  }
+  if (items.length === 0) {
+    items.push('Define Thyra handoff requirements');
+  }
+  return items;
+}
+
+function deriveStateDensity(output: EvaluatorOutput, candidate: RealizationCandidate): 'low' | 'medium' | 'high' {
+  const gov = candidate as Partial<GovernanceWorldCandidate>;
+  if (gov.stateDensity) return gov.stateDensity;
+
+  const strongSignals = output.evidenceUsed.length;
+  if (strongSignals >= 5) return 'high';
+  if (strongSignals >= 2) return 'medium';
+  return 'low';
+}
+
+function deriveGovernancePressure(output: EvaluatorOutput, candidate: RealizationCandidate): 'low' | 'medium' | 'high' {
+  const gov = candidate as Partial<GovernanceWorldCandidate>;
+  if (gov.governancePressure) return gov.governancePressure;
+
+  const risks = output.unresolvedRisks.length;
+  if (risks >= 4) return 'high';
+  if (risks >= 2) return 'medium';
+  return 'low';
+}
+
+// ─── Specialized Builders ───
+
+function buildEconomicCommitMemo(
+  base: CommitMemo,
+  output: EvaluatorOutput,
+  candidate: RealizationCandidate,
+): EconomicCommitMemo {
+  return {
+    ...base,
+    buyerHypothesis: extractBuyerHypothesis(output, candidate),
+    painHypothesis: extractPainHypothesis(output, candidate),
+    paymentEvidence: output.evidenceUsed.filter((e) => isPaymentRelated(e)),
+    whyThisVehicleNow: candidate.whyThisCandidate,
+    nextSignalAfterBuild: output.recommendedNextStep,
+  };
+}
+
+function buildGovernanceCommitMemo(
+  base: CommitMemo,
+  output: EvaluatorOutput,
+  candidate: RealizationCandidate,
+): GovernanceCommitMemo {
+  const gov = candidate as Partial<GovernanceWorldCandidate>;
+  return {
+    ...base,
+    selectedWorldForm: candidate.worldForm ?? 'market',
+    minimumWorldShape: gov.likelyMinimumWorldShape ?? candidate.notes,
+    stateDensityAssessment: deriveStateDensity(output, candidate),
+    governancePressureAssessment: deriveGovernancePressure(output, candidate),
+    firstCycleDesign: extractCycleDesign(output),
+    thyraHandoffRequirements: extractThyraRequirements(output, candidate),
+  };
+}
+
+// ─── Main Export ───
+
+export function buildCommitMemo(
+  evaluatorOutput: EvaluatorOutput,
+  candidate: RealizationCandidate,
+): CommitMemo | EconomicCommitMemo | GovernanceCommitMemo {
+  const baseMemo: CommitMemo = {
+    candidateId: candidate.id,
+    regime: candidate.regime,
+    verdict: evaluatorOutput.verdict,
+    rationale: evaluatorOutput.rationale,
+    evidenceUsed: evaluatorOutput.evidenceUsed,
+    unresolvedRisks: evaluatorOutput.unresolvedRisks,
+    whatForgeShouldBuild: deriveWhatToBuild(evaluatorOutput, candidate),
+    whatForgeMustNotBuild: deriveWhatNotToBuild(evaluatorOutput, candidate),
+    recommendedNextStep: evaluatorOutput.recommendedNextStep,
+  };
+
+  if (candidate.regime === 'economic') {
+    return buildEconomicCommitMemo(baseMemo, evaluatorOutput, candidate);
+  }
+  if (candidate.regime === 'governance') {
+    return buildGovernanceCommitMemo(baseMemo, evaluatorOutput, candidate);
+  }
+  return baseMemo;
+}

--- a/src/decision/evaluators/economic.test.ts
+++ b/src/decision/evaluators/economic.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi } from 'vitest';
+import { evaluateEconomic } from './economic';
+import type { EvaluatorInput } from '../../schemas/decision';
+import type { LLMClient } from '../../llm/client';
+
+function makeMockLLM(response: { ok: true; data: unknown } | { ok: false; error: string }): LLMClient {
+  return {
+    generateStructured: vi.fn().mockResolvedValue(response),
+    generateText: vi.fn(),
+  } as unknown as LLMClient;
+}
+
+function makeEvaluatorInput(): EvaluatorInput {
+  return {
+    candidate: {
+      id: 'cand-econ-1',
+      regime: 'economic',
+      form: 'service',
+      description: 'Consulting for SMBs',
+      whyThisCandidate: ['Buyer demand is strong'],
+      assumptions: ['Buyers will pay $500/month'],
+      probeReadinessHints: ['Landing page live'],
+      timeToSignal: 'short',
+      notes: ['Focus on onboarding'],
+    },
+    probeableForm: {
+      candidateId: 'cand-econ-1',
+      regime: 'economic',
+      hypothesis: 'Buyer demand is strong',
+      testTarget: 'buyer willingness to pay for service',
+      judge: 'potential buyer',
+      cheapestBelievableProbe: 'direct offer / landing page CTA for service',
+      disconfirmers: ['NOT: Buyers will pay $500/month'],
+    },
+    signals: [
+      {
+        candidateId: 'cand-econ-1',
+        probeId: 'probe-1',
+        regime: 'economic',
+        signalType: 'buyer_interview',
+        strength: 'strong',
+        evidence: ['Buyer confirmed pain', 'Payment discussion started'],
+        interpretation: 'Strong economic signal',
+        nextQuestions: ['What price?'],
+      },
+    ],
+  };
+}
+
+describe('evaluateEconomic', () => {
+  it('returns commit verdict when strong buyer + payment signals', async () => {
+    const llm = makeMockLLM({
+      ok: true,
+      data: {
+        verdict: 'commit',
+        rationale: ['Strong buyer shape', 'Payment-adjacent signal exists'],
+        evidenceUsed: ['Buyer confirmed pain', 'Payment discussion started'],
+        unresolvedRisks: ['Churn rate unknown'],
+        recommendedNextStep: ['Build MVP'],
+      },
+    });
+
+    const result = await evaluateEconomic(llm, makeEvaluatorInput());
+
+    expect(result.verdict).toBe('commit');
+    expect(result.rationale.length).toBeGreaterThan(0);
+    expect(result.evidenceUsed.length).toBeGreaterThan(0);
+  });
+
+  it('returns hold verdict when signals are weak', async () => {
+    const llm = makeMockLLM({
+      ok: true,
+      data: {
+        verdict: 'hold',
+        rationale: ['Interest exists but not payment-adjacent'],
+        evidenceUsed: ['General interest noted'],
+        unresolvedRisks: ['No payment signal yet'],
+        recommendedNextStep: ['Run another probe round'],
+      },
+    });
+
+    const result = await evaluateEconomic(llm, makeEvaluatorInput());
+
+    expect(result.verdict).toBe('hold');
+    expect(result.rationale).toContain('Interest exists but not payment-adjacent');
+  });
+
+  it('returns hold on LLM failure (graceful degradation)', async () => {
+    const llm = makeMockLLM({
+      ok: false,
+      error: 'Schema validation failed',
+    });
+
+    const result = await evaluateEconomic(llm, makeEvaluatorInput());
+
+    expect(result.verdict).toBe('hold');
+    expect(result.rationale[0]).toContain('Evaluation could not complete');
+  });
+
+  it('returns hold when LLM throws an exception', async () => {
+    const llm = {
+      generateStructured: vi.fn().mockRejectedValue(new Error('Network timeout')),
+      generateText: vi.fn(),
+    } as unknown as LLMClient;
+
+    const result = await evaluateEconomic(llm, makeEvaluatorInput());
+
+    expect(result.verdict).toBe('hold');
+    expect(result.rationale[0]).toContain('Network timeout');
+  });
+});

--- a/src/decision/evaluators/governance.test.ts
+++ b/src/decision/evaluators/governance.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { evaluateGovernance } from './governance';
+import type { EvaluatorInput } from '../../schemas/decision';
+import type { LLMClient } from '../../llm/client';
+
+function makeMockLLM(response: { ok: true; data: unknown } | { ok: false; error: string }): LLMClient {
+  return {
+    generateStructured: vi.fn().mockResolvedValue(response),
+    generateText: vi.fn(),
+  } as unknown as LLMClient;
+}
+
+function makeEvaluatorInput(): EvaluatorInput {
+  return {
+    candidate: {
+      id: 'cand-gov-1',
+      regime: 'governance',
+      form: 'world',
+      worldForm: 'commons',
+      description: 'Community governance world',
+      whyThisCandidate: ['Dense state changes', 'Clear closure cycle'],
+      assumptions: ['Participants will engage in governance'],
+      probeReadinessHints: ['Minimum world shape defined'],
+      timeToSignal: 'medium',
+      notes: ['State: member roles, resource pool', 'Change: proposal flow'],
+    },
+    probeableForm: {
+      candidateId: 'cand-gov-1',
+      regime: 'governance',
+      hypothesis: 'Dense state changes; Clear closure cycle',
+      testTarget: 'world density of commons',
+      judge: 'world state/change closure',
+      cheapestBelievableProbe: 'minimum state instantiation of commons',
+      disconfirmers: ['NOT: Participants will engage in governance'],
+    },
+    signals: [
+      {
+        candidateId: 'cand-gov-1',
+        probeId: 'probe-gov-1',
+        regime: 'governance',
+        signalType: 'world_density_check',
+        strength: 'strong',
+        evidence: ['State defined: roles + resources', 'Closure cycle validated'],
+        interpretation: 'World has sufficient density',
+        nextQuestions: ['What is the first real change proposal?'],
+      },
+    ],
+  };
+}
+
+describe('evaluateGovernance', () => {
+  it('returns commit when world density + closure signals are strong', async () => {
+    const llm = makeMockLLM({
+      ok: true,
+      data: {
+        verdict: 'commit',
+        rationale: ['Minimum world shape exists', 'Closure cycle can run'],
+        evidenceUsed: ['State defined: roles + resources', 'Closure cycle validated'],
+        unresolvedRisks: ['Outcome visibility not yet tested'],
+        recommendedNextStep: ['Instantiate first cycle'],
+        handoffNotes: ['World type: commons'],
+      },
+    });
+
+    const result = await evaluateGovernance(llm, makeEvaluatorInput());
+
+    expect(result.verdict).toBe('commit');
+    expect(result.rationale.length).toBeGreaterThan(0);
+    expect(result.evidenceUsed.length).toBeGreaterThan(0);
+  });
+
+  it('returns discard when world is tool-in-clothing', async () => {
+    const llm = makeMockLLM({
+      ok: true,
+      data: {
+        verdict: 'discard',
+        rationale: ['Essentially a tool wearing world aesthetics'],
+        evidenceUsed: ['No real state changes', 'No governance pressure'],
+        unresolvedRisks: ['Fundamental world density missing'],
+        recommendedNextStep: ['Reconsider as tool instead of world'],
+      },
+    });
+
+    const result = await evaluateGovernance(llm, makeEvaluatorInput());
+
+    expect(result.verdict).toBe('discard');
+    expect(result.rationale).toContain('Essentially a tool wearing world aesthetics');
+  });
+
+  it('returns hold on LLM failure (graceful degradation)', async () => {
+    const llm = makeMockLLM({
+      ok: false,
+      error: 'Schema validation failed',
+    });
+
+    const result = await evaluateGovernance(llm, makeEvaluatorInput());
+
+    expect(result.verdict).toBe('hold');
+    expect(result.rationale[0]).toContain('Evaluation could not complete');
+  });
+
+  it('returns hold when LLM throws an exception', async () => {
+    const llm = {
+      generateStructured: vi.fn().mockRejectedValue(new Error('API rate limited')),
+      generateText: vi.fn(),
+    } as unknown as LLMClient;
+
+    const result = await evaluateGovernance(llm, makeEvaluatorInput());
+
+    expect(result.verdict).toBe('hold');
+    expect(result.rationale[0]).toContain('API rate limited');
+  });
+});

--- a/src/decision/probe-shell.test.ts
+++ b/src/decision/probe-shell.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+import { isProbeReady, packageProbe, recordSignal } from './probe-shell';
+import type { RealizationCandidate } from '../schemas/decision';
+import type { SignalEvidence } from './probe-shell';
+
+function makeCandidate(overrides: Partial<RealizationCandidate> = {}): RealizationCandidate {
+  return {
+    id: 'cand-1',
+    regime: 'economic',
+    form: 'service',
+    description: 'Test candidate',
+    whyThisCandidate: ['Strong demand'],
+    assumptions: ['Users will pay'],
+    probeReadinessHints: ['Landing page ready'],
+    timeToSignal: 'short',
+    notes: ['Note 1'],
+    ...overrides,
+  };
+}
+
+describe('isProbeReady', () => {
+  it('returns false for candidate with empty whyThisCandidate', () => {
+    const candidate = makeCandidate({ whyThisCandidate: [] });
+    expect(isProbeReady(candidate)).toBe(false);
+  });
+
+  it('returns false for candidate with empty assumptions', () => {
+    const candidate = makeCandidate({ assumptions: [] });
+    expect(isProbeReady(candidate)).toBe(false);
+  });
+
+  it('returns false for candidate with empty probeReadinessHints', () => {
+    const candidate = makeCandidate({ probeReadinessHints: [] });
+    expect(isProbeReady(candidate)).toBe(false);
+  });
+
+  it('returns false for candidate with undefined probeReadinessHints', () => {
+    const candidate = makeCandidate({ probeReadinessHints: undefined });
+    expect(isProbeReady(candidate)).toBe(false);
+  });
+
+  it('returns true for valid candidate with all fields populated', () => {
+    const candidate = makeCandidate();
+    expect(isProbeReady(candidate)).toBe(true);
+  });
+});
+
+describe('packageProbe', () => {
+  it('produces valid ProbeableForm with all required fields', () => {
+    const candidate = makeCandidate();
+    const probe = packageProbe(candidate);
+
+    expect(probe.candidateId).toBe('cand-1');
+    expect(probe.regime).toBe('economic');
+    expect(probe.hypothesis).toBeDefined();
+    expect(probe.hypothesis.length).toBeGreaterThan(0);
+    expect(probe.testTarget).toBeDefined();
+    expect(probe.judge).toBeDefined();
+    expect(probe.cheapestBelievableProbe).toBeDefined();
+    expect(probe.disconfirmers).toBeDefined();
+    expect(probe.disconfirmers.length).toBeGreaterThan(0);
+  });
+
+  it('derives correct testTarget for economic regime', () => {
+    const candidate = makeCandidate({ regime: 'economic', vehicle: 'SaaS platform' });
+    const probe = packageProbe(candidate);
+
+    expect(probe.testTarget).toContain('buyer willingness to pay');
+    expect(probe.testTarget).toContain('SaaS platform');
+  });
+
+  it('derives correct testTarget for governance regime', () => {
+    const candidate = makeCandidate({ regime: 'governance', worldForm: 'commons' });
+    const probe = packageProbe(candidate);
+
+    expect(probe.testTarget).toContain('world density');
+    expect(probe.testTarget).toContain('commons');
+  });
+
+  it('joins whyThisCandidate into hypothesis', () => {
+    const candidate = makeCandidate({ whyThisCandidate: ['Reason A', 'Reason B'] });
+    const probe = packageProbe(candidate);
+
+    expect(probe.hypothesis).toBe('Reason A; Reason B');
+  });
+
+  it('derives disconfirmers from assumptions', () => {
+    const candidate = makeCandidate({ assumptions: ['Users will pay', 'Market exists'] });
+    const probe = packageProbe(candidate);
+
+    expect(probe.disconfirmers).toEqual(['NOT: Users will pay', 'NOT: Market exists']);
+  });
+});
+
+describe('recordSignal', () => {
+  it('assembles valid SignalPacket', () => {
+    const evidence: SignalEvidence = {
+      signalType: 'buyer_interview',
+      strength: 'strong',
+      evidence: ['Buyer confirmed pain point'],
+      interpretation: 'Strong buy signal',
+      nextQuestions: ['What price range?'],
+    };
+
+    const signal = recordSignal('probe-1', 'cand-1', 'economic', evidence);
+
+    expect(signal.candidateId).toBe('cand-1');
+    expect(signal.probeId).toBe('probe-1');
+    expect(signal.regime).toBe('economic');
+    expect(signal.signalType).toBe('buyer_interview');
+    expect(signal.strength).toBe('strong');
+  });
+
+  it('preserves all evidence fields including negativeEvidence', () => {
+    const evidence: SignalEvidence = {
+      signalType: 'market_test',
+      strength: 'moderate',
+      evidence: ['Some interest shown'],
+      negativeEvidence: ['Price resistance noted'],
+      interpretation: 'Mixed signals',
+      nextQuestions: ['Try lower price?'],
+    };
+
+    const signal = recordSignal('probe-2', 'cand-2', 'economic', evidence);
+
+    expect(signal.evidence).toEqual(['Some interest shown']);
+    expect(signal.negativeEvidence).toEqual(['Price resistance noted']);
+    expect(signal.interpretation).toBe('Mixed signals');
+    expect(signal.nextQuestions).toEqual(['Try lower price?']);
+  });
+
+  it('handles missing negativeEvidence', () => {
+    const evidence: SignalEvidence = {
+      signalType: 'user_test',
+      strength: 'weak',
+      evidence: ['Some usage'],
+      interpretation: 'Low engagement',
+      nextQuestions: ['Why low?'],
+    };
+
+    const signal = recordSignal('probe-3', 'cand-3', 'governance', evidence);
+
+    expect(signal.negativeEvidence).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- buildCommitMemo routes to economic/governance specializations
- Full Track E tests: probe-shell, evaluators, commit-memo
- 968 tests pass

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)