### PR TITLE
fix(clients): resolve Karvi/Edda default port collision

### DIFF
--- a/src/karvi-client/client.test.ts
+++ b/src/karvi-client/client.test.ts
@@ -35,7 +35,7 @@ describe('URL construction', () => {
       }),
     });
     await client.registerPipeline({ name: 'deploy-pipe', steps: [sampleStep] });
-    expect(capturedUrl).toBe('http://localhost:3463/api/pipelines');
+    expect(capturedUrl).toBe('http://localhost:3464/api/pipelines');
     expect(capturedMethod).toBe('POST');
   });
 
@@ -50,7 +50,7 @@ describe('URL construction', () => {
       }),
     });
     await client.listPipelines();
-    expect(capturedUrl).toBe('http://localhost:3463/api/pipelines');
+    expect(capturedUrl).toBe('http://localhost:3464/api/pipelines');
     expect(capturedMethod).toBe('GET');
   });
 
@@ -65,7 +65,7 @@ describe('URL construction', () => {
       }),
     });
     await client.deletePipeline('my-pipe');
-    expect(capturedUrl).toBe('http://localhost:3463/api/pipelines/my-pipe');
+    expect(capturedUrl).toBe('http://localhost:3464/api/pipelines/my-pipe');
     expect(capturedMethod).toBe('DELETE');
   });
 
@@ -78,7 +78,7 @@ describe('URL construction', () => {
       }),
     });
     await client.getHealth();
-    expect(capturedUrl).toBe('http://localhost:3463/api/health');
+    expect(capturedUrl).toBe('http://localhost:3464/api/health');
   });
 
   it('custom baseUrl is respected', async () => {

--- a/src/karvi-client/client.ts
+++ b/src/karvi-client/client.ts
@@ -29,7 +29,7 @@ export class KarviClient {
   private readonly fetchFn: typeof fetch;
 
   constructor(options: KarviClientOptions = {}) {
-    this.baseUrl = options.baseUrl ?? 'http://localhost:3463';
+    this.baseUrl = options.baseUrl ?? 'http://localhost:3464';
     this.timeout = options.timeout ?? 10_000;
     this.retries = options.retries ?? 2;
     this.fetchFn = options.fetchFn ?? globalThis.fetch;


### PR DESCRIPTION
Closes #177. Changed KarviClient default port from 3463 to 3464 to resolve collision with EddaClient.