### PR TITLE
feat(decision): add CommitMemo to ForgeBuildRequest translation

### DIFF
--- a/src/decision/forge-handoff.test.ts
+++ b/src/decision/forge-handoff.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { translateToSettlement, buildSyntheticCommitMemo } from './forge-handoff';
+import { buildForgeBuildRequest, buildSyntheticCommitMemo, type ForgeHandoffContext } from './forge-handoff';
+import { ForgeBuildRequestSchema } from '../karvi-client/schemas';
 import type {
   EconomicCommitMemo,
   GovernanceCommitMemo,
@@ -8,6 +9,15 @@ import type {
 } from '../schemas/decision';
 
 // ─── Fixtures ───
+
+function makeContext(overrides?: Partial<ForgeHandoffContext>): ForgeHandoffContext {
+  return {
+    sessionId: 'session-001',
+    workingDir: '/tmp/test',
+    targetRepo: 'test-repo',
+    ...overrides,
+  };
+}
 
 function makeEconomicMemo(overrides?: Partial<EconomicCommitMemo>): EconomicCommitMemo {
   return {
@@ -86,83 +96,143 @@ function makePathCheckResult(overrides?: Partial<PathCheckResult>): PathCheckRes
 
 // ─── Tests ───
 
-describe('translateToSettlement', () => {
+describe('buildForgeBuildRequest', () => {
   describe('economic regime', () => {
-    it('maps EconomicCommitMemo to economic settlement payload', () => {
+    it('maps EconomicCommitMemo to ForgeBuildRequest with economic regimeContext', () => {
       const memo = makeEconomicMemo();
-      const result = translateToSettlement(memo);
+      const ctx = makeContext();
+      const result = buildForgeBuildRequest(memo, ctx);
 
-      expect(result.kind).toBe('economic');
-      if (result.kind !== 'economic') throw new Error('unreachable');
-
-      expect(result.taskSpec.intent).toBe(memo.buyerHypothesis);
-      expect(result.taskSpec.inputs.buyer).toBe(memo.buyerHypothesis);
-      expect(result.taskSpec.inputs.pain).toBe(memo.painHypothesis);
-      expect(result.taskSpec.inputs.vehicle).toBe(memo.whyThisVehicleNow.join(', '));
-      expect(result.taskSpec.constraints).toEqual(memo.whatForgeShouldBuild);
-      expect(result.taskSpec.exclusions).toEqual(memo.whatForgeMustNotBuild);
-      expect(result.taskSpec.success_condition).toBe(memo.nextSignalAfterBuild[0]);
+      expect(result.sessionId).toBe(ctx.sessionId);
+      expect(result.candidateId).toBe(memo.candidateId);
+      expect(result.regime).toBe('economic');
+      expect(result.verdict).toBe('commit');
+      expect(result.whatToBuild).toEqual(memo.whatForgeShouldBuild);
+      expect(result.whatNotToBuild).toEqual(memo.whatForgeMustNotBuild);
+      expect(result.rationale).toEqual(memo.rationale);
+      expect(result.evidenceUsed).toEqual(memo.evidenceUsed);
+      expect(result.unresolvedRisks).toEqual(memo.unresolvedRisks);
     });
 
-    it('maps workflow hints from economic memo', () => {
+    it('includes all 6 economic regimeContext fields', () => {
       const memo = makeEconomicMemo();
-      const result = translateToSettlement(memo);
+      const result = buildForgeBuildRequest(memo, makeContext());
 
-      if (result.kind !== 'economic') throw new Error('unreachable');
+      expect(result.regimeContext.kind).toBe('economic');
+      if (result.regimeContext.kind !== 'economic') throw new Error('unreachable');
 
-      expect(result.workflowHints.name).toBe(`${memo.candidateId}-delivery`);
-      expect(result.workflowHints.purpose).toBe(memo.rationale[0]);
-      expect(result.workflowHints.steps).toEqual(memo.whatForgeShouldBuild);
+      expect(result.regimeContext.buyerHypothesis).toBe(memo.buyerHypothesis);
+      expect(result.regimeContext.painHypothesis).toBe(memo.painHypothesis);
+      expect(result.regimeContext.vehicleType).toBe(memo.whyThisVehicleNow[0]);
+      expect(result.regimeContext.paymentEvidence).toEqual(memo.paymentEvidence);
+      expect(result.regimeContext.whyThisVehicleNow).toEqual(memo.whyThisVehicleNow);
+      expect(result.regimeContext.nextSignalAfterBuild).toEqual(memo.nextSignalAfterBuild);
     });
 
-    it('falls back to rationale when buyerHypothesis is empty', () => {
-      const memo = makeEconomicMemo({ buyerHypothesis: '' });
-      const result = translateToSettlement(memo);
+    it('derives vehicleType from whyThisVehicleNow[0]', () => {
+      const memo = makeEconomicMemo({ whyThisVehicleNow: ['SaaS platform'] });
+      const result = buildForgeBuildRequest(memo, makeContext());
 
-      if (result.kind !== 'economic') throw new Error('unreachable');
-
-      expect(result.taskSpec.intent).toBe(memo.rationale.join('; '));
+      if (result.regimeContext.kind !== 'economic') throw new Error('unreachable');
+      expect(result.regimeContext.vehicleType).toBe('SaaS platform');
     });
 
-    it('falls back success_condition when nextSignalAfterBuild is empty', () => {
-      const memo = makeEconomicMemo({ nextSignalAfterBuild: [] });
-      const result = translateToSettlement(memo);
+    it('falls back vehicleType to unknown when whyThisVehicleNow is empty', () => {
+      const memo = makeEconomicMemo({ whyThisVehicleNow: [] });
+      const result = buildForgeBuildRequest(memo, makeContext());
 
-      if (result.kind !== 'economic') throw new Error('unreachable');
+      if (result.regimeContext.kind !== 'economic') throw new Error('unreachable');
+      expect(result.regimeContext.vehicleType).toBe('unknown');
+    });
 
-      expect(result.taskSpec.success_condition).toBe('First paying customer');
+    it('includes context fields from ForgeHandoffContext', () => {
+      const ctx = makeContext({ workingDir: '/projects/demo', targetRepo: 'org/repo' });
+      const result = buildForgeBuildRequest(makeEconomicMemo(), ctx);
+
+      expect(result.context.workingDir).toBe('/projects/demo');
+      expect(result.context.targetRepo).toBe('org/repo');
+    });
+
+    it('validates output against ForgeBuildRequestSchema', () => {
+      const result = buildForgeBuildRequest(makeEconomicMemo(), makeContext());
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
     });
   });
 
   describe('governance regime', () => {
-    it('maps GovernanceCommitMemo to governance settlement payload', () => {
+    it('maps GovernanceCommitMemo to ForgeBuildRequest with governance regimeContext', () => {
       const memo = makeGovernanceMemo();
-      const result = translateToSettlement(memo);
+      const ctx = makeContext();
+      const result = buildForgeBuildRequest(memo, ctx);
 
-      expect(result.kind).toBe('governance');
-      if (result.kind !== 'governance') throw new Error('unreachable');
+      expect(result.sessionId).toBe(ctx.sessionId);
+      expect(result.candidateId).toBe(memo.candidateId);
+      expect(result.regime).toBe('governance');
+      expect(result.verdict).toBe('commit');
+      expect(result.whatToBuild).toEqual(memo.whatForgeShouldBuild);
+      expect(result.whatNotToBuild).toEqual(memo.whatForgeMustNotBuild);
+    });
 
-      expect(result.villagePack.name).toBe(`world-${memo.selectedWorldForm}-${memo.candidateId.slice(0, 8)}`);
-      expect(result.villagePack.target_repo).toBe('');
-      expect(result.villagePack.worldForm).toBe(memo.selectedWorldForm);
-      expect(result.villagePack.constitutionHints.rules).toEqual(memo.thyraHandoffRequirements);
-      expect(result.villagePack.constitutionHints.allowed_permissions).toEqual([]);
-      expect(result.villagePack.minimumWorldShape).toEqual(memo.minimumWorldShape);
-      expect(result.villagePack.firstCycleDesign).toEqual(memo.firstCycleDesign);
+    it('includes all 6 governance regimeContext fields', () => {
+      const memo = makeGovernanceMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      expect(result.regimeContext.kind).toBe('governance');
+      if (result.regimeContext.kind !== 'governance') throw new Error('unreachable');
+
+      expect(result.regimeContext.worldForm).toBe(memo.selectedWorldForm);
+      expect(result.regimeContext.minimumWorldShape).toEqual(memo.minimumWorldShape);
+      expect(result.regimeContext.firstCycleDesign).toEqual(memo.firstCycleDesign);
+      expect(result.regimeContext.stateDensityAssessment).toBe(memo.stateDensityAssessment);
+      expect(result.regimeContext.governancePressureAssessment).toBe(memo.governancePressureAssessment);
+      expect(result.regimeContext.thyraHandoffRequirements).toEqual(memo.thyraHandoffRequirements);
+    });
+
+    it('validates output against ForgeBuildRequestSchema', () => {
+      const result = buildForgeBuildRequest(makeGovernanceMemo(), makeContext());
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
     });
   });
 
   describe('generic fallback', () => {
-    it('maps non-economic non-governance memo to economic payload', () => {
+    it('maps non-economic non-governance memo to ForgeBuildRequest with economic regimeContext', () => {
       const memo = makeBaseMemo();
-      const result = translateToSettlement(memo);
+      const result = buildForgeBuildRequest(memo, makeContext());
 
-      expect(result.kind).toBe('economic');
-      if (result.kind !== 'economic') throw new Error('unreachable');
+      expect(result.regime).toBe('capability');
+      expect(result.regimeContext.kind).toBe('economic');
+      expect(result.whatToBuild).toEqual(memo.whatForgeShouldBuild);
+    });
 
-      expect(result.taskSpec.intent).toBe(memo.rationale.join('; '));
-      expect(result.taskSpec.inputs.regime).toBe('capability');
-      expect(result.taskSpec.constraints).toEqual(memo.whatForgeShouldBuild);
+    it('uses rationale as fallback for economic fields', () => {
+      const memo = makeBaseMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      if (result.regimeContext.kind !== 'economic') throw new Error('unreachable');
+      expect(result.regimeContext.buyerHypothesis).toBe(memo.rationale[0]);
+      expect(result.regimeContext.painHypothesis).toBe(memo.rationale.join('; '));
+      expect(result.regimeContext.vehicleType).toBe('unknown');
+      expect(result.regimeContext.paymentEvidence).toEqual([]);
+      expect(result.regimeContext.whyThisVehicleNow).toEqual([]);
+      expect(result.regimeContext.nextSignalAfterBuild).toEqual(memo.recommendedNextStep);
+    });
+
+    it('validates output against ForgeBuildRequestSchema', () => {
+      const result = buildForgeBuildRequest(makeBaseMemo(), makeContext());
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  describe('context handling', () => {
+    it('handles optional context fields', () => {
+      const ctx = makeContext({ workingDir: undefined, targetRepo: undefined });
+      const result = buildForgeBuildRequest(makeEconomicMemo(), ctx);
+
+      expect(result.context.workingDir).toBeUndefined();
+      expect(result.context.targetRepo).toBeUndefined();
     });
   });
 });

--- a/src/decision/forge-handoff.ts
+++ b/src/decision/forge-handoff.ts
@@ -6,41 +6,15 @@ import type {
   Regime,
   WorldForm,
 } from '../schemas/decision';
+import { ForgeBuildRequestSchema, type ForgeBuildRequest } from '../karvi-client/schemas';
 
-// ─── Settlement Payload Types ───
+// ─── Context for Forge Handoff ───
 
-type EconomicSettlementPayload = {
-  kind: 'economic';
-  taskSpec: {
-    intent: string;
-    inputs: Record<string, string>;
-    constraints: string[];
-    exclusions: string[];
-    success_condition: string;
-  };
-  workflowHints: {
-    name: string;
-    purpose: string;
-    steps: string[];
-  };
+export type ForgeHandoffContext = {
+  sessionId: string;
+  workingDir?: string;
+  targetRepo?: string;
 };
-
-type GovernanceSettlementPayload = {
-  kind: 'governance';
-  villagePack: {
-    name: string;
-    target_repo: string;
-    worldForm: WorldForm;
-    constitutionHints: {
-      rules: string[];
-      allowed_permissions: string[];
-    };
-    minimumWorldShape: string[];
-    firstCycleDesign: string[];
-  };
-};
-
-export type SettlementPayload = EconomicSettlementPayload | GovernanceSettlementPayload;
 
 // ─── Type Guards ───
 
@@ -54,80 +28,118 @@ function isGovernanceCommitMemo(memo: CommitMemo): memo is GovernanceCommitMemo 
 
 // ─── Economic Translation ───
 
-function translateEconomic(memo: EconomicCommitMemo): EconomicSettlementPayload {
+function buildEconomicRequest(
+  memo: EconomicCommitMemo,
+  context: ForgeHandoffContext,
+): ForgeBuildRequest {
   return {
-    kind: 'economic',
-    taskSpec: {
-      intent: memo.buyerHypothesis || memo.rationale.join('; '),
-      inputs: {
-        buyer: memo.buyerHypothesis || '',
-        pain: memo.painHypothesis || '',
-        vehicle: memo.whyThisVehicleNow.join(', ') || '',
-      },
-      constraints: memo.whatForgeShouldBuild,
-      exclusions: memo.whatForgeMustNotBuild,
-      success_condition: memo.nextSignalAfterBuild[0] || 'First paying customer',
+    sessionId: context.sessionId,
+    candidateId: memo.candidateId,
+    regime: memo.regime,
+    verdict: 'commit',
+    whatToBuild: memo.whatForgeShouldBuild,
+    whatNotToBuild: memo.whatForgeMustNotBuild,
+    rationale: memo.rationale,
+    evidenceUsed: memo.evidenceUsed,
+    unresolvedRisks: memo.unresolvedRisks,
+    regimeContext: {
+      kind: 'economic',
+      buyerHypothesis: memo.buyerHypothesis,
+      painHypothesis: memo.painHypothesis,
+      vehicleType: memo.whyThisVehicleNow[0] || 'unknown',
+      paymentEvidence: memo.paymentEvidence,
+      whyThisVehicleNow: memo.whyThisVehicleNow,
+      nextSignalAfterBuild: memo.nextSignalAfterBuild,
     },
-    workflowHints: {
-      name: `${memo.candidateId}-delivery`,
-      purpose: memo.rationale[0] || 'Economic delivery workflow',
-      steps: memo.whatForgeShouldBuild,
+    context: {
+      workingDir: context.workingDir,
+      targetRepo: context.targetRepo,
     },
   };
 }
 
 // ─── Governance Translation ───
 
-function translateGovernance(memo: GovernanceCommitMemo): GovernanceSettlementPayload {
+function buildGovernanceRequest(
+  memo: GovernanceCommitMemo,
+  context: ForgeHandoffContext,
+): ForgeBuildRequest {
   return {
-    kind: 'governance',
-    villagePack: {
-      name: `world-${memo.selectedWorldForm}-${memo.candidateId.slice(0, 8)}`,
-      target_repo: '',
+    sessionId: context.sessionId,
+    candidateId: memo.candidateId,
+    regime: memo.regime,
+    verdict: 'commit',
+    whatToBuild: memo.whatForgeShouldBuild,
+    whatNotToBuild: memo.whatForgeMustNotBuild,
+    rationale: memo.rationale,
+    evidenceUsed: memo.evidenceUsed,
+    unresolvedRisks: memo.unresolvedRisks,
+    regimeContext: {
+      kind: 'governance',
       worldForm: memo.selectedWorldForm,
-      constitutionHints: {
-        rules: memo.thyraHandoffRequirements,
-        allowed_permissions: [],
-      },
       minimumWorldShape: memo.minimumWorldShape,
       firstCycleDesign: memo.firstCycleDesign,
+      stateDensityAssessment: memo.stateDensityAssessment,
+      governancePressureAssessment: memo.governancePressureAssessment,
+      thyraHandoffRequirements: memo.thyraHandoffRequirements,
+    },
+    context: {
+      workingDir: context.workingDir,
+      targetRepo: context.targetRepo,
     },
   };
 }
 
 // ─── Generic Fallback (non-economic, non-governance regimes) ───
 
-function translateGenericFallback(memo: CommitMemo): EconomicSettlementPayload {
+function buildFallbackRequest(
+  memo: CommitMemo,
+  context: ForgeHandoffContext,
+): ForgeBuildRequest {
   return {
-    kind: 'economic',
-    taskSpec: {
-      intent: memo.rationale.join('; '),
-      inputs: {
-        regime: memo.regime,
-        candidate: memo.candidateId,
-      },
-      constraints: memo.whatForgeShouldBuild,
-      exclusions: memo.whatForgeMustNotBuild,
-      success_condition: memo.recommendedNextStep[0] || 'Deliver first iteration',
+    sessionId: context.sessionId,
+    candidateId: memo.candidateId,
+    regime: memo.regime,
+    verdict: 'commit',
+    whatToBuild: memo.whatForgeShouldBuild,
+    whatNotToBuild: memo.whatForgeMustNotBuild,
+    rationale: memo.rationale,
+    evidenceUsed: memo.evidenceUsed,
+    unresolvedRisks: memo.unresolvedRisks,
+    regimeContext: {
+      kind: 'economic',
+      buyerHypothesis: memo.rationale[0] || '',
+      painHypothesis: memo.rationale.join('; '),
+      vehicleType: 'unknown',
+      paymentEvidence: [],
+      whyThisVehicleNow: [],
+      nextSignalAfterBuild: memo.recommendedNextStep,
     },
-    workflowHints: {
-      name: `${memo.candidateId}-delivery`,
-      purpose: memo.rationale[0] || `${memo.regime} delivery workflow`,
-      steps: memo.whatForgeShouldBuild,
+    context: {
+      workingDir: context.workingDir,
+      targetRepo: context.targetRepo,
     },
   };
 }
 
 // ─── Main Export ───
 
-export function translateToSettlement(commitMemo: CommitMemo): SettlementPayload {
+export function buildForgeBuildRequest(
+  commitMemo: CommitMemo,
+  context: ForgeHandoffContext,
+): ForgeBuildRequest {
+  let request: ForgeBuildRequest;
+
   if (isEconomicCommitMemo(commitMemo)) {
-    return translateEconomic(commitMemo);
+    request = buildEconomicRequest(commitMemo, context);
+  } else if (isGovernanceCommitMemo(commitMemo)) {
+    request = buildGovernanceRequest(commitMemo, context);
+  } else {
+    request = buildFallbackRequest(commitMemo, context);
   }
-  if (isGovernanceCommitMemo(commitMemo)) {
-    return translateGovernance(commitMemo);
-  }
-  return translateGenericFallback(commitMemo);
+
+  // Validate output against schema (CONTRACT: output must match ForgeBuildRequestSchema)
+  return ForgeBuildRequestSchema.parse(request);
 }
 
 // ─── Synthetic CommitMemo for Forge Fast-Path ───

--- a/src/routes/decisions.ts
+++ b/src/routes/decisions.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import type { Database } from 'bun:sqlite';
 import { ok, error } from './response';
 import type { LLMClient } from '../llm/client';
+import type { KarviClient } from '../karvi-client/client';
 import {
   DecisionSessionManager,
   type DecisionSession,
@@ -12,6 +13,7 @@ import { checkPath, type PathCheckContext } from '../decision/path-check';
 import { buildSpace } from '../decision/space-builder';
 import { applyKillFilters, type KillFilterConstraints } from '../decision/kill-filters';
 import { isProbeReady, packageProbe } from '../decision/probe-shell';
+import { buildForgeBuildRequest, type ForgeHandoffContext } from '../decision/forge-handoff';
 import type {
   IntentRoute,
   PathCheckResult,
@@ -27,6 +29,7 @@ export interface DecisionDeps {
   db: Database;
   llm: LLMClient;
   sessionManager: DecisionSessionManager;
+  karvi?: KarviClient;
 }
 
 // ─── Helpers ───
@@ -470,11 +473,28 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
       return error(c, 'CONFIRMATION_REQUIRED', 'Forge requires confirmation: true (CONTRACT SETTLE-01)', 400);
     }
 
+    // Extract context fields from request body
+    const workingDir = typeof body.workingDir === 'string' ? body.workingDir : undefined;
+    const targetRepo = typeof body.targetRepo === 'string' ? body.targetRepo : undefined;
+
     // Fast-path: forge-fast-path at path-check stage
     if (session.routeDecision === 'forge-fast-path' && session.stage === 'path-check') {
       const syntheticMemo = buildFastPathCommitMemo(session);
       deps.sessionManager.fastPathToDone(session.id);
-      return ok(c, { sessionId: session.id, commitMemo: syntheticMemo, forgeReady: true, fastPath: true, stage: 'done' });
+
+      // Build ForgeBuildRequest and dispatch to Karvi (graceful degradation)
+      const forgeContext: ForgeHandoffContext = { sessionId: session.id, workingDir, targetRepo };
+      const forgeBuildRequest = buildForgeBuildRequest(syntheticMemo, forgeContext);
+      let forgeResult: { buildId: string; status: string; pipeline: string } | null = null;
+      if (deps.karvi) {
+        try {
+          forgeResult = await deps.karvi.forgeBuild(forgeBuildRequest);
+        } catch (err) {
+          console.error('[forge] karvi.forgeBuild failed (fast-path):', err);
+        }
+      }
+
+      return ok(c, { sessionId: session.id, commitMemo: syntheticMemo, forgeBuildRequest, forgeResult, forgeReady: true, fastPath: true, stage: 'done' });
     }
 
     // Normal path: must be at commit-review stage


### PR DESCRIPTION
Closes #147. Replace translateToSettlement with buildForgeBuildRequest producing ForgeBuildRequest validated against ForgeBuildRequestSchema. Economic and governance regimes map all 6 fields each to regimeContext. Integrates karviClient.forgeBuild dispatch with graceful degradation. 1031 tests pass.