### PR TITLE
feat(routing): add dispatch.mode=karvi path in container router

### DIFF
--- a/src/routes/container-bridge.test.ts
+++ b/src/routes/container-bridge.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import {
+  resolveContainer,
+  containerToConversationMode,
+  shouldBypassContainerRouting,
+  shouldDispatchToKarvi,
+} from './container-bridge';
+import type { SkillLookup, SkillObjectLookup } from '../skills/types';
+import type { RoutingContext, ContainerSelection } from '../containers/types';
+import type { SkillObject } from '../schemas/skill-object';
+
+// ─── Helpers ───
+
+function emptyLookup(): SkillLookup {
+  return { findMatching: () => [] };
+}
+
+function skillLookup(skillId: string): SkillLookup {
+  return {
+    findMatching: () => [
+      { skillId, confidence: 'high' as const, matchedTriggers: ['deploy'] },
+    ],
+  };
+}
+
+function ctx(overrides: Partial<RoutingContext> = {}): RoutingContext {
+  return { userMessage: 'hello', ...overrides };
+}
+
+function makeSkillObjectLookup(mode: 'local' | 'karvi' | 'hybrid' | null): SkillObjectLookup {
+  return {
+    getSkillObject: () => mode === null ? null : ({
+      dispatch: { mode },
+    } as unknown as SkillObject),
+  };
+}
+
+function makeSelection(overrides: Partial<ContainerSelection> = {}): ContainerSelection {
+  return {
+    primary: 'skill',
+    confidence: 'high',
+    rationale: 'test',
+    skillId: 'deploy-svc',
+    ...overrides,
+  };
+}
+
+// ─── containerToConversationMode ───
+
+describe('containerToConversationMode', () => {
+  it('maps world → world_design', () => {
+    expect(containerToConversationMode('world')).toBe('world_design');
+  });
+
+  it('maps shape → world_design', () => {
+    expect(containerToConversationMode('shape')).toBe('world_design');
+  });
+
+  it('maps task → task', () => {
+    expect(containerToConversationMode('task')).toBe('task');
+  });
+
+  it('maps skill → task', () => {
+    expect(containerToConversationMode('skill')).toBe('task');
+  });
+
+  it('passes through currentMode for non-world/shape containers', () => {
+    expect(containerToConversationMode('task', 'pipeline_design')).toBe('pipeline_design');
+    expect(containerToConversationMode('skill', 'workflow_design')).toBe('workflow_design');
+    expect(containerToConversationMode('review', 'commerce_design')).toBe('commerce_design');
+    expect(containerToConversationMode('harvest', 'org_design')).toBe('org_design');
+  });
+
+  it('forces world_design for world even if currentMode set', () => {
+    expect(containerToConversationMode('world', 'task')).toBe('world_design');
+  });
+
+  it('forces world_design for shape even if currentMode set', () => {
+    expect(containerToConversationMode('shape', 'task')).toBe('world_design');
+  });
+});
+
+// ─── shouldBypassContainerRouting ───
+
+describe('shouldBypassContainerRouting', () => {
+  it('returns true for world_management', () => {
+    expect(shouldBypassContainerRouting('world_management')).toBe(true);
+  });
+
+  it('returns false for world_design', () => {
+    expect(shouldBypassContainerRouting('world_design')).toBe(false);
+  });
+
+  it('returns false for task', () => {
+    expect(shouldBypassContainerRouting('task')).toBe(false);
+  });
+
+  it('returns false for pipeline_design', () => {
+    expect(shouldBypassContainerRouting('pipeline_design')).toBe(false);
+  });
+});
+
+// ─── shouldDispatchToKarvi ───
+
+describe('shouldDispatchToKarvi', () => {
+  it('returns true when primary=skill and dispatch.mode=karvi', () => {
+    const selection = makeSelection({ primary: 'skill', skillId: 'deploy-svc' });
+    expect(shouldDispatchToKarvi(selection, makeSkillObjectLookup('karvi'))).toBe(true);
+  });
+
+  it('returns false when primary=skill and dispatch.mode=local', () => {
+    const selection = makeSelection({ primary: 'skill', skillId: 'deploy-svc' });
+    expect(shouldDispatchToKarvi(selection, makeSkillObjectLookup('local'))).toBe(false);
+  });
+
+  it('returns false when primary=skill and dispatch.mode=hybrid', () => {
+    const selection = makeSelection({ primary: 'skill', skillId: 'deploy-svc' });
+    expect(shouldDispatchToKarvi(selection, makeSkillObjectLookup('hybrid'))).toBe(false);
+  });
+
+  it('returns false when primary is not skill', () => {
+    const selection = makeSelection({ primary: 'task', skillId: undefined });
+    expect(shouldDispatchToKarvi(selection, makeSkillObjectLookup('karvi'))).toBe(false);
+  });
+
+  it('returns false when skillId is missing', () => {
+    const selection = makeSelection({ primary: 'skill', skillId: undefined });
+    expect(shouldDispatchToKarvi(selection, makeSkillObjectLookup('karvi'))).toBe(false);
+  });
+
+  it('returns false when skill object not found', () => {
+    const selection = makeSelection({ primary: 'skill', skillId: 'nonexistent' });
+    expect(shouldDispatchToKarvi(selection, makeSkillObjectLookup(null))).toBe(false);
+  });
+});
+
+// ─── resolveContainer ───
+
+describe('resolveContainer', () => {
+  it('resolves explore → shape with decision pipeline redirect', () => {
+    const result = resolveContainer(
+      ctx({ userMessage: 'I want to do something interesting' }),
+      emptyLookup(),
+    );
+    expect(result.selection.primary).toBe('shape');
+    expect(result.redirectToDecisionPipeline).toBe(true);
+    expect(result.mappedMode).toBe('world_design');
+  });
+
+  it('resolves act + skill match → skill without redirect', () => {
+    const result = resolveContainer(
+      ctx({ userMessage: 'deploy checkout-service', intentType: 'confirm' }),
+      skillLookup('deploy-svc'),
+    );
+    expect(result.selection.primary).toBe('skill');
+    expect(result.selection.skillId).toBe('deploy-svc');
+    expect(result.redirectToDecisionPipeline).toBe(false);
+  });
+
+  it('resolves act + no skill → task without redirect', () => {
+    const result = resolveContainer(
+      ctx({ userMessage: 'run the migration', intentType: 'confirm' }),
+      emptyLookup(),
+    );
+    expect(result.selection.primary).toBe('task');
+    expect(result.redirectToDecisionPipeline).toBe(false);
+  });
+
+  it('resolves world context → world without redirect', () => {
+    const result = resolveContainer(
+      ctx({ userMessage: 'update the project', hasActiveWorld: true }),
+      emptyLookup(),
+    );
+    expect(result.selection.primary).toBe('world');
+    expect(result.redirectToDecisionPipeline).toBe(false);
+  });
+
+  it('resolves harvest → harvest without redirect', () => {
+    const result = resolveContainer(
+      ctx({ userMessage: 'save this as a reusable skill', intentType: 'settle_signal' }),
+      emptyLookup(),
+    );
+    expect(result.selection.primary).toBe('harvest');
+    expect(result.redirectToDecisionPipeline).toBe(false);
+  });
+
+  it('passes through currentMode for non-shape containers', () => {
+    const result = resolveContainer(
+      ctx({ userMessage: 'run the build', intentType: 'confirm' }),
+      emptyLookup(),
+      'pipeline_design',
+    );
+    expect(result.mappedMode).toBe('pipeline_design');
+  });
+
+  it('overrides currentMode for shape', () => {
+    const result = resolveContainer(
+      ctx({ userMessage: 'help me think about this' }),
+      emptyLookup(),
+      'pipeline_design',
+    );
+    expect(result.selection.primary).toBe('shape');
+    expect(result.mappedMode).toBe('world_design');
+  });
+
+  it('returns correct behavior for confidence levels', () => {
+    const highResult = resolveContainer(
+      ctx({ hasActiveWorld: true }),
+      emptyLookup(),
+    );
+    expect(highResult.behavior).toBe('proceed');
+
+    const medResult = resolveContainer(
+      ctx({ userMessage: 'run something', intentType: 'confirm' }),
+      emptyLookup(),
+    );
+    expect(medResult.behavior).toBe('showRationale');
+  });
+});

--- a/src/routes/container-bridge.ts
+++ b/src/routes/container-bridge.ts
@@ -1,0 +1,105 @@
+import type { Container, ContainerSelection, RoutingContext } from '../containers/types';
+import type { SkillLookup, SkillObjectLookup } from '../skills/types';
+import type { ConversationMode } from '../schemas/conversation';
+import { selectContainer, getConfidenceBehavior } from '../containers/router';
+
+// ─── Types ───
+
+export interface ContainerContext {
+  selection: ContainerSelection;
+  behavior: 'proceed' | 'showRationale' | 'askClarification';
+  mappedMode: ConversationMode;
+  redirectToDecisionPipeline: boolean;
+}
+
+// ─── Container → ConversationMode Mapping ───
+
+const CONTAINER_MODE_MAP: Record<Container, ConversationMode> = {
+  world: 'world_design',
+  shape: 'world_design',
+  skill: 'task',
+  task: 'task',
+  review: 'task',
+  harvest: 'task',
+};
+
+/**
+ * Map a container to an existing ConversationMode.
+ * If currentMode is already set and valid, pass through unchanged
+ * for containers that don't force a specific mode.
+ */
+export function containerToConversationMode(
+  container: Container,
+  currentMode?: ConversationMode,
+): ConversationMode {
+  if (currentMode && container !== 'world' && container !== 'shape') {
+    return currentMode;
+  }
+  return CONTAINER_MODE_MAP[container];
+}
+
+// ─── Bypass Check ───
+
+const BYPASS_MODES: Set<ConversationMode> = new Set(['world_management']);
+
+/**
+ * Some modes bypass container routing entirely.
+ * world_management is a legacy mode that goes directly to conductor.
+ */
+export function shouldBypassContainerRouting(mode: ConversationMode): boolean {
+  return BYPASS_MODES.has(mode);
+}
+
+// ─── Karvi Dispatch Check ───
+
+/**
+ * Check if a skill container selection should dispatch to Karvi
+ * instead of executing locally.
+ *
+ * Returns true when:
+ * - primary container is 'skill'
+ * - skillId is present in selection
+ * - skill object exists and has dispatch.mode === 'karvi'
+ */
+export function shouldDispatchToKarvi(
+  selection: ContainerSelection,
+  skillObjectLookup: SkillObjectLookup,
+): boolean {
+  if (selection.primary !== 'skill' || !selection.skillId) return false;
+  const obj = skillObjectLookup.getSkillObject(selection.skillId);
+  if (!obj) return false;
+  return obj.dispatch.mode === 'karvi';
+}
+
+// ─── Main Bridge Function ───
+
+/**
+ * Resolve container selection and map to conductor context.
+ *
+ * This is the bridge between the container router (L1) and the
+ * existing conductor (turn-handler). Placed in routes/ (assembly layer)
+ * to comply with ARCH-02.
+ *
+ * When Shape container is selected, sets redirectToDecisionPipeline = true
+ * so the route layer can redirect to POST /api/decisions/start instead
+ * of entering the normal conductor flow.
+ */
+export function resolveContainer(
+  ctx: RoutingContext,
+  skillLookup: SkillLookup,
+  currentMode?: ConversationMode,
+): ContainerContext {
+  const selection = selectContainer(ctx, skillLookup);
+  const behavior = getConfidenceBehavior(selection);
+  const mappedMode = containerToConversationMode(selection.primary, currentMode);
+
+  // Shape container delegates to world-design decision pipeline
+  const redirectToDecisionPipeline = selection.primary === 'shape';
+
+  return {
+    selection,
+    behavior,
+    mappedMode,
+    redirectToDecisionPipeline,
+  };
+}

--- a/src/routes/skill-dispatcher.test.ts
+++ b/src/routes/skill-dispatcher.test.ts
@@ -1,0 +1,467 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { buildDispatchRequest, dispatchToKarvi, resubmitWithApproval } from './skill-dispatcher';
+import type { SkillDispatchContext, DispatchDeps } from './skill-dispatcher';
+import type { SkillObject } from '../schemas/skill-object';
+import type { SkillObjectLookup } from '../skills/types';
+import { KarviClient } from '../karvi-client/client';
+import { KarviNetworkError, KarviApiError } from '../karvi-client/schemas';
+import type { Database } from 'bun:sqlite';
+import { createDb, initSchema } from '../db';
+
+// ─── Fixtures ───
+
+function makeSkillObject(overrides?: { mode?: 'local' | 'karvi' | 'hybrid' }): SkillObject {
+  return {
+    kind: 'SkillObject',
+    apiVersion: '1.0.0',
+    id: 'skill.deploy-service',
+    name: 'deploy-service',
+    version: '1.2.0',
+    status: 'promoted',
+    identity: {
+      summary: 'Deploy a service',
+      owners: { human: ['dev'], agent: ['volva'] },
+      domain: 'ops',
+      tags: ['deploy'],
+      maturity: 'stable',
+      riskTier: 'medium',
+    },
+    purpose: {
+      problemShapes: ['deploy'],
+      desiredOutcomes: ['deployed'],
+      nonGoals: [],
+      notFor: [],
+    },
+    routing: {
+      description: 'Deploy service',
+      triggerWhen: ['deploy'],
+      doNotTriggerWhen: [],
+      priority: 50,
+      conflictsWith: [],
+      mayChainTo: [],
+    },
+    contract: {
+      inputs: { required: [], optional: [] },
+      outputs: { primary: [], secondary: [] },
+      successCriteria: [],
+      failureModes: [],
+    },
+    package: {
+      root: '/skills/deploy',
+      entryFile: 'SKILL.md',
+      references: [],
+      scripts: [],
+      assets: [],
+      config: { schemaFile: '', dataFile: '' },
+      hooks: [],
+      localState: { enabled: false, stablePath: '', files: [] },
+    },
+    environment: {
+      toolsRequired: ['git', 'docker'],
+      toolsOptional: ['kubectl'],
+      permissions: {
+        filesystem: { read: true, write: true },
+        network: { read: true, write: true },
+        process: { spawn: true },
+        secrets: { read: ['DEPLOY_KEY'] },
+      },
+      externalSideEffects: true,
+      executionMode: 'active',
+    },
+    dispatch: {
+      mode: overrides?.mode ?? 'karvi',
+      targetSelection: { repoPolicy: 'explicit', runtimeOptions: ['claude'] },
+      workerClass: ['implementation'],
+      handoff: { inputArtifacts: [], outputArtifacts: ['deploy_url'] },
+      executionPolicy: { sync: false, retries: 1, timeoutMinutes: 20, escalationOnFailure: true },
+      approval: { requireHumanBeforeDispatch: false, requireHumanBeforeMerge: true },
+    },
+    verification: {
+      smokeChecks: ['staging-smoke-pass'],
+      assertions: [],
+      humanCheckpoints: [],
+      outcomeSignals: ['deploy_url_reachable'],
+    },
+    memory: {
+      localMemoryPolicy: { canStore: [], cannotStore: [] },
+      precedentWriteback: { enabled: false, target: '', when: [] },
+    },
+    governance: {
+      mutability: {
+        agentMayEdit: [],
+        agentMayPropose: [],
+        humanApprovalRequired: [],
+        forbiddenWithoutHuman: [],
+      },
+      reviewPolicy: { requiredReviewers: [] },
+      promotionGates: [],
+      rollbackPolicy: { allowed: false, rollbackOn: [] },
+      supersession: { supersedes: [], supersededBy: null },
+    },
+  };
+}
+
+function makeContext(overrides?: Partial<SkillDispatchContext>): SkillDispatchContext {
+  return {
+    skillId: 'skill.deploy-service',
+    conversationId: 'conv_123',
+    userMessage: 'Deploy checkout-service to staging',
+    workingDir: '/repos/checkout-service',
+    inputs: { service_name: 'checkout-service' },
+    ...overrides,
+  };
+}
+
+function makeLookup(skillObj: SkillObject | null): SkillObjectLookup {
+  return {
+    getSkillObject: () => skillObj,
+  };
+}
+
+function makeMockKarviClient(): KarviClient & {
+  dispatchSkill: ReturnType<typeof vi.fn>;
+  getDispatchStatus: ReturnType<typeof vi.fn>;
+} {
+  const client = {
+    dispatchSkill: vi.fn(),
+    getDispatchStatus: vi.fn(),
+    getHealth: vi.fn(),
+    cancelDispatch: vi.fn(),
+    registerPipeline: vi.fn(),
+    listPipelines: vi.fn(),
+    deletePipeline: vi.fn(),
+    forgeBuild: vi.fn(),
+  } as unknown as KarviClient & {
+    dispatchSkill: ReturnType<typeof vi.fn>;
+    getDispatchStatus: ReturnType<typeof vi.fn>;
+  };
+  return client;
+}
+
+// ─── buildDispatchRequest ───
+
+describe('buildDispatchRequest', () => {
+  it('assembles all fields from merged skill object and context', () => {
+    const skill = makeSkillObject();
+    const ctx = makeContext();
+    const result = buildDispatchRequest(skill, ctx, '# SKILL.md content');
+
+    expect(result.skillId).toBe('skill.deploy-service');
+    expect(result.skillName).toBe('deploy-service');
+    expect(result.skillVersion).toBe('1.2.0');
+    expect(result.skillContent).toBe('# SKILL.md content');
+    expect(result.environment.toolsRequired).toEqual(['git', 'docker']);
+    expect(result.environment.permissions.filesystem.read).toBe(true);
+    expect(result.dispatch.targetSelection.repoPolicy).toBe('explicit');
+    expect(result.dispatch.workerClass).toEqual(['implementation']);
+    expect(result.dispatch.executionPolicy.timeoutMinutes).toBe(20);
+    expect(result.dispatch.approval.requireHumanBeforeMerge).toBe(true);
+    expect(result.verification.smokeChecks).toEqual(['staging-smoke-pass']);
+    expect(result.context.conversationId).toBe('conv_123');
+    expect(result.context.userMessage).toBe('Deploy checkout-service to staging');
+    expect(result.context.inputs.service_name).toBe('checkout-service');
+  });
+
+  it('handles optional context fields', () => {
+    const skill = makeSkillObject();
+    const ctx = makeContext({ conversationId: undefined, workingDir: undefined });
+    const result = buildDispatchRequest(skill, ctx, 'content');
+
+    expect(result.context.conversationId).toBeUndefined();
+    expect(result.context.workingDir).toBeUndefined();
+  });
+});
+
+// ─── dispatchToKarvi ───
+
+describe('dispatchToKarvi', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+  });
+
+  it('returns fallback_local when skill not found', async () => {
+    const client = makeMockKarviClient();
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(null),
+      karviClient: client,
+      db,
+    };
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('fallback_local');
+    if (result.type === 'fallback_local') {
+      expect(result.reason).toContain('Skill not found');
+    }
+  });
+
+  it('returns fallback_local when dispatch.mode is local', async () => {
+    const client = makeMockKarviClient();
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject({ mode: 'local' })),
+      karviClient: client,
+      db,
+    };
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('fallback_local');
+    if (result.type === 'fallback_local') {
+      expect(result.reason).toContain("'local'");
+    }
+  });
+
+  it('returns dispatched on successful Karvi execution', async () => {
+    // Insert skill instance for telemetry foreign key
+    db.prepare(
+      `INSERT INTO skill_instances (id, skill_id, name, status, run_count, success_count)
+       VALUES (?, ?, ?, ?, 0, 0)`,
+    ).run('skill.deploy-service', 'skill.deploy-service', 'deploy-service', 'promoted');
+
+    const client = makeMockKarviClient();
+    client.dispatchSkill.mockResolvedValueOnce({
+      dispatchId: 'dispatch_001',
+      status: 'pending',
+    });
+    client.getDispatchStatus.mockResolvedValueOnce({
+      id: 'dispatch_001',
+      status: 'completed',
+      type: 'skill',
+      createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
+      result: {
+        skillId: 'skill.deploy-service',
+        status: 'success',
+        durationMs: 5000,
+        steps: [{ stepId: 'plan', type: 'plan', status: 'success', artifacts: [] }],
+        outputs: { deploy_url: 'https://staging.example.com' },
+        verification: { smokeChecksPassed: true, failedChecks: [] },
+        telemetry: { tokensUsed: 1000, costUsd: 0.05, runtime: 'claude', model: 'claude-sonnet-4-5-20250514', stepsExecuted: 1 },
+      },
+    });
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject()),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# Deploy SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('dispatched');
+    if (result.type === 'dispatched') {
+      expect(result.result.status).toBe('success');
+      expect(result.result.outputs.deploy_url).toBe('https://staging.example.com');
+    }
+
+    // Verify dispatchSkill was called with correct request
+    expect(client.dispatchSkill).toHaveBeenCalledOnce();
+    const sentRequest = client.dispatchSkill.mock.calls[0][0];
+    expect(sentRequest.skillId).toBe('skill.deploy-service');
+    expect(sentRequest.skillContent).toBe('# Deploy SKILL.md');
+  });
+
+  it('returns approval_required when Karvi requires approval', async () => {
+    const client = makeMockKarviClient();
+    client.dispatchSkill.mockRejectedValueOnce(
+      new KarviApiError('APPROVAL_REQUIRED', 'pending_abc123'),
+    );
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject()),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('approval_required');
+    if (result.type === 'approval_required') {
+      expect(result.pendingId).toBe('pending_abc123');
+      expect(result.skillName).toBe('deploy-service');
+      expect(result.sideEffects).toBe(true);
+    }
+  });
+
+  it('returns fallback_local when Karvi is unreachable', async () => {
+    const client = makeMockKarviClient();
+    client.dispatchSkill.mockRejectedValueOnce(
+      new KarviNetworkError('Connection refused'),
+    );
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject()),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('fallback_local');
+    if (result.type === 'fallback_local') {
+      expect(result.reason).toContain('Karvi unreachable');
+    }
+  });
+
+  it('returns fallback_local when SKILL.md cannot be read', async () => {
+    const client = makeMockKarviClient();
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject()),
+      karviClient: client,
+      db,
+      readSkillContent: () => { throw new Error('File not found'); },
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('fallback_local');
+    if (result.type === 'fallback_local') {
+      expect(result.reason).toContain('Failed to read SKILL.md');
+    }
+  });
+
+  it('records telemetry after successful dispatch', async () => {
+    const client = makeMockKarviClient();
+    client.dispatchSkill.mockResolvedValueOnce({
+      dispatchId: 'dispatch_002',
+      status: 'pending',
+    });
+    client.getDispatchStatus.mockResolvedValueOnce({
+      id: 'dispatch_002',
+      status: 'completed',
+      type: 'skill',
+      createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
+      result: {
+        skillId: 'skill.deploy-service',
+        status: 'success',
+        durationMs: 3000,
+        steps: [],
+        outputs: {},
+        verification: { smokeChecksPassed: true, failedChecks: [] },
+        telemetry: { tokensUsed: 500, costUsd: 0.02, runtime: 'claude', model: 'claude-sonnet-4-5-20250514', stepsExecuted: 0 },
+      },
+    });
+
+    // Insert a skill_instance record so telemetry recording works
+    db.prepare(
+      `INSERT INTO skill_instances (id, skill_id, name, status, run_count, success_count)
+       VALUES (?, ?, ?, ?, 0, 0)`,
+    ).run('skill.deploy-service', 'skill.deploy-service', 'deploy-service', 'promoted');
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject()),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    await dispatchToKarvi(makeContext(), deps);
+
+    // Check that run was recorded
+    const runs = db.prepare('SELECT * FROM skill_runs WHERE skill_instance_id = ?')
+      .all('skill.deploy-service') as Array<Record<string, unknown>>;
+    expect(runs).toHaveLength(1);
+    expect(runs[0].outcome).toBe('success');
+    expect(runs[0].duration_ms).toBe(3000);
+
+    // Check counters updated
+    const instance = db.prepare('SELECT run_count, success_count FROM skill_instances WHERE id = ?')
+      .get('skill.deploy-service') as Record<string, unknown>;
+    expect(instance.run_count).toBe(1);
+    expect(instance.success_count).toBe(1);
+  });
+});
+
+// ─── resubmitWithApproval ───
+
+describe('resubmitWithApproval', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+  });
+
+  it('sends approval token in the dispatch request', async () => {
+    const client = makeMockKarviClient();
+    client.dispatchSkill.mockResolvedValueOnce({
+      dispatchId: 'dispatch_003',
+      status: 'pending',
+    });
+    client.getDispatchStatus.mockResolvedValueOnce({
+      id: 'dispatch_003',
+      status: 'completed',
+      type: 'skill',
+      createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
+      result: {
+        skillId: 'skill.deploy-service',
+        status: 'success',
+        durationMs: 4000,
+        steps: [],
+        outputs: {},
+        verification: { smokeChecksPassed: true, failedChecks: [] },
+        telemetry: { tokensUsed: 800, costUsd: 0.03, runtime: 'claude', model: 'claude-sonnet-4-5-20250514', stepsExecuted: 1 },
+      },
+    });
+
+    // Insert skill instance for telemetry
+    db.prepare(
+      `INSERT INTO skill_instances (id, skill_id, name, status, run_count, success_count)
+       VALUES (?, ?, ?, ?, 0, 0)`,
+    ).run('skill.deploy-service', 'skill.deploy-service', 'deploy-service', 'promoted');
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject()),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const token = {
+      pendingId: 'pending_abc123',
+      approvedBy: 'human',
+      approvedAt: '2026-01-01T00:00:00Z',
+    };
+
+    const result = await resubmitWithApproval(makeContext(), token, deps);
+    expect(result.type).toBe('dispatched');
+
+    // Verify the approval token was included
+    const sentRequest = client.dispatchSkill.mock.calls[0][0];
+    expect(sentRequest.approvalToken).toEqual(token);
+  });
+
+  it('returns fallback_local when skill not found', async () => {
+    const client = makeMockKarviClient();
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(null),
+      karviClient: client,
+      db,
+    };
+
+    const token = { pendingId: 'p1', approvedBy: 'human', approvedAt: '2026-01-01T00:00:00Z' };
+    const result = await resubmitWithApproval(makeContext(), token, deps);
+    expect(result.type).toBe('fallback_local');
+  });
+
+  it('returns fallback_local when Karvi is unreachable on resubmit', async () => {
+    const client = makeMockKarviClient();
+    client.dispatchSkill.mockRejectedValueOnce(
+      new KarviNetworkError('Connection refused'),
+    );
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject()),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const token = { pendingId: 'p1', approvedBy: 'human', approvedAt: '2026-01-01T00:00:00Z' };
+    const result = await resubmitWithApproval(makeContext(), token, deps);
+    expect(result.type).toBe('fallback_local');
+    if (result.type === 'fallback_local') {
+      expect(result.reason).toContain('Karvi unreachable');
+    }
+  });
+});

--- a/src/routes/skill-dispatcher.ts
+++ b/src/routes/skill-dispatcher.ts
@@ -1,0 +1,291 @@
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import type { Database } from 'bun:sqlite';
+import type { SkillObject } from '../schemas/skill-object';
+import type { SkillObjectLookup } from '../skills/types';
+import type { SkillDispatchRequest, SkillDispatchResult } from '../karvi-client/schemas';
+import { KarviClient } from '../karvi-client/client';
+import { KarviNetworkError, KarviApiError } from '../karvi-client/schemas';
+import { mergeSkillObject } from '../skills/overlay-merge';
+import { recordRun } from '../skills/telemetry';
+
+// ─── Types ───
+
+export interface SkillDispatchContext {
+  skillId: string;
+  conversationId?: string;
+  userMessage: string;
+  workingDir?: string;
+  inputs: Record<string, string>;
+}
+
+export type SkillDispatchOutcome =
+  | { type: 'dispatched'; result: SkillDispatchResult }
+  | { type: 'approval_required'; pendingId: string; skillName: string; permissions: SkillObject['environment']['permissions']; sideEffects: boolean }
+  | { type: 'fallback_local'; reason: string };
+
+export interface DispatchDeps {
+  skillObjectLookup: SkillObjectLookup;
+  karviClient: KarviClient;
+  db: Database;
+  readSkillContent?: (skillFilePath: string) => string;
+  dispatchOverlay?: Record<string, unknown>;
+}
+
+// ─── Pure Functions ───
+
+/**
+ * Read SKILL.md content from the skill package directory.
+ * The skill.object.yaml filePath points to e.g. /path/to/skills/deploy/skill.object.yaml
+ * The SKILL.md should be in the same directory.
+ */
+export function readSkillMdContent(skillFilePath: string): string {
+  const dir = dirname(skillFilePath);
+  const skillMdPath = join(dir, 'SKILL.md');
+  return readFileSync(skillMdPath, 'utf-8');
+}
+
+/**
+ * Build a SkillDispatchRequest from a merged SkillObject and dispatch context.
+ * Pure function — no side effects.
+ */
+export function buildDispatchRequest(
+  merged: SkillObject,
+  ctx: SkillDispatchContext,
+  skillContent: string,
+): SkillDispatchRequest {
+  return {
+    skillId: merged.id,
+    skillName: merged.name,
+    skillVersion: merged.version,
+    skillContent,
+    environment: {
+      toolsRequired: merged.environment.toolsRequired,
+      toolsOptional: merged.environment.toolsOptional,
+      permissions: merged.environment.permissions,
+      externalSideEffects: merged.environment.externalSideEffects,
+      executionMode: merged.environment.executionMode,
+    },
+    dispatch: {
+      targetSelection: merged.dispatch.targetSelection,
+      workerClass: merged.dispatch.workerClass,
+      handoff: merged.dispatch.handoff,
+      executionPolicy: merged.dispatch.executionPolicy,
+      approval: merged.dispatch.approval,
+    },
+    verification: {
+      smokeChecks: merged.verification.smokeChecks,
+      assertions: merged.verification.assertions,
+      humanCheckpoints: merged.verification.humanCheckpoints,
+      outcomeSignals: merged.verification.outcomeSignals,
+    },
+    context: {
+      conversationId: ctx.conversationId,
+      userMessage: ctx.userMessage,
+      workingDir: ctx.workingDir,
+      inputs: ctx.inputs,
+    },
+  };
+}
+
+// ─── Dispatch Orchestration ───
+
+/**
+ * Dispatch a skill to Karvi for remote execution.
+ *
+ * Returns a discriminated union:
+ * - 'dispatched': Karvi executed the skill successfully (or with failure status)
+ * - 'approval_required': Karvi needs human approval before dispatch
+ * - 'fallback_local': Karvi is unreachable or skill is not configured for Karvi
+ */
+export async function dispatchToKarvi(
+  ctx: SkillDispatchContext,
+  deps: DispatchDeps,
+): Promise<SkillDispatchOutcome> {
+  // 1. Look up skill object
+  const skillObj = deps.skillObjectLookup.getSkillObject(ctx.skillId);
+  if (!skillObj) {
+    return { type: 'fallback_local', reason: `Skill not found: ${ctx.skillId}` };
+  }
+
+  // 2. Check dispatch mode
+  if (skillObj.dispatch.mode !== 'karvi') {
+    return { type: 'fallback_local', reason: `Skill dispatch.mode is '${skillObj.dispatch.mode}', not 'karvi'` };
+  }
+
+  // 3. Merge with dispatch overlay (four-plane-ownership)
+  const merged = deps.dispatchOverlay
+    ? mergeSkillObject(skillObj, deps.dispatchOverlay)
+    : skillObj;
+
+  // 4. Read SKILL.md content
+  const readContent = deps.readSkillContent ?? readSkillMdContent;
+  let skillContent: string;
+  try {
+    // Find the file path from the registry index entry
+    skillContent = readContent(ctx.skillId);
+  } catch {
+    return { type: 'fallback_local', reason: 'Failed to read SKILL.md content' };
+  }
+
+  // 5. Build request
+  const request = buildDispatchRequest(merged, ctx, skillContent);
+
+  // 6. Dispatch to Karvi
+  try {
+    const dispatchResponse = await deps.karviClient.dispatchSkill(request);
+
+    // 7. Poll for completion
+    const result = await pollForCompletion(
+      dispatchResponse.dispatchId,
+      deps.karviClient,
+      merged.dispatch.executionPolicy.timeoutMinutes,
+    );
+
+    // 8. Record telemetry
+    recordRun(deps.db, {
+      skillInstanceId: ctx.skillId,
+      conversationId: ctx.conversationId,
+      outcome: mapResultStatus(result.status),
+      durationMs: result.durationMs,
+      notes: `Karvi dispatch: ${dispatchResponse.dispatchId}`,
+    });
+
+    return { type: 'dispatched', result };
+  } catch (error) {
+    // Handle APPROVAL_REQUIRED
+    if (error instanceof KarviApiError && error.code === 'APPROVAL_REQUIRED') {
+      return {
+        type: 'approval_required',
+        pendingId: error.message,
+        skillName: merged.name,
+        permissions: merged.environment.permissions,
+        sideEffects: merged.environment.externalSideEffects,
+      };
+    }
+
+    // Graceful fallback on network errors
+    if (error instanceof KarviNetworkError) {
+      console.error('[skill-dispatcher] Karvi unreachable, falling back to local:', error.message);
+      return { type: 'fallback_local', reason: `Karvi unreachable: ${error.message}` };
+    }
+
+    // Re-throw unexpected errors
+    throw error;
+  }
+}
+
+/**
+ * Re-submit a dispatch request with approval token after user approves.
+ */
+export async function resubmitWithApproval(
+  ctx: SkillDispatchContext,
+  approvalToken: { pendingId: string; approvedBy: string; approvedAt: string },
+  deps: DispatchDeps,
+): Promise<SkillDispatchOutcome> {
+  const skillObj = deps.skillObjectLookup.getSkillObject(ctx.skillId);
+  if (!skillObj) {
+    return { type: 'fallback_local', reason: `Skill not found: ${ctx.skillId}` };
+  }
+
+  const merged = deps.dispatchOverlay
+    ? mergeSkillObject(skillObj, deps.dispatchOverlay)
+    : skillObj;
+
+  const readContent = deps.readSkillContent ?? readSkillMdContent;
+  let skillContent: string;
+  try {
+    skillContent = readContent(ctx.skillId);
+  } catch {
+    return { type: 'fallback_local', reason: 'Failed to read SKILL.md content' };
+  }
+
+  const request: SkillDispatchRequest = {
+    ...buildDispatchRequest(merged, ctx, skillContent),
+    approvalToken,
+  };
+
+  try {
+    const dispatchResponse = await deps.karviClient.dispatchSkill(request);
+
+    const result = await pollForCompletion(
+      dispatchResponse.dispatchId,
+      deps.karviClient,
+      merged.dispatch.executionPolicy.timeoutMinutes,
+    );
+
+    recordRun(deps.db, {
+      skillInstanceId: ctx.skillId,
+      conversationId: ctx.conversationId,
+      outcome: mapResultStatus(result.status),
+      durationMs: result.durationMs,
+      notes: `Karvi dispatch (approved): ${dispatchResponse.dispatchId}`,
+    });
+
+    return { type: 'dispatched', result };
+  } catch (error) {
+    if (error instanceof KarviNetworkError) {
+      console.error('[skill-dispatcher] Karvi unreachable on resubmit:', error.message);
+      return { type: 'fallback_local', reason: `Karvi unreachable: ${error.message}` };
+    }
+    throw error;
+  }
+}
+
+// ─── Internal Helpers ───
+
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLL_ATTEMPTS = (timeoutMinutes: number) => Math.ceil((timeoutMinutes * 60 * 1000) / POLL_INTERVAL_MS);
+
+async function pollForCompletion(
+  dispatchId: string,
+  client: KarviClient,
+  timeoutMinutes: number,
+): Promise<SkillDispatchResult> {
+  const maxAttempts = MAX_POLL_ATTEMPTS(timeoutMinutes);
+
+  for (let i = 0; i < maxAttempts; i++) {
+    const status = await client.getDispatchStatus(dispatchId);
+
+    if (status.status === 'completed' || status.status === 'failed' || status.status === 'cancelled') {
+      if (status.result && 'outputs' in status.result) {
+        return status.result;
+      }
+      // Terminal state but no result — construct minimal result
+      return {
+        skillId: '',
+        status: status.status === 'completed' ? 'success' : 'failure',
+        durationMs: 0,
+        steps: [],
+        outputs: {},
+        verification: { smokeChecksPassed: false, failedChecks: [] },
+        telemetry: { tokensUsed: 0, costUsd: 0, runtime: 'unknown', model: 'unknown', stepsExecuted: 0 },
+      };
+    }
+
+    await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
+  }
+
+  // Timeout
+  return {
+    skillId: '',
+    status: 'failure',
+    durationMs: timeoutMinutes * 60 * 1000,
+    steps: [],
+    outputs: {},
+    verification: { smokeChecksPassed: false, failedChecks: ['timeout'] },
+    telemetry: { tokensUsed: 0, costUsd: 0, runtime: 'unknown', model: 'unknown', stepsExecuted: 0 },
+  };
+}
+
+function mapResultStatus(status: SkillDispatchResult['status']): 'success' | 'failure' | 'partial' {
+  switch (status) {
+    case 'success':
+      return 'success';
+    case 'partial':
+      return 'partial';
+    case 'failure':
+    case 'cancelled':
+      return 'failure';
+  }
+}

--- a/src/skills/registry.ts
+++ b/src/skills/registry.ts
@@ -4,7 +4,7 @@ import type { SkillObject, SkillStatus } from '../schemas/skill-object';
 import { parseSkillYamlFile } from './yaml-parser';
 import type { SkillFilter, SkillIndexEntry, ScanResult } from './types';
 
-export type { SkillLookup, SkillMatch } from './types';
+export type { SkillLookup, SkillMatch, SkillObjectLookup } from './types';
 
 const STATUS_ORDER: SkillStatus[] = [
   'draft',
@@ -76,6 +76,11 @@ export class SkillRegistry {
 
   get(id: string): SkillObject | null {
     return this.index.get(id)?.skillObject ?? null;
+  }
+
+  /** Satisfies SkillObjectLookup interface */
+  getSkillObject(skillId: string): SkillObject | null {
+    return this.get(skillId);
   }
 
   list(filter?: SkillFilter): SkillIndexEntry[] {

--- a/src/skills/types.ts
+++ b/src/skills/types.ts
@@ -12,6 +12,12 @@ export interface SkillMatch {
   matchedTriggers: string[];
 }
 
+// ─── DI interface for Skill Object lookup ───
+
+export interface SkillObjectLookup {
+  getSkillObject(skillId: string): SkillObject | null;
+}
+
 // ─── Registry types ───
 
 export interface SkillIndexEntry {


### PR DESCRIPTION
Closes #146. Adds skill-dispatcher with Karvi dispatch orchestration, approval flow, graceful fallback, and telemetry recording. 18 new tests.