### PR TITLE
feat(skills): add skill CRUD routes + container selection routes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,11 @@ import { conversationRoutes } from './routes/conversations';
 import { cardRoutes } from './routes/cards';
 import { settlementRoutes } from './routes/settlements';
 import { decisionRoutes } from './routes/decisions';
+import { skillRoutes } from './routes/skills';
+import { containerRoutes } from './routes/containers';
 import { DecisionSessionManager } from './decision/session-manager';
+import { SkillRegistry } from './skills/registry';
+import { createSkillLookup } from './skills/trigger-matcher';
 
 const dbPath = process.env.VOLVA_DB_PATH || ':memory:';
 const db = createDb(dbPath);
@@ -20,6 +24,8 @@ const thyra = new ThyraClient();
 const karvi = new KarviClient();
 
 const sessionManager = new DecisionSessionManager(db);
+const registry = new SkillRegistry();
+const skillLookup = createSkillLookup(registry);
 
 const app = new Hono();
 
@@ -27,6 +33,8 @@ app.route('/', conversationRoutes({ db, llm, cardManager, thyra }));
 app.route('/', cardRoutes({ cardManager }));
 app.route('/', settlementRoutes({ db, cardManager, thyra, karvi }));
 app.route('/', decisionRoutes({ db, llm, sessionManager }));
+app.route('/', skillRoutes({ db, llm, registry }));
+app.route('/', containerRoutes({ skillLookup }));
 
 export default {
   port: 3460,

--- a/src/routes/containers.test.ts
+++ b/src/routes/containers.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+import { Hono } from 'hono';
+import { containerRoutes } from './containers';
+import type { SkillLookup, SkillMatch } from '../skills/types';
+
+// ─── Helpers ───
+
+function createMockSkillLookup(matches: SkillMatch[] = []): SkillLookup {
+  return {
+    findMatching: () => matches,
+  };
+}
+
+function createTestApp(skillLookup?: SkillLookup) {
+  const app = new Hono();
+  app.route('/', containerRoutes({ skillLookup: skillLookup ?? createMockSkillLookup() }));
+  return app;
+}
+
+async function jsonPost(app: Hono, path: string, body: Record<string, unknown> = {}) {
+  return app.request(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+// ─── Tests ───
+
+describe('containerRoutes', () => {
+  describe('POST /api/containers/select', () => {
+    it('requires userMessage', async () => {
+      const app = createTestApp();
+      const res = await jsonPost(app, '/api/containers/select', {});
+      expect(res.status).toBe(400);
+    });
+
+    it('returns container selection for world keyword', async () => {
+      const app = createTestApp();
+      const res = await jsonPost(app, '/api/containers/select', {
+        userMessage: 'Set up my workspace for the project',
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      expect(json.ok).toBe(true);
+      const data = json.data as Record<string, unknown>;
+      const selection = data.selection as Record<string, unknown>;
+      expect(selection.primary).toBe('world');
+      expect(selection.confidence).toBe('high');
+    });
+
+    it('returns shape for exploratory messages', async () => {
+      const app = createTestApp();
+      const res = await jsonPost(app, '/api/containers/select', {
+        userMessage: 'I want to explore some ideas about my business',
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      const data = json.data as Record<string, unknown>;
+      const selection = data.selection as Record<string, unknown>;
+      expect(selection.primary).toBe('shape');
+    });
+
+    it('returns skill when matching skill found', async () => {
+      const lookup = createMockSkillLookup([
+        { skillId: 'skill.deploy', confidence: 'high', matchedTriggers: ['deploy'] },
+      ]);
+      const app = createTestApp(lookup);
+      const res = await jsonPost(app, '/api/containers/select', {
+        userMessage: 'deploy my service now',
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      const data = json.data as Record<string, unknown>;
+      const selection = data.selection as Record<string, unknown>;
+      expect(selection.primary).toBe('skill');
+      expect(selection.skillId).toBe('skill.deploy');
+    });
+
+    it('includes behavior in response', async () => {
+      const app = createTestApp();
+      const res = await jsonPost(app, '/api/containers/select', {
+        userMessage: 'Set up my workspace',
+      });
+      const json = await res.json() as Record<string, unknown>;
+      const data = json.data as Record<string, unknown>;
+      expect(data.behavior).toBeDefined();
+    });
+
+    it('accepts optional routing context fields', async () => {
+      const app = createTestApp();
+      const res = await jsonPost(app, '/api/containers/select', {
+        userMessage: 'do some work',
+        hasActiveWorld: true,
+        conversationHistory: ['previous message'],
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      const data = json.data as Record<string, unknown>;
+      const selection = data.selection as Record<string, unknown>;
+      // hasActiveWorld should route to world
+      expect(selection.primary).toBe('world');
+    });
+  });
+
+  describe('POST /api/containers/transition', () => {
+    it('requires current, proposed, and reason', async () => {
+      const app = createTestApp();
+
+      let res = await jsonPost(app, '/api/containers/transition', { proposed: 'task', reason: 'test' });
+      expect(res.status).toBe(400);
+
+      res = await jsonPost(app, '/api/containers/transition', { current: 'shape', reason: 'test' });
+      expect(res.status).toBe(400);
+
+      res = await jsonPost(app, '/api/containers/transition', { current: 'shape', proposed: 'task' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid container names', async () => {
+      const app = createTestApp();
+      const res = await jsonPost(app, '/api/containers/transition', {
+        current: 'invalid',
+        proposed: 'task',
+        reason: 'test',
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('allows valid transition shape → task', async () => {
+      const app = createTestApp();
+      const res = await jsonPost(app, '/api/containers/transition', {
+        current: 'shape',
+        proposed: 'task',
+        reason: 'User wants bounded work',
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      const data = json.data as Record<string, unknown>;
+      expect(data.allowed).toBe(true);
+      expect(data.newContainer).toBe('task');
+    });
+
+    it('rejects invalid transition task → world', async () => {
+      const app = createTestApp();
+      const res = await jsonPost(app, '/api/containers/transition', {
+        current: 'task',
+        proposed: 'world',
+        reason: 'test',
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      const data = json.data as Record<string, unknown>;
+      expect(data.allowed).toBe(false);
+      expect(data.newContainer).toBe('task');
+    });
+
+    it('allows same-container no-op transition', async () => {
+      const app = createTestApp();
+      const res = await jsonPost(app, '/api/containers/transition', {
+        current: 'task',
+        proposed: 'task',
+        reason: 'No change needed',
+      });
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      const data = json.data as Record<string, unknown>;
+      expect(data.allowed).toBe(true);
+    });
+  });
+});

--- a/src/routes/containers.ts
+++ b/src/routes/containers.ts
@@ -1,0 +1,87 @@
+import { Hono } from 'hono';
+import { ok, error } from './response';
+import { selectContainer, getConfidenceBehavior } from '../containers/router';
+import { checkContainerTransition } from '../containers/transitions';
+import type { SkillLookup } from '../skills/types';
+import type { Container, RoutingContext } from '../containers/types';
+import type { IntentType } from '../schemas/intent';
+
+// ─── DI Interface ───
+
+export interface ContainerDeps {
+  skillLookup: SkillLookup;
+}
+
+// ─── Helpers ───
+
+const VALID_CONTAINERS: Container[] = ['world', 'shape', 'skill', 'task', 'review', 'harvest'];
+
+function isValidContainer(value: string): value is Container {
+  return (VALID_CONTAINERS as string[]).includes(value);
+}
+
+// ─── Route Factory ───
+
+export function containerRoutes(deps: ContainerDeps): Hono {
+  const app = new Hono();
+
+  // ─── POST /api/containers/select ───
+  // Container selection (0 LLM calls — keyword heuristics)
+  app.post('/api/containers/select', async (c) => {
+    const body: Record<string, unknown> = await c.req.json();
+    const userMessage = body.userMessage;
+
+    if (!userMessage || typeof userMessage !== 'string') {
+      return error(c, 'INVALID_INPUT', 'userMessage is required', 400);
+    }
+
+    const ctx: RoutingContext = { userMessage };
+
+    if (typeof body.intentType === 'string') {
+      ctx.intentType = body.intentType as IntentType;
+    }
+    if (typeof body.hasActiveWorld === 'boolean') {
+      ctx.hasActiveWorld = body.hasActiveWorld;
+    }
+    if (Array.isArray(body.conversationHistory)) {
+      ctx.conversationHistory = (body.conversationHistory as unknown[])
+        .filter((s): s is string => typeof s === 'string');
+    }
+
+    const selection = selectContainer(ctx, deps.skillLookup);
+    const behavior = getConfidenceBehavior(selection);
+
+    return ok(c, { selection, behavior });
+  });
+
+  // ─── POST /api/containers/transition ───
+  // Validate container transition (0 LLM calls — pure function)
+  app.post('/api/containers/transition', async (c) => {
+    const body: Record<string, unknown> = await c.req.json();
+    const current = body.current;
+    const proposed = body.proposed;
+    const reason = body.reason;
+
+    if (!current || typeof current !== 'string') {
+      return error(c, 'INVALID_INPUT', 'current container is required', 400);
+    }
+    if (!proposed || typeof proposed !== 'string') {
+      return error(c, 'INVALID_INPUT', 'proposed container is required', 400);
+    }
+    if (!reason || typeof reason !== 'string') {
+      return error(c, 'INVALID_INPUT', 'reason is required', 400);
+    }
+
+    if (!isValidContainer(current)) {
+      return error(c, 'INVALID_INPUT', `Invalid container: ${current}`, 400);
+    }
+    if (!isValidContainer(proposed)) {
+      return error(c, 'INVALID_INPUT', `Invalid container: ${proposed}`, 400);
+    }
+
+    const result = checkContainerTransition(current, proposed, reason);
+    return ok(c, result);
+  });
+
+  return app;
+}

--- a/src/routes/skills.test.ts
+++ b/src/routes/skills.test.ts
@@ -1,0 +1,374 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Hono } from 'hono';
+import { createDb, initSchema } from '../db';
+import { SkillRegistry } from '../skills/registry';
+import { skillRoutes } from './skills';
+import type { Database } from 'bun:sqlite';
+import type { LLMClient } from '../llm/client';
+import type { SkillObject } from '../schemas/skill-object';
+
+// ─── Helpers ───
+
+function createMockLLM(): LLMClient & { generateStructured: ReturnType<typeof vi.fn> } {
+  return {
+    generateStructured: vi.fn(),
+    generateText: vi.fn(),
+  } as unknown as LLMClient & { generateStructured: ReturnType<typeof vi.fn> };
+}
+
+function makeMinimalSkillObject(overrides?: Partial<SkillObject>): SkillObject {
+  return {
+    kind: 'SkillObject',
+    apiVersion: 'volva.ai/v0',
+    id: 'skill.test-skill',
+    name: 'Test Skill',
+    version: '0.1.0',
+    status: 'sandbox',
+    identity: {
+      summary: 'A test skill',
+      owners: { human: [], agent: [] },
+      domain: 'testing',
+      tags: ['test'],
+      maturity: 'emerging',
+      riskTier: 'low',
+    },
+    purpose: {
+      problemShapes: ['test problems'],
+      desiredOutcomes: ['tested code'],
+      nonGoals: ['production deploys'],
+      notFor: [],
+    },
+    routing: {
+      description: 'A test skill',
+      triggerWhen: ['run tests', 'test suite'],
+      doNotTriggerWhen: ['deploy'],
+      priority: 50,
+      conflictsWith: [],
+      mayChainTo: [],
+    },
+    contract: {
+      inputs: { required: [], optional: [] },
+      outputs: { primary: [], secondary: [] },
+      successCriteria: ['tests pass'],
+      failureModes: [],
+    },
+    package: {
+      root: 'skills/test-skill/',
+      entryFile: 'SKILL.md',
+      references: [],
+      scripts: [],
+      assets: [],
+      config: { schemaFile: 'config.schema.json', dataFile: 'config.json' },
+      hooks: [],
+      localState: { enabled: true, stablePath: '${SKILL_DATA}/test-skill/', files: [] },
+    },
+    environment: {
+      toolsRequired: [],
+      toolsOptional: [],
+      permissions: {
+        filesystem: { read: true, write: false },
+        network: { read: false, write: false },
+        process: { spawn: false },
+        secrets: { read: [] },
+      },
+      externalSideEffects: false,
+      executionMode: 'advisory',
+    },
+    dispatch: {
+      mode: 'local',
+      targetSelection: { repoPolicy: 'explicit', runtimeOptions: [] },
+      workerClass: [],
+      handoff: { inputArtifacts: [], outputArtifacts: [] },
+      executionPolicy: { sync: false, retries: 1, timeoutMinutes: 30, escalationOnFailure: true },
+      approval: { requireHumanBeforeDispatch: false, requireHumanBeforeMerge: true },
+    },
+    verification: {
+      smokeChecks: ['run unit tests'],
+      assertions: [],
+      humanCheckpoints: [],
+      outcomeSignals: [],
+    },
+    memory: {
+      localMemoryPolicy: { canStore: [], cannotStore: ['secrets'] },
+      precedentWriteback: { enabled: true, target: 'edda', when: [] },
+    },
+    governance: {
+      mutability: { agentMayEdit: [], agentMayPropose: [], humanApprovalRequired: [], forbiddenWithoutHuman: [] },
+      reviewPolicy: { requiredReviewers: ['owner'] },
+      promotionGates: [],
+      rollbackPolicy: { allowed: true, rollbackOn: [] },
+      supersession: { supersedes: [], supersededBy: null },
+    },
+    telemetry: {
+      track: [{ metric: 'run_count' }],
+      thresholds: { promotion_min_success: 3, retirement_idle_days: 90 },
+      reporting: { target: 'edda', frequency: 'on_governance' },
+    },
+    lifecycle: {
+      createdFrom: [],
+      currentStage: 'capture',
+      promotionPath: ['draft', 'sandbox', 'promoted', 'core'],
+      retirementCriteria: [],
+      lastReviewedAt: null,
+    },
+    ...overrides,
+  };
+}
+
+function createTestApp(db: Database): { app: Hono; registry: SkillRegistry; llm: LLMClient & { generateStructured: ReturnType<typeof vi.fn> } } {
+  const llm = createMockLLM();
+  const registry = new SkillRegistry();
+  const app = new Hono();
+  app.route('/', skillRoutes({ db, llm, registry }));
+  return { app, registry, llm };
+}
+
+async function jsonPost(app: Hono, path: string, body: Record<string, unknown> = {}) {
+  return app.request(path, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+async function jsonGet(app: Hono, path: string) {
+  return app.request(path, { method: 'GET' });
+}
+
+// ─── Tests ───
+
+describe('skillRoutes', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+  });
+
+  describe('GET /api/skills', () => {
+    it('returns empty list when no skills registered', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonGet(app, '/api/skills');
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      expect(json.ok).toBe(true);
+      const data = json.data as Record<string, unknown>;
+      expect(data.skills).toEqual([]);
+      expect(data.total).toBe(0);
+    });
+
+    it('rejects invalid status filter', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonGet(app, '/api/skills?status=invalid');
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/skills/:id', () => {
+    it('returns 404 for unknown skill', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonGet(app, '/api/skills/skill.nonexistent');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/skills/:id/run', () => {
+    it('returns 404 for unknown skill', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonPost(app, '/api/skills/skill.nonexistent/run', {
+        outcome: 'success',
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it('rejects invalid outcome', async () => {
+      const { app, registry } = createTestApp(db);
+      // Manually inject a skill into the registry
+      const skillObj = makeMinimalSkillObject();
+      (registry as unknown as Record<string, unknown>)['index'] = new Map([
+        ['skill.test-skill', {
+          id: 'skill.test-skill',
+          name: 'Test Skill',
+          status: 'sandbox',
+          priority: 50,
+          filePath: '/fake/path',
+          triggerWhen: ['run tests'],
+          doNotTriggerWhen: ['deploy'],
+          skillObject: skillObj,
+        }],
+      ]);
+
+      const res = await jsonPost(app, '/api/skills/skill.test-skill/run', {
+        outcome: 'invalid',
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/skills/:id/promotion', () => {
+    it('returns 404 for unknown skill', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonGet(app, '/api/skills/skill.nonexistent/promotion');
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('POST /api/skills/match', () => {
+    it('requires context', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonPost(app, '/api/skills/match', {});
+      expect(res.status).toBe(400);
+    });
+
+    it('returns empty matches when no skills registered', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonPost(app, '/api/skills/match', { context: 'run tests' });
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      const data = json.data as Record<string, unknown>;
+      expect(data.matches).toEqual([]);
+    });
+  });
+
+  describe('POST /api/skills/harvest', () => {
+    it('requires context', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonPost(app, '/api/skills/harvest', { history: [{ role: 'user', content: 'hi' }] });
+      expect(res.status).toBe(400);
+    });
+
+    it('requires non-empty history', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonPost(app, '/api/skills/harvest', { context: 'test', history: [] });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns candidate with awaitConfirmation (SETTLE-01)', async () => {
+      const { app, llm } = createTestApp(db);
+
+      llm.generateStructured.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          name: 'Test Pattern',
+          summary: 'A test pattern',
+          problemShapes: ['testing'],
+          desiredOutcomes: ['tested'],
+          nonGoals: [],
+          triggerWhen: ['test'],
+          doNotTriggerWhen: [],
+          methodOutline: ['step 1'],
+          observedGotchas: [],
+        },
+      });
+
+      const res = await jsonPost(app, '/api/skills/harvest', {
+        context: 'test context',
+        history: [{ role: 'user', content: 'do some testing' }],
+      });
+
+      expect(res.status).toBe(200);
+      const json = await res.json() as Record<string, unknown>;
+      expect(json.ok).toBe(true);
+      const data = json.data as Record<string, unknown>;
+      expect(data.awaitConfirmation).toBe(true);
+      expect(data.candidate).toBeDefined();
+    });
+  });
+
+  describe('POST /api/skills/crystallize', () => {
+    it('requires confirmation (SETTLE-01)', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonPost(app, '/api/skills/crystallize', {
+        candidate: { name: 'test', summary: 'test' },
+      });
+      expect(res.status).toBe(400);
+      const json = await res.json() as Record<string, unknown>;
+      const err = json.error as Record<string, unknown>;
+      expect(err.code).toBe('CONFIRMATION_REQUIRED');
+    });
+
+    it('crystallizes candidate with confirmation', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonPost(app, '/api/skills/crystallize', {
+        confirmation: true,
+        candidate: {
+          name: 'Test Pattern',
+          summary: 'A test pattern for testing',
+          problemShapes: ['testing'],
+          desiredOutcomes: ['tested code'],
+          nonGoals: [],
+          triggerWhen: ['run tests'],
+          doNotTriggerWhen: ['deploy'],
+          methodOutline: ['step 1'],
+          observedGotchas: [],
+        },
+      });
+
+      expect(res.status).toBe(201);
+      const json = await res.json() as Record<string, unknown>;
+      expect(json.ok).toBe(true);
+      const data = json.data as Record<string, unknown>;
+      expect(data.skillObject).toBeDefined();
+      expect(data.yaml).toBeDefined();
+      expect(data.skillMd).toBeDefined();
+    });
+
+    it('rejects missing candidate', async () => {
+      const { app } = createTestApp(db);
+      const res = await jsonPost(app, '/api/skills/crystallize', {
+        confirmation: true,
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('harvest → crystallize 2-step flow (SETTLE-01)', () => {
+    it('completes the full 2-step flow', async () => {
+      const { app, llm } = createTestApp(db);
+
+      // Step 1: Harvest returns candidate for review
+      llm.generateStructured.mockResolvedValueOnce({
+        ok: true,
+        data: {
+          name: 'Deploy Flow',
+          summary: 'Standardized deploy pattern',
+          problemShapes: ['deployment'],
+          desiredOutcomes: ['deployed'],
+          nonGoals: [],
+          triggerWhen: ['deploy'],
+          doNotTriggerWhen: ['rollback'],
+          methodOutline: ['build', 'test', 'deploy'],
+          observedGotchas: ['check ports'],
+        },
+      });
+
+      const harvestRes = await jsonPost(app, '/api/skills/harvest', {
+        context: 'deploy flow context',
+        history: [
+          { role: 'user', content: 'deploy the service' },
+          { role: 'assistant', content: 'deploying...' },
+        ],
+      });
+
+      expect(harvestRes.status).toBe(200);
+      const harvestJson = await harvestRes.json() as Record<string, unknown>;
+      const harvestData = harvestJson.data as Record<string, unknown>;
+      expect(harvestData.awaitConfirmation).toBe(true);
+
+      // Step 2: User reviews and confirms crystallization
+      const candidate = harvestData.candidate;
+      const crystallizeRes = await jsonPost(app, '/api/skills/crystallize', {
+        confirmation: true,
+        candidate,
+      });
+
+      expect(crystallizeRes.status).toBe(201);
+      const crystallizeJson = await crystallizeRes.json() as Record<string, unknown>;
+      expect(crystallizeJson.ok).toBe(true);
+      const crystallizeData = crystallizeJson.data as Record<string, unknown>;
+      const skillObject = crystallizeData.skillObject as Record<string, unknown>;
+      expect(skillObject.name).toBe('Deploy Flow');
+      expect(skillObject.status).toBe('draft');
+    });
+  });
+});

--- a/src/routes/skills.ts
+++ b/src/routes/skills.ts
@@ -1,0 +1,299 @@
+import { Hono } from 'hono';
+import type { Database } from 'bun:sqlite';
+import { ok, error } from './response';
+import type { LLMClient } from '../llm/client';
+import { SkillRegistry } from '../skills/registry';
+import { matchSkills } from '../skills/trigger-matcher';
+import { recordRun, getMetrics } from '../skills/telemetry';
+import { evaluatePromotionGates } from '../skills/promotion';
+import { capturePattern } from '../skills/harvest';
+import { crystallize } from '../skills/crystallizer';
+import type { SkillStatus } from '../schemas/skill-object';
+
+// ─── DI Interface ───
+
+export interface SkillDeps {
+  db: Database;
+  llm: LLMClient;
+  registry: SkillRegistry;
+}
+
+// ─── Route Factory ───
+
+export function skillRoutes(deps: SkillDeps): Hono {
+  const app = new Hono();
+
+  // ─── GET /api/skills ───
+  // List skills with optional filters (0 LLM calls)
+  app.get('/api/skills', (c) => {
+    const status = c.req.query('status');
+    const domain = c.req.query('domain');
+    const tags = c.req.query('tags');
+
+    const filter: { minStatus?: SkillStatus; domain?: string; tags?: string[] } = {};
+
+    if (status) {
+      const validStatuses: SkillStatus[] = ['draft', 'sandbox', 'promoted', 'core', 'deprecated', 'superseded'];
+      if (!validStatuses.includes(status as SkillStatus)) {
+        return error(c, 'INVALID_INPUT', `Invalid status filter: ${status}`, 400);
+      }
+      filter.minStatus = status as SkillStatus;
+    }
+
+    if (domain) {
+      filter.domain = domain;
+    }
+
+    if (tags) {
+      filter.tags = tags.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+    }
+
+    const entries = deps.registry.list(filter);
+    const skills = entries.map((entry) => ({
+      id: entry.id,
+      name: entry.name,
+      status: entry.status,
+      priority: entry.priority,
+      domain: entry.skillObject.identity.domain,
+      tags: entry.skillObject.identity.tags,
+      maturity: entry.skillObject.identity.maturity,
+    }));
+
+    return ok(c, { skills, total: skills.length });
+  });
+
+  // ─── GET /api/skills/:id ───
+  // Get skill detail (0 LLM calls)
+  app.get('/api/skills/:id', (c) => {
+    const id = c.req.param('id');
+    const skillObject = deps.registry.get(id);
+
+    if (!skillObject) {
+      return error(c, 'NOT_FOUND', `Skill ${id} not found`, 404);
+    }
+
+    return ok(c, { skill: skillObject });
+  });
+
+  // ─── POST /api/skills/:id/run ───
+  // Record a skill run (telemetry) (0 LLM calls)
+  app.post('/api/skills/:id/run', async (c) => {
+    const skillId = c.req.param('id');
+    const body: Record<string, unknown> = await c.req.json();
+
+    // Verify skill exists in registry
+    const skillObject = deps.registry.get(skillId);
+    if (!skillObject) {
+      return error(c, 'NOT_FOUND', `Skill ${skillId} not found`, 404);
+    }
+
+    // Look up or create skill_instance row
+    const instanceRow = deps.db
+      .query('SELECT id FROM skill_instances WHERE skill_id = ?')
+      .get(skillId) as Record<string, unknown> | null;
+
+    let instanceId: string;
+    if (instanceRow) {
+      instanceId = instanceRow.id as string;
+    } else {
+      instanceId = `inst_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      deps.db.run(
+        'INSERT INTO skill_instances (id, skill_id, name, status, current_stage) VALUES (?, ?, ?, ?, ?)',
+        [instanceId, skillId, skillObject.name, skillObject.status, skillObject.lifecycle?.currentStage ?? 'capture'],
+      );
+    }
+
+    const outcome = typeof body.outcome === 'string' ? body.outcome : 'success';
+    const validOutcomes = ['success', 'failure', 'partial'];
+    if (!validOutcomes.includes(outcome)) {
+      return error(c, 'INVALID_INPUT', `Invalid outcome: ${outcome}`, 400);
+    }
+
+    const durationMs = typeof body.durationMs === 'number' ? body.durationMs : undefined;
+    const notes = typeof body.notes === 'string' ? body.notes : undefined;
+    const conversationId = typeof body.conversationId === 'string' ? body.conversationId : undefined;
+
+    const runId = recordRun(deps.db, {
+      skillInstanceId: instanceId,
+      conversationId,
+      outcome: outcome as 'success' | 'failure' | 'partial',
+      durationMs,
+      notes,
+    });
+
+    return ok(c, { runId, skillId, instanceId }, 201);
+  });
+
+  // ─── GET /api/skills/:id/promotion ───
+  // Evaluate promotion gates (0 LLM calls)
+  app.get('/api/skills/:id/promotion', (c) => {
+    const skillId = c.req.param('id');
+    const skillObject = deps.registry.get(skillId);
+
+    if (!skillObject) {
+      return error(c, 'NOT_FOUND', `Skill ${skillId} not found`, 404);
+    }
+
+    // Look up skill instance for metrics
+    const instanceRow = deps.db
+      .query('SELECT id FROM skill_instances WHERE skill_id = ?')
+      .get(skillId) as Record<string, unknown> | null;
+
+    if (!instanceRow) {
+      return ok(c, {
+        eligible: false,
+        gates: [],
+        blockers: ['no_runs'],
+        message: 'No recorded runs for this skill',
+      });
+    }
+
+    const metrics = getMetrics(deps.db, instanceRow.id as string);
+    if (!metrics) {
+      return ok(c, {
+        eligible: false,
+        gates: [],
+        blockers: ['no_metrics'],
+        message: 'No metrics available',
+      });
+    }
+
+    const result = evaluatePromotionGates(metrics, skillObject);
+    return ok(c, result);
+  });
+
+  // ─── POST /api/skills/match ───
+  // Trigger matching against context (0 LLM calls)
+  app.post('/api/skills/match', async (c) => {
+    const body: Record<string, unknown> = await c.req.json();
+    const context = body.context;
+
+    if (!context || typeof context !== 'string') {
+      return error(c, 'INVALID_INPUT', 'context is required', 400);
+    }
+
+    const entries = deps.registry.list();
+    const matches = matchSkills(context, entries);
+
+    return ok(c, { matches });
+  });
+
+  // ─── POST /api/skills/harvest ───
+  // Pattern capture step 1 of 2 (SETTLE-01: returns candidate for review)
+  // 1 LLM call — NOT inside handleTurn, satisfies COND-02
+  app.post('/api/skills/harvest', async (c) => {
+    const body: Record<string, unknown> = await c.req.json();
+    const context = body.context;
+    const history = body.history;
+
+    if (!context || typeof context !== 'string') {
+      return error(c, 'INVALID_INPUT', 'context is required', 400);
+    }
+
+    if (!Array.isArray(history) || history.length === 0) {
+      return error(c, 'INVALID_INPUT', 'history is required (non-empty array of {role, content})', 400);
+    }
+
+    const conversationHistory = history
+      .filter(
+        (msg): msg is { role: string; content: string } =>
+          typeof msg === 'object' &&
+          msg !== null &&
+          typeof (msg as Record<string, unknown>).role === 'string' &&
+          typeof (msg as Record<string, unknown>).content === 'string',
+      )
+      .map((msg) => ({ role: msg.role, content: msg.content }));
+
+    if (conversationHistory.length === 0) {
+      return error(c, 'INVALID_INPUT', 'history must contain messages with role and content', 400);
+    }
+
+    const result = await capturePattern(deps.llm, conversationHistory, context);
+
+    if (!result.ok) {
+      return error(c, 'LLM_ERROR', result.error, 500);
+    }
+
+    // SETTLE-01: Return candidate for user review, do NOT auto-crystallize
+    return ok(c, {
+      candidate: result.data,
+      awaitConfirmation: true,
+      message: 'Review the captured pattern. POST /api/skills/crystallize with the candidate to finalize.',
+    });
+  });
+
+  // ─── POST /api/skills/crystallize ───
+  // Crystallize candidate step 2 of 2 (SETTLE-01: requires confirmation)
+  // 0 LLM calls — pure function
+  app.post('/api/skills/crystallize', async (c) => {
+    const body: Record<string, unknown> = await c.req.json();
+
+    // SETTLE-01: requires explicit confirmation
+    if (body.confirmation !== true) {
+      return error(
+        c,
+        'CONFIRMATION_REQUIRED',
+        'Crystallize requires confirmation: true (CONTRACT SETTLE-01)',
+        400,
+      );
+    }
+
+    const candidate = body.candidate;
+    if (!candidate || typeof candidate !== 'object') {
+      return error(c, 'INVALID_INPUT', 'candidate is required', 400);
+    }
+
+    const candidateRecord = candidate as Record<string, unknown>;
+
+    // Validate required fields
+    const name = candidateRecord.name;
+    const summary = candidateRecord.summary;
+    if (typeof name !== 'string' || typeof summary !== 'string') {
+      return error(c, 'INVALID_INPUT', 'candidate must have name and summary', 400);
+    }
+
+    const skillCandidate = {
+      name,
+      summary,
+      problemShapes: Array.isArray(candidateRecord.problemShapes)
+        ? (candidateRecord.problemShapes as unknown[]).filter((s): s is string => typeof s === 'string')
+        : [],
+      desiredOutcomes: Array.isArray(candidateRecord.desiredOutcomes)
+        ? (candidateRecord.desiredOutcomes as unknown[]).filter((s): s is string => typeof s === 'string')
+        : [],
+      nonGoals: Array.isArray(candidateRecord.nonGoals)
+        ? (candidateRecord.nonGoals as unknown[]).filter((s): s is string => typeof s === 'string')
+        : [],
+      triggerWhen: Array.isArray(candidateRecord.triggerWhen)
+        ? (candidateRecord.triggerWhen as unknown[]).filter((s): s is string => typeof s === 'string')
+        : [],
+      doNotTriggerWhen: Array.isArray(candidateRecord.doNotTriggerWhen)
+        ? (candidateRecord.doNotTriggerWhen as unknown[]).filter((s): s is string => typeof s === 'string')
+        : [],
+      methodOutline: Array.isArray(candidateRecord.methodOutline)
+        ? (candidateRecord.methodOutline as unknown[]).filter((s): s is string => typeof s === 'string')
+        : [],
+      observedGotchas: Array.isArray(candidateRecord.observedGotchas)
+        ? (candidateRecord.observedGotchas as unknown[]).filter((s): s is string => typeof s === 'string')
+        : [],
+    };
+
+    try {
+      const result = crystallize(skillCandidate);
+      return ok(c, {
+        skillObject: result.skillObject,
+        yaml: result.yaml,
+        skillMd: result.skillMd,
+      }, 201);
+    } catch (err) {
+      return error(
+        c,
+        'CRYSTALLIZE_ERROR',
+        err instanceof Error ? err.message : 'Crystallization failed',
+        500,
+      );
+    }
+  });
+
+  return app;
+}


### PR DESCRIPTION
## Summary
- Skill routes: list, get, run, promotion, match, harvest, crystallize
- Container routes: select, transition
- Harvest 2-step flow (SETTLE-01)
- 26 new tests (1069 total)

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)