### PR TITLE
feat(karvi): implement cancel endpoint for dispatches

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -488,6 +488,18 @@ describe('DB Layer — initSchema', () => {
     expect(row.payload_json).toBe('{}');
   });
 
+  it('accepts dispatch_cancelled event_type', () => {
+    db.run("INSERT INTO decision_sessions (id) VALUES ('ds1')");
+    db.run(
+      "INSERT INTO decision_events (id, session_id, event_type, object_type, object_id, payload_json) VALUES ('de2', 'ds1', 'dispatch_cancelled', 'session', 'disp-001', '{\"reason\":\"user_cancel\"}')"
+    );
+    const row = db
+      .prepare("SELECT * FROM decision_events WHERE id = 'de2'")
+      .get() as Record<string, unknown>;
+    expect(row.event_type).toBe('dispatch_cancelled');
+    expect(row.object_id).toBe('disp-001');
+  });
+
   it('rejects decision_event with invalid event_type', () => {
     db.run("INSERT INTO decision_sessions (id) VALUES ('ds1')");
     expect(() => {

--- a/src/db.ts
+++ b/src/db.ts
@@ -176,7 +176,8 @@ export function initSchema(db: Database): void {
       'candidate_generated','candidate_pruned',
       'probe_started','probe_completed',
       'signal_recorded','commit_drafted',
-      'promotion_checked','spec_crystallized'
+      'promotion_checked','spec_crystallized',
+      'dispatch_cancelled'
     )),
     object_type TEXT NOT NULL CHECK(object_type IN ('session','card','candidate','probe','signal','commit','promotion')),
     object_id TEXT NOT NULL,

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { settlementRoutes } from './routes/settlements';
 import { decisionRoutes } from './routes/decisions';
 import { skillRoutes } from './routes/skills';
 import { containerRoutes } from './routes/containers';
+import { dispatchRoutes } from './routes/dispatches';
 import { DecisionSessionManager } from './decision/session-manager';
 import { SkillRegistry } from './skills/registry';
 import { createSkillLookup } from './skills/trigger-matcher';
@@ -35,6 +36,7 @@ app.route('/', settlementRoutes({ db, cardManager, thyra, karvi }));
 app.route('/', decisionRoutes({ db, llm, sessionManager }));
 app.route('/', skillRoutes({ db, llm, registry }));
 app.route('/', containerRoutes({ skillLookup }));
+app.route('/', dispatchRoutes({ karvi, db }));
 
 export default {
   port: 3460,

--- a/src/karvi-client/client.test.ts
+++ b/src/karvi-client/client.test.ts
@@ -436,6 +436,29 @@ describe('cancelDispatch', () => {
     expect(result.cancelled).toBe(true);
   });
 
+  it('parses full spec response with status, stepsCompleted, stepsAborted', async () => {
+    const client = new KarviClient({
+      fetchFn: mockFetch(() =>
+        jsonResponse({
+          ok: true,
+          data: {
+            id: 'disp-456',
+            cancelled: true,
+            status: 'cancelled',
+            stepsCompleted: 1,
+            stepsAborted: 2,
+          },
+        })
+      ),
+    });
+    const result = await client.cancelDispatch('disp-456');
+    expect(result.id).toBe('disp-456');
+    expect(result.cancelled).toBe(true);
+    expect(result.status).toBe('cancelled');
+    expect(result.stepsCompleted).toBe(1);
+    expect(result.stepsAborted).toBe(2);
+  });
+
   it('throws KarviApiError on ALREADY_CANCELLED', async () => {
     const client = new KarviClient({
       retries: 0,
@@ -444,6 +467,17 @@ describe('cancelDispatch', () => {
       ),
     });
     await expect(client.cancelDispatch('disp-123'))
+      .rejects.toBeInstanceOf(KarviApiError);
+  });
+
+  it('throws KarviApiError on NOT_FOUND', async () => {
+    const client = new KarviClient({
+      retries: 0,
+      fetchFn: mockFetch(() =>
+        jsonResponse({ ok: false, error: { code: 'NOT_FOUND', message: 'Dispatch not found' } })
+      ),
+    });
+    await expect(client.cancelDispatch('nonexistent'))
       .rejects.toBeInstanceOf(KarviApiError);
   });
 });

--- a/src/karvi-client/schemas.ts
+++ b/src/karvi-client/schemas.ts
@@ -283,5 +283,8 @@ export type DispatchStatus = z.infer<typeof DispatchStatusSchema>;
 export const CancelResultSchema = z.object({
   id: z.string(),
   cancelled: z.boolean(),
+  status: z.string().optional(),
+  stepsCompleted: z.number().optional(),
+  stepsAborted: z.number().optional(),
 });
 export type CancelResult = z.infer<typeof CancelResultSchema>;

--- a/src/routes/dispatches.test.ts
+++ b/src/routes/dispatches.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { dispatchRoutes } from './dispatches';
+import type { DispatchRouteDeps } from './dispatches';
+import { KarviClient } from '../karvi-client/client';
+import { KarviApiError, KarviNetworkError } from '../karvi-client/schemas';
+import type { Database } from 'bun:sqlite';
+import { createDb, initSchema } from '../db';
+
+// ─── Fixtures ───
+
+function makeMockKarviClient(): KarviClient & {
+  cancelDispatch: ReturnType<typeof vi.fn>;
+} {
+  const client = {
+    cancelDispatch: vi.fn(),
+    dispatchSkill: vi.fn(),
+    forgeBuild: vi.fn(),
+    getDispatchStatus: vi.fn(),
+    getHealth: vi.fn(),
+    registerPipeline: vi.fn(),
+    listPipelines: vi.fn(),
+    deletePipeline: vi.fn(),
+  } as unknown as KarviClient & {
+    cancelDispatch: ReturnType<typeof vi.fn>;
+  };
+  return client;
+}
+
+// ─── Tests ───
+
+describe('POST /api/dispatches/:id/cancel', () => {
+  let db: Database;
+  let karvi: KarviClient & { cancelDispatch: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+    karvi = makeMockKarviClient();
+  });
+
+  function makeApp(deps?: Partial<DispatchRouteDeps>) {
+    return dispatchRoutes({ karvi, db, ...deps });
+  }
+
+  async function cancelRequest(
+    app: ReturnType<typeof makeApp>,
+    id: string,
+    body?: Record<string, unknown>,
+  ) {
+    const req = new Request(`http://localhost/api/dispatches/${id}/cancel`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body ?? {}),
+    });
+    return app.fetch(req);
+  }
+
+  it('returns cancel result on success', async () => {
+    karvi.cancelDispatch.mockResolvedValueOnce({
+      id: 'disp-001',
+      cancelled: true,
+      status: 'cancelled',
+      stepsCompleted: 1,
+      stepsAborted: 2,
+    });
+
+    const app = makeApp();
+    const res = await cancelRequest(app, 'disp-001');
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.ok).toBe(true);
+
+    const data = json.data as Record<string, unknown>;
+    expect(data.id).toBe('disp-001');
+    expect(data.cancelled).toBe(true);
+    expect(data.stepsCompleted).toBe(1);
+    expect(data.stepsAborted).toBe(2);
+  });
+
+  it('returns 404 on NOT_FOUND', async () => {
+    karvi.cancelDispatch.mockRejectedValueOnce(
+      new KarviApiError('NOT_FOUND', 'Dispatch not found'),
+    );
+
+    const app = makeApp();
+    const res = await cancelRequest(app, 'nonexistent');
+    expect(res.status).toBe(404);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.ok).toBe(false);
+    const err = json.error as Record<string, unknown>;
+    expect(err.code).toBe('NOT_FOUND');
+  });
+
+  it('returns 409 on ALREADY_CANCELLED', async () => {
+    karvi.cancelDispatch.mockRejectedValueOnce(
+      new KarviApiError('ALREADY_CANCELLED', 'Already cancelled'),
+    );
+
+    const app = makeApp();
+    const res = await cancelRequest(app, 'disp-done');
+    expect(res.status).toBe(409);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.ok).toBe(false);
+    const err = json.error as Record<string, unknown>;
+    expect(err.code).toBe('ALREADY_CANCELLED');
+  });
+
+  it('returns 503 when Karvi is unreachable', async () => {
+    karvi.cancelDispatch.mockRejectedValueOnce(
+      new KarviNetworkError('Connection refused'),
+    );
+
+    const app = makeApp();
+    const res = await cancelRequest(app, 'disp-002');
+    expect(res.status).toBe(503);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.ok).toBe(false);
+    const err = json.error as Record<string, unknown>;
+    expect(err.code).toBe('KARVI_UNAVAILABLE');
+  });
+
+  it('records decision event when sessionId is provided', async () => {
+    // Create a decision session for the FK constraint
+    db.prepare(
+      `INSERT INTO decision_sessions (id, stage, status) VALUES (?, 'routing', 'active')`,
+    ).run('session-001');
+
+    karvi.cancelDispatch.mockResolvedValueOnce({
+      id: 'disp-003',
+      cancelled: true,
+    });
+
+    const app = makeApp();
+    const res = await cancelRequest(app, 'disp-003', {
+      sessionId: 'session-001',
+      reason: 'user_timeout',
+    });
+    expect(res.status).toBe(200);
+
+    // Verify event was recorded
+    const events = db.prepare(
+      'SELECT * FROM decision_events WHERE session_id = ? AND event_type = ?',
+    ).all('session-001', 'dispatch_cancelled') as Array<Record<string, unknown>>;
+
+    expect(events).toHaveLength(1);
+    expect(events[0].object_id).toBe('disp-003');
+    const payload = JSON.parse(events[0].payload_json as string) as Record<string, unknown>;
+    expect(payload.reason).toBe('user_timeout');
+    expect(payload.cancelled).toBe(true);
+  });
+
+  it('succeeds even without sessionId (no event recorded)', async () => {
+    karvi.cancelDispatch.mockResolvedValueOnce({
+      id: 'disp-004',
+      cancelled: true,
+    });
+
+    const app = makeApp();
+    const res = await cancelRequest(app, 'disp-004');
+    expect(res.status).toBe(200);
+
+    // Verify no events recorded
+    const events = db.prepare(
+      'SELECT * FROM decision_events WHERE event_type = ?',
+    ).all('dispatch_cancelled') as Array<Record<string, unknown>>;
+    expect(events).toHaveLength(0);
+  });
+});

--- a/src/routes/dispatches.ts
+++ b/src/routes/dispatches.ts
@@ -1,0 +1,65 @@
+import { Hono } from 'hono';
+import type { Database } from 'bun:sqlite';
+import { ok, error } from './response';
+import { KarviClient } from '../karvi-client/client';
+import { KarviApiError, KarviNetworkError } from '../karvi-client/schemas';
+
+// ─── DI Interface ───
+
+export interface DispatchRouteDeps {
+  karvi: KarviClient;
+  db: Database;
+}
+
+// ─── Route Factory ───
+
+export function dispatchRoutes(deps: DispatchRouteDeps): Hono {
+  const app = new Hono();
+
+  // ─── POST /api/dispatches/:id/cancel ───
+  // Cancel an in-progress dispatch or build on Karvi (0 LLM calls)
+  app.post('/api/dispatches/:id/cancel', async (c) => {
+    const id = c.req.param('id');
+    const body: Record<string, unknown> = await c.req.json().catch(() => ({})) as Record<string, unknown>;
+    const sessionId = typeof body.sessionId === 'string' ? body.sessionId : null;
+    const reason = typeof body.reason === 'string' ? body.reason : 'user_cancel';
+
+    try {
+      const result = await deps.karvi.cancelDispatch(id);
+
+      // Record cancellation event if session context is provided
+      if (sessionId) {
+        try {
+          const eventId = `evt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+          deps.db.prepare(
+            `INSERT INTO decision_events (id, session_id, event_type, object_type, object_id, payload_json)
+             VALUES (?, ?, 'dispatch_cancelled', 'session', ?, ?)`,
+          ).run(eventId, sessionId, id, JSON.stringify({ reason, cancelled: result.cancelled }));
+        } catch (dbErr) {
+          // Event logging is best-effort — do not fail the cancel response
+          console.error('[dispatches] Failed to record cancel event:', dbErr);
+        }
+      }
+
+      return ok(c, result);
+    } catch (err) {
+      if (err instanceof KarviApiError) {
+        const statusMap: Record<string, number> = {
+          NOT_FOUND: 404,
+          ALREADY_CANCELLED: 409,
+        };
+        const httpStatus = statusMap[err.code] ?? 400;
+        return error(c, err.code, err.message, httpStatus as 400 | 404 | 409);
+      }
+
+      if (err instanceof KarviNetworkError) {
+        console.error('[dispatches] Karvi unreachable on cancel:', err.message);
+        return error(c, 'KARVI_UNAVAILABLE', `Karvi unreachable: ${err.message}`, 503);
+      }
+
+      throw err;
+    }
+  });
+
+  return app;
+}

--- a/src/routes/skill-dispatcher.test.ts
+++ b/src/routes/skill-dispatcher.test.ts
@@ -121,6 +121,7 @@ function makeLookup(skillObj: SkillObject | null): SkillObjectLookup {
 function makeMockKarviClient(): KarviClient & {
   dispatchSkill: ReturnType<typeof vi.fn>;
   getDispatchStatus: ReturnType<typeof vi.fn>;
+  cancelDispatch: ReturnType<typeof vi.fn>;
 } {
   const client = {
     dispatchSkill: vi.fn(),
@@ -134,6 +135,7 @@ function makeMockKarviClient(): KarviClient & {
   } as unknown as KarviClient & {
     dispatchSkill: ReturnType<typeof vi.fn>;
     getDispatchStatus: ReturnType<typeof vi.fn>;
+    cancelDispatch: ReturnType<typeof vi.fn>;
   };
   return client;
 }
@@ -368,6 +370,102 @@ describe('dispatchToKarvi', () => {
       .get('skill.deploy-service') as Record<string, unknown>;
     expect(instance.run_count).toBe(1);
     expect(instance.success_count).toBe(1);
+  });
+});
+
+// ─── timeout auto-cancel ───
+
+describe('pollForCompletion auto-cancel on timeout', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+  });
+
+  it('calls cancelDispatch when polling times out', async () => {
+    // Insert skill instance for telemetry recording
+    db.prepare(
+      `INSERT INTO skill_instances (id, skill_id, name, status, run_count, success_count)
+       VALUES (?, ?, ?, ?, 0, 0)`,
+    ).run('skill.deploy-service', 'skill.deploy-service', 'deploy-service', 'promoted');
+
+    const client = makeMockKarviClient();
+    client.dispatchSkill.mockResolvedValueOnce({
+      dispatchId: 'dispatch_timeout',
+      status: 'pending',
+    });
+    // Always return 'running' so it times out
+    client.getDispatchStatus.mockResolvedValue({
+      id: 'dispatch_timeout',
+      status: 'running',
+      type: 'skill',
+      createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
+      result: null,
+    });
+    client.cancelDispatch.mockResolvedValueOnce({ id: 'dispatch_timeout', cancelled: true });
+
+    // Use a skill with very short timeout to avoid slow test
+    const skillObj = makeSkillObject();
+    skillObj.dispatch.executionPolicy.timeoutMinutes = 0; // 0 minutes = 0 poll attempts
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(skillObj),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('dispatched');
+    if (result.type === 'dispatched') {
+      expect(result.result.status).toBe('failure');
+      expect(result.result.verification.failedChecks).toContain('timeout');
+    }
+
+    // Verify cancelDispatch was called
+    expect(client.cancelDispatch).toHaveBeenCalledWith('dispatch_timeout');
+  });
+
+  it('still returns timeout result when cancelDispatch fails', async () => {
+    db.prepare(
+      `INSERT INTO skill_instances (id, skill_id, name, status, run_count, success_count)
+       VALUES (?, ?, ?, ?, 0, 0)`,
+    ).run('skill.deploy-service', 'skill.deploy-service', 'deploy-service', 'promoted');
+
+    const client = makeMockKarviClient();
+    client.dispatchSkill.mockResolvedValueOnce({
+      dispatchId: 'dispatch_timeout2',
+      status: 'pending',
+    });
+    client.getDispatchStatus.mockResolvedValue({
+      id: 'dispatch_timeout2',
+      status: 'running',
+      type: 'skill',
+      createdAt: '2026-01-01',
+      updatedAt: '2026-01-01',
+      result: null,
+    });
+    // Cancel itself fails
+    client.cancelDispatch.mockRejectedValueOnce(new Error('Network error'));
+
+    const skillObj = makeSkillObject();
+    skillObj.dispatch.executionPolicy.timeoutMinutes = 0;
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(skillObj),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('dispatched');
+    if (result.type === 'dispatched') {
+      expect(result.result.status).toBe('failure');
+      expect(result.result.verification.failedChecks).toContain('timeout');
+    }
   });
 });
 

--- a/src/routes/skill-dispatcher.ts
+++ b/src/routes/skill-dispatcher.ts
@@ -266,7 +266,13 @@ async function pollForCompletion(
     await new Promise(resolve => setTimeout(resolve, POLL_INTERVAL_MS));
   }
 
-  // Timeout
+  // Timeout — best-effort cancel on Karvi side
+  try {
+    await client.cancelDispatch(dispatchId);
+  } catch {
+    // Karvi may already be done or unreachable — non-fatal
+  }
+
   return {
     skillId: '',
     status: 'failure',


### PR DESCRIPTION
Extends CancelResultSchema, adds auto-cancel on timeout, creates cancel route, records events. Closes #150