### PR TITLE
feat(routing): add dispatch.mode fallback when Karvi is unreachable

### DIFF
--- a/src/db.test.ts
+++ b/src/db.test.ts
@@ -20,7 +20,7 @@ describe('DB Layer — initSchema', () => {
     initSchema(db);
   });
 
-  it('creates all 14 tables', () => {
+  it('creates all 15 tables', () => {
     const tables = db
       .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
       .all() as { name: string }[];
@@ -42,6 +42,8 @@ describe('DB Layer — initSchema', () => {
     expect(names).toContain('decision_events');
     // Approval audit table
     expect(names).toContain('approval_audits');
+    // Dispatch queue table
+    expect(names).toContain('dispatch_queue');
   });
 
   it('creates secondary indexes on high-frequency columns', () => {
@@ -55,6 +57,7 @@ describe('DB Layer — initSchema', () => {
     expect(names).toContain('idx_decision_sessions_status');
     expect(names).toContain('idx_candidate_records_session');
     expect(names).toContain('idx_approval_audits_pending');
+    expect(names).toContain('idx_dispatch_queue_status');
   });
 
   it('is idempotent (can call initSchema twice)', () => {
@@ -527,6 +530,43 @@ describe('DB Layer — initSchema', () => {
         "INSERT INTO decision_events (id, session_id, event_type, object_type, object_id) VALUES ('de1', 'nonexistent', 'route_assigned', 'session', 'ds1')"
       );
     }).toThrow();
+  });
+
+  // ── dispatch_queue ──
+
+  it('can insert and query a dispatch_queue entry', () => {
+    db.run(
+      `INSERT INTO dispatch_queue (id, skill_id, conversation_id, request_json, fallback_reason)
+       VALUES ('dq1', 'skill.deploy', 'conv_1', '{"skillId":"skill.deploy"}', 'Karvi health check failed')`,
+    );
+    const row = db
+      .prepare("SELECT * FROM dispatch_queue WHERE id = 'dq1'")
+      .get() as Record<string, unknown>;
+    expect(row.skill_id).toBe('skill.deploy');
+    expect(row.status).toBe('pending');
+    expect(row.retry_count).toBe(0);
+    expect(row.max_retries).toBe(3);
+  });
+
+  it('rejects dispatch_queue with invalid status', () => {
+    expect(() => {
+      db.run(
+        `INSERT INTO dispatch_queue (id, skill_id, request_json, fallback_reason, status)
+         VALUES ('dq2', 'skill.x', '{}', 'reason', 'invalid_status')`,
+      );
+    }).toThrow();
+  });
+
+  it('can update dispatch_queue status to dispatched', () => {
+    db.run(
+      `INSERT INTO dispatch_queue (id, skill_id, request_json, fallback_reason)
+       VALUES ('dq3', 'skill.deploy', '{}', 'reason')`,
+    );
+    db.run("UPDATE dispatch_queue SET status = 'dispatched', updated_at = datetime('now') WHERE id = 'dq3'");
+    const row = db
+      .prepare("SELECT status FROM dispatch_queue WHERE id = 'dq3'")
+      .get() as Record<string, unknown>;
+    expect(row.status).toBe('dispatched');
   });
 
   // ── approval_audits ──

--- a/src/db.ts
+++ b/src/db.ts
@@ -249,6 +249,23 @@ export function initSchema(db: Database): void {
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
   )`);
 
+  // ─── Dispatch Queue Table ───
+
+  db.run(`CREATE TABLE IF NOT EXISTS dispatch_queue (
+    id TEXT PRIMARY KEY,
+    skill_id TEXT NOT NULL,
+    conversation_id TEXT,
+    request_json TEXT NOT NULL,
+    fallback_reason TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending'
+      CHECK(status IN ('pending','dispatched','failed','expired')),
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    max_retries INTEGER NOT NULL DEFAULT 3,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    next_retry_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+  )`);
+
   // ─── Secondary Indexes ───
 
   db.run('CREATE INDEX IF NOT EXISTS idx_cards_conv_version ON cards(conversation_id, version)');
@@ -257,4 +274,5 @@ export function initSchema(db: Database): void {
   db.run('CREATE INDEX IF NOT EXISTS idx_decision_sessions_status ON decision_sessions(status)');
   db.run('CREATE INDEX IF NOT EXISTS idx_candidate_records_session ON candidate_records(session_id)');
   db.run('CREATE INDEX IF NOT EXISTS idx_approval_audits_pending ON approval_audits(pending_id)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_dispatch_queue_status ON dispatch_queue(status, next_retry_at)');
 }

--- a/src/routes/approval-e2e.test.ts
+++ b/src/routes/approval-e2e.test.ts
@@ -98,6 +98,14 @@ function createApprovalMockFetch(state: ApprovalMockState) {
       }), { status: 200, headers: { 'Content-Type': 'application/json' } });
     }
 
+    // GET /api/health -> return healthy
+    if (method === 'GET' && urlStr.endsWith('/api/health')) {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
     return new Response('Not Found', { status: 404 });
   }) as unknown as typeof fetch;
 }
@@ -164,6 +172,7 @@ function makeSkillObject(overrides?: { requireHumanBeforeDispatch?: boolean }): 
     },
     dispatch: {
       mode: 'karvi',
+      fallback: 'local',
       targetSelection: { repoPolicy: 'explicit', runtimeOptions: ['claude'] },
       workerClass: ['implementation'],
       handoff: { inputArtifacts: [], outputArtifacts: ['deploy_url'] },

--- a/src/routes/approvals.test.ts
+++ b/src/routes/approvals.test.ts
@@ -71,6 +71,7 @@ function makeSkillObject(overrides?: Partial<SkillObject>): SkillObject {
     },
     dispatch: {
       mode: 'karvi',
+      fallback: 'local',
       targetSelection: { repoPolicy: 'explicit', runtimeOptions: ['claude'] },
       workerClass: ['implementation'],
       handoff: { inputArtifacts: [], outputArtifacts: ['deploy_url'] },
@@ -116,7 +117,7 @@ function makeMockKarviClient(): KarviClient & {
   return {
     dispatchSkill: vi.fn(),
     getDispatchStatus: vi.fn(),
-    getHealth: vi.fn(),
+    getHealth: vi.fn().mockResolvedValue({ ok: true }),
     cancelDispatch: vi.fn(),
     registerPipeline: vi.fn(),
     listPipelines: vi.fn(),

--- a/src/routes/dispatches.test.ts
+++ b/src/routes/dispatches.test.ts
@@ -10,6 +10,8 @@ import { createDb, initSchema } from '../db';
 
 function makeMockKarviClient(): KarviClient & {
   cancelDispatch: ReturnType<typeof vi.fn>;
+  getHealth: ReturnType<typeof vi.fn>;
+  dispatchSkill: ReturnType<typeof vi.fn>;
 } {
   const client = {
     cancelDispatch: vi.fn(),
@@ -22,6 +24,8 @@ function makeMockKarviClient(): KarviClient & {
     deletePipeline: vi.fn(),
   } as unknown as KarviClient & {
     cancelDispatch: ReturnType<typeof vi.fn>;
+    getHealth: ReturnType<typeof vi.fn>;
+    dispatchSkill: ReturnType<typeof vi.fn>;
   };
   return client;
 }
@@ -30,7 +34,7 @@ function makeMockKarviClient(): KarviClient & {
 
 describe('POST /api/dispatches/:id/cancel', () => {
   let db: Database;
-  let karvi: KarviClient & { cancelDispatch: ReturnType<typeof vi.fn> };
+  let karvi: KarviClient & { cancelDispatch: ReturnType<typeof vi.fn>; getHealth: ReturnType<typeof vi.fn>; dispatchSkill: ReturnType<typeof vi.fn> };
 
   beforeEach(() => {
     db = createDb(':memory:');
@@ -168,5 +172,83 @@ describe('POST /api/dispatches/:id/cancel', () => {
       'SELECT * FROM decision_events WHERE event_type = ?',
     ).all('dispatch_cancelled') as Array<Record<string, unknown>>;
     expect(events).toHaveLength(0);
+  });
+});
+
+// ─── POST /api/dispatches/queue/process ───
+
+describe('POST /api/dispatches/queue/process', () => {
+  let db: Database;
+  let karvi: KarviClient & { cancelDispatch: ReturnType<typeof vi.fn>; getHealth: ReturnType<typeof vi.fn>; dispatchSkill: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+    karvi = makeMockKarviClient();
+  });
+
+  function makeApp(deps?: Partial<DispatchRouteDeps>) {
+    return dispatchRoutes({ karvi, db, ...deps });
+  }
+
+  async function processQueueRequest(app: ReturnType<typeof makeApp>) {
+    const req = new Request('http://localhost/api/dispatches/queue/process', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    return app.fetch(req);
+  }
+
+  it('returns zero counts when Karvi is unhealthy', async () => {
+    karvi.getHealth.mockResolvedValueOnce({ ok: false });
+
+    const app = makeApp();
+    const res = await processQueueRequest(app);
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.ok).toBe(true);
+    const data = json.data as Record<string, unknown>;
+    expect(data.processed).toBe(0);
+  });
+
+  it('processes pending items when healthy', async () => {
+    // Insert pending item
+    const requestJson = JSON.stringify({
+      skillId: 'skill.test',
+      skillName: 'test',
+      skillVersion: '1.0',
+      skillContent: '',
+      environment: {
+        toolsRequired: [], toolsOptional: [],
+        permissions: { filesystem: { read: false, write: false }, network: { read: false, write: false }, process: { spawn: false }, secrets: { read: [] } },
+        externalSideEffects: false, executionMode: 'advisory',
+      },
+      dispatch: {
+        targetSelection: { repoPolicy: 'explicit', runtimeOptions: [] },
+        workerClass: [], handoff: { inputArtifacts: [], outputArtifacts: [] },
+        executionPolicy: { sync: false, retries: 0, timeoutMinutes: 1, escalationOnFailure: false },
+        approval: { requireHumanBeforeDispatch: false, requireHumanBeforeMerge: false },
+      },
+      verification: { smokeChecks: [], assertions: [], humanCheckpoints: [], outcomeSignals: [] },
+      context: { userMessage: 'test', inputs: {} },
+    });
+    db.prepare(
+      `INSERT INTO dispatch_queue (id, skill_id, request_json, fallback_reason)
+       VALUES (?, ?, ?, ?)`,
+    ).run('dq_route_1', 'skill.test', requestJson, 'health check failed');
+
+    karvi.getHealth.mockResolvedValueOnce({ ok: true });
+    karvi.dispatchSkill.mockResolvedValueOnce({ dispatchId: 'disp-new', status: 'pending' });
+
+    const app = makeApp();
+    const res = await processQueueRequest(app);
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as Record<string, unknown>;
+    const data = json.data as Record<string, unknown>;
+    expect(data.processed).toBe(1);
+    expect(data.succeeded).toBe(1);
+    expect(data.failed).toBe(0);
   });
 });

--- a/src/routes/dispatches.ts
+++ b/src/routes/dispatches.ts
@@ -3,6 +3,7 @@ import type { Database } from 'bun:sqlite';
 import { ok, error } from './response';
 import { KarviClient } from '../karvi-client/client';
 import { KarviApiError, KarviNetworkError } from '../karvi-client/schemas';
+import { processDispatchQueue } from './skill-dispatcher';
 
 // ─── DI Interface ───
 
@@ -59,6 +60,13 @@ export function dispatchRoutes(deps: DispatchRouteDeps): Hono {
 
       throw err;
     }
+  });
+
+  // ─── POST /api/dispatches/queue/process ───
+  // Process pending dispatch queue items when Karvi reconnects (0 LLM calls)
+  app.post('/api/dispatches/queue/process', async (c) => {
+    const result = await processDispatchQueue(deps.karvi, deps.db);
+    return ok(c, result);
   });
 
   return app;

--- a/src/routes/skill-dispatcher.test.ts
+++ b/src/routes/skill-dispatcher.test.ts
@@ -10,7 +10,7 @@ import { createDb, initSchema } from '../db';
 
 // ─── Fixtures ───
 
-function makeSkillObject(overrides?: { mode?: 'local' | 'karvi' | 'hybrid' }): SkillObject {
+function makeSkillObject(overrides?: { mode?: 'local' | 'karvi' | 'hybrid'; fallback?: 'local' | 'queue' | 'reject' }): SkillObject {
   return {
     kind: 'SkillObject',
     apiVersion: '1.0.0',
@@ -70,6 +70,7 @@ function makeSkillObject(overrides?: { mode?: 'local' | 'karvi' | 'hybrid' }): S
     },
     dispatch: {
       mode: overrides?.mode ?? 'karvi',
+      fallback: overrides?.fallback ?? 'local',
       targetSelection: { repoPolicy: 'explicit', runtimeOptions: ['claude'] },
       workerClass: ['implementation'],
       handoff: { inputArtifacts: [], outputArtifacts: ['deploy_url'] },
@@ -122,11 +123,12 @@ function makeMockKarviClient(): KarviClient & {
   dispatchSkill: ReturnType<typeof vi.fn>;
   getDispatchStatus: ReturnType<typeof vi.fn>;
   cancelDispatch: ReturnType<typeof vi.fn>;
+  getHealth: ReturnType<typeof vi.fn>;
 } {
   const client = {
     dispatchSkill: vi.fn(),
     getDispatchStatus: vi.fn(),
-    getHealth: vi.fn(),
+    getHealth: vi.fn().mockResolvedValue({ ok: true }),
     cancelDispatch: vi.fn(),
     registerPipeline: vi.fn(),
     listPipelines: vi.fn(),
@@ -136,6 +138,7 @@ function makeMockKarviClient(): KarviClient & {
     dispatchSkill: ReturnType<typeof vi.fn>;
     getDispatchStatus: ReturnType<typeof vi.fn>;
     cancelDispatch: ReturnType<typeof vi.fn>;
+    getHealth: ReturnType<typeof vi.fn>;
   };
   return client;
 }
@@ -391,6 +394,232 @@ describe('dispatchToKarvi', () => {
       .get('skill.deploy-service') as Record<string, unknown>;
     expect(instance.run_count).toBe(1);
     expect(instance.success_count).toBe(1);
+  });
+});
+
+// ─── Health check + fallback strategy ───
+
+describe('dispatchToKarvi fallback strategies', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+  });
+
+  it('returns fallback_local when health check fails and fallback=local', async () => {
+    const client = makeMockKarviClient();
+    client.getHealth.mockResolvedValueOnce({ ok: false });
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject({ fallback: 'local' })),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('fallback_local');
+    if (result.type === 'fallback_local') {
+      expect(result.reason).toBe('Karvi health check failed');
+    }
+  });
+
+  it('returns queued when health check fails and fallback=queue', async () => {
+    const client = makeMockKarviClient();
+    client.getHealth.mockResolvedValueOnce({ ok: false });
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject({ fallback: 'queue' })),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('queued');
+    if (result.type === 'queued') {
+      expect(result.reason).toBe('Karvi health check failed');
+      expect(result.queueId).toMatch(/^dq_/);
+    }
+
+    // Verify row was inserted in dispatch_queue
+    const rows = db.prepare('SELECT * FROM dispatch_queue').all() as Array<Record<string, unknown>>;
+    expect(rows).toHaveLength(1);
+    expect(rows[0].skill_id).toBe('skill.deploy-service');
+    expect(rows[0].status).toBe('pending');
+  });
+
+  it('returns rejected when health check fails and fallback=reject', async () => {
+    const client = makeMockKarviClient();
+    client.getHealth.mockResolvedValueOnce({ ok: false });
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject({ fallback: 'reject' })),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('rejected');
+    if (result.type === 'rejected') {
+      expect(result.reason).toBe('Karvi health check failed');
+    }
+  });
+
+  it('returns queued on network error when fallback=queue', async () => {
+    const client = makeMockKarviClient();
+    // Health check passes but dispatch fails with network error
+    client.getHealth.mockResolvedValueOnce({ ok: true });
+    client.dispatchSkill.mockRejectedValueOnce(
+      new KarviNetworkError('Connection reset'),
+    );
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject({ fallback: 'queue' })),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('queued');
+    if (result.type === 'queued') {
+      expect(result.reason).toContain('Karvi unreachable');
+    }
+  });
+
+  it('returns rejected on network error when fallback=reject', async () => {
+    const client = makeMockKarviClient();
+    client.getHealth.mockResolvedValueOnce({ ok: true });
+    client.dispatchSkill.mockRejectedValueOnce(
+      new KarviNetworkError('Connection reset'),
+    );
+
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject({ fallback: 'reject' })),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('rejected');
+    if (result.type === 'rejected') {
+      expect(result.reason).toContain('Karvi unreachable');
+    }
+  });
+
+  it('defaults fallback to local when not explicitly set (backward compat)', async () => {
+    const client = makeMockKarviClient();
+    client.getHealth.mockResolvedValueOnce({ ok: false });
+
+    // makeSkillObject defaults fallback to 'local'
+    const deps: DispatchDeps = {
+      skillObjectLookup: makeLookup(makeSkillObject()),
+      karviClient: client,
+      db,
+      readSkillContent: () => '# SKILL.md',
+    };
+
+    const result = await dispatchToKarvi(makeContext(), deps);
+    expect(result.type).toBe('fallback_local');
+  });
+});
+
+// ─── Queue processing ───
+
+describe('processDispatchQueue', () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = createDb(':memory:');
+    initSchema(db);
+  });
+
+  it('processes pending items when Karvi is healthy', async () => {
+    // Insert a pending queue item
+    db.prepare(
+      `INSERT INTO dispatch_queue (id, skill_id, request_json, fallback_reason, max_retries)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run('dq_test_1', 'skill.deploy', '{"skillId":"skill.deploy","skillName":"deploy","skillVersion":"1.0","skillContent":"","environment":{"toolsRequired":[],"toolsOptional":[],"permissions":{"filesystem":{"read":true,"write":false},"network":{"read":true,"write":false},"process":{"spawn":false},"secrets":{"read":[]}},"externalSideEffects":false,"executionMode":"advisory"},"dispatch":{"targetSelection":{"repoPolicy":"explicit","runtimeOptions":[]},"workerClass":[],"handoff":{"inputArtifacts":[],"outputArtifacts":[]},"executionPolicy":{"sync":false,"retries":1,"timeoutMinutes":20,"escalationOnFailure":false},"approval":{"requireHumanBeforeDispatch":false,"requireHumanBeforeMerge":false}},"verification":{"smokeChecks":[],"assertions":[],"humanCheckpoints":[],"outcomeSignals":[]},"context":{"userMessage":"test","inputs":{}}}', 'health check failed', 3);
+
+    const client = makeMockKarviClient();
+    client.getHealth.mockResolvedValueOnce({ ok: true });
+    client.dispatchSkill.mockResolvedValueOnce({ dispatchId: 'disp-001', status: 'pending' });
+
+    const { processDispatchQueue } = await import('./skill-dispatcher');
+    const result = await processDispatchQueue(client, db);
+
+    expect(result.processed).toBe(1);
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(0);
+
+    // Verify status updated
+    const row = db.prepare("SELECT status FROM dispatch_queue WHERE id = 'dq_test_1'")
+      .get() as Record<string, unknown>;
+    expect(row.status).toBe('dispatched');
+  });
+
+  it('returns zero when Karvi is unhealthy', async () => {
+    db.prepare(
+      `INSERT INTO dispatch_queue (id, skill_id, request_json, fallback_reason)
+       VALUES (?, ?, ?, ?)`,
+    ).run('dq_test_2', 'skill.deploy', '{}', 'reason');
+
+    const client = makeMockKarviClient();
+    client.getHealth.mockResolvedValueOnce({ ok: false });
+
+    const { processDispatchQueue } = await import('./skill-dispatcher');
+    const result = await processDispatchQueue(client, db);
+
+    expect(result.processed).toBe(0);
+    expect(result.succeeded).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it('marks as failed when retries exhausted', async () => {
+    db.prepare(
+      `INSERT INTO dispatch_queue (id, skill_id, request_json, fallback_reason, retry_count, max_retries)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('dq_test_3', 'skill.deploy', '{"skillId":"x","skillName":"x","skillVersion":"1","skillContent":"","environment":{"toolsRequired":[],"toolsOptional":[],"permissions":{"filesystem":{"read":false,"write":false},"network":{"read":false,"write":false},"process":{"spawn":false},"secrets":{"read":[]}},"externalSideEffects":false,"executionMode":"advisory"},"dispatch":{"targetSelection":{"repoPolicy":"explicit","runtimeOptions":[]},"workerClass":[],"handoff":{"inputArtifacts":[],"outputArtifacts":[]},"executionPolicy":{"sync":false,"retries":0,"timeoutMinutes":1,"escalationOnFailure":false},"approval":{"requireHumanBeforeDispatch":false,"requireHumanBeforeMerge":false}},"verification":{"smokeChecks":[],"assertions":[],"humanCheckpoints":[],"outcomeSignals":[]},"context":{"userMessage":"test","inputs":{}}}', 'reason', 2, 3);
+
+    const client = makeMockKarviClient();
+    client.getHealth.mockResolvedValueOnce({ ok: true });
+    client.dispatchSkill.mockRejectedValueOnce(new Error('dispatch failed'));
+
+    const { processDispatchQueue } = await import('./skill-dispatcher');
+    const result = await processDispatchQueue(client, db);
+
+    expect(result.processed).toBe(1);
+    expect(result.failed).toBe(1);
+
+    const row = db.prepare("SELECT status, retry_count FROM dispatch_queue WHERE id = 'dq_test_3'")
+      .get() as Record<string, unknown>;
+    expect(row.status).toBe('failed');
+    expect(row.retry_count).toBe(3);
+  });
+
+  it('increments retry_count on dispatch failure when retries remain', async () => {
+    db.prepare(
+      `INSERT INTO dispatch_queue (id, skill_id, request_json, fallback_reason, retry_count, max_retries)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    ).run('dq_test_4', 'skill.deploy', '{"skillId":"x","skillName":"x","skillVersion":"1","skillContent":"","environment":{"toolsRequired":[],"toolsOptional":[],"permissions":{"filesystem":{"read":false,"write":false},"network":{"read":false,"write":false},"process":{"spawn":false},"secrets":{"read":[]}},"externalSideEffects":false,"executionMode":"advisory"},"dispatch":{"targetSelection":{"repoPolicy":"explicit","runtimeOptions":[]},"workerClass":[],"handoff":{"inputArtifacts":[],"outputArtifacts":[]},"executionPolicy":{"sync":false,"retries":0,"timeoutMinutes":1,"escalationOnFailure":false},"approval":{"requireHumanBeforeDispatch":false,"requireHumanBeforeMerge":false}},"verification":{"smokeChecks":[],"assertions":[],"humanCheckpoints":[],"outcomeSignals":[]},"context":{"userMessage":"test","inputs":{}}}', 'reason', 0, 3);
+
+    const client = makeMockKarviClient();
+    client.getHealth.mockResolvedValueOnce({ ok: true });
+    client.dispatchSkill.mockRejectedValueOnce(new Error('temporary failure'));
+
+    const { processDispatchQueue } = await import('./skill-dispatcher');
+    const result = await processDispatchQueue(client, db);
+
+    expect(result.failed).toBe(1);
+
+    const row = db.prepare("SELECT status, retry_count FROM dispatch_queue WHERE id = 'dq_test_4'")
+      .get() as Record<string, unknown>;
+    expect(row.status).toBe('pending');
+    expect(row.retry_count).toBe(1);
   });
 });
 

--- a/src/routes/skill-dispatcher.ts
+++ b/src/routes/skill-dispatcher.ts
@@ -22,7 +22,9 @@ export interface SkillDispatchContext {
 export type SkillDispatchOutcome =
   | { type: 'dispatched'; result: SkillDispatchResult }
   | { type: 'approval_required'; pendingId: string; skillName: string; permissions: SkillObject['environment']['permissions']; sideEffects: boolean; executionMode: string }
-  | { type: 'fallback_local'; reason: string };
+  | { type: 'fallback_local'; reason: string }
+  | { type: 'queued'; queueId: string; reason: string }
+  | { type: 'rejected'; reason: string };
 
 export interface DispatchDeps {
   skillObjectLookup: SkillObjectLookup;
@@ -118,7 +120,24 @@ export async function dispatchToKarvi(
     ? mergeSkillObject(skillObj, deps.dispatchOverlay)
     : skillObj;
 
-  // 4. Read SKILL.md content
+  // 4. Health check before dispatch
+  const health = await deps.karviClient.getHealth();
+  if (!health.ok) {
+    const fallbackStrategy = merged.dispatch.fallback;
+    const reason = 'Karvi health check failed';
+
+    switch (fallbackStrategy) {
+      case 'local':
+        console.warn('[skill-dispatcher] Karvi unhealthy, falling back to local');
+        return { type: 'fallback_local', reason };
+      case 'queue':
+        return enqueueDispatch(deps.db, merged, ctx, reason);
+      case 'reject':
+        return { type: 'rejected', reason };
+    }
+  }
+
+  // 5. Read SKILL.md content
   const readContent = deps.readSkillContent ?? readSkillMdContent;
   let skillContent: string;
   try {
@@ -128,21 +147,21 @@ export async function dispatchToKarvi(
     return { type: 'fallback_local', reason: 'Failed to read SKILL.md content' };
   }
 
-  // 5. Build request
+  // 6. Build request
   const request = buildDispatchRequest(merged, ctx, skillContent);
 
-  // 6. Dispatch to Karvi
+  // 7. Dispatch to Karvi
   try {
     const dispatchResponse = await deps.karviClient.dispatchSkill(request);
 
-    // 7. Poll for completion
+    // 8. Poll for completion
     const result = await pollForCompletion(
       dispatchResponse.dispatchId,
       deps.karviClient,
       merged.dispatch.executionPolicy.timeoutMinutes,
     );
 
-    // 8. Record telemetry
+    // 9. Record telemetry
     recordRun(deps.db, {
       skillInstanceId: ctx.skillId,
       conversationId: ctx.conversationId,
@@ -165,10 +184,20 @@ export async function dispatchToKarvi(
       };
     }
 
-    // Graceful fallback on network errors
+    // Graceful fallback on network errors — respects per-skill fallback strategy
     if (error instanceof KarviNetworkError) {
-      console.error('[skill-dispatcher] Karvi unreachable, falling back to local:', error.message);
-      return { type: 'fallback_local', reason: `Karvi unreachable: ${error.message}` };
+      const fallbackStrategy = merged.dispatch.fallback;
+      const reason = `Karvi unreachable: ${error.message}`;
+
+      switch (fallbackStrategy) {
+        case 'local':
+          console.error('[skill-dispatcher] Karvi unreachable, falling back to local:', error.message);
+          return { type: 'fallback_local', reason };
+        case 'queue':
+          return enqueueDispatch(deps.db, merged, ctx, reason);
+        case 'reject':
+          return { type: 'rejected', reason };
+      }
     }
 
     // Re-throw unexpected errors
@@ -206,6 +235,23 @@ export async function resubmitWithApproval(
     approvalToken,
   };
 
+  // Health check before resubmit
+  const health = await deps.karviClient.getHealth();
+  if (!health.ok) {
+    const fallbackStrategy = merged.dispatch.fallback;
+    const reason = 'Karvi health check failed on resubmit';
+
+    switch (fallbackStrategy) {
+      case 'local':
+        console.warn('[skill-dispatcher] Karvi unhealthy on resubmit, falling back to local');
+        return { type: 'fallback_local', reason };
+      case 'queue':
+        return enqueueDispatch(deps.db, merged, ctx, reason);
+      case 'reject':
+        return { type: 'rejected', reason };
+    }
+  }
+
   try {
     const dispatchResponse = await deps.karviClient.dispatchSkill(request);
 
@@ -226,11 +272,101 @@ export async function resubmitWithApproval(
     return { type: 'dispatched', result };
   } catch (error) {
     if (error instanceof KarviNetworkError) {
-      console.error('[skill-dispatcher] Karvi unreachable on resubmit:', error.message);
-      return { type: 'fallback_local', reason: `Karvi unreachable: ${error.message}` };
+      const fallbackStrategy = merged.dispatch.fallback;
+      const reason = `Karvi unreachable on resubmit: ${error.message}`;
+
+      switch (fallbackStrategy) {
+        case 'local':
+          console.error('[skill-dispatcher] Karvi unreachable on resubmit:', error.message);
+          return { type: 'fallback_local', reason };
+        case 'queue':
+          return enqueueDispatch(deps.db, merged, ctx, reason);
+        case 'reject':
+          return { type: 'rejected', reason };
+      }
     }
     throw error;
   }
+}
+
+// ─── Queue Helpers ───
+
+/**
+ * Enqueue a dispatch request for later retry when Karvi reconnects.
+ */
+function enqueueDispatch(
+  db: Database,
+  merged: SkillObject,
+  ctx: SkillDispatchContext,
+  reason: string,
+): SkillDispatchOutcome {
+  const queueId = `dq_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const request = buildDispatchRequest(merged, ctx, '');
+
+  db.prepare(
+    `INSERT INTO dispatch_queue (id, skill_id, conversation_id, request_json, fallback_reason, max_retries)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    queueId,
+    ctx.skillId,
+    ctx.conversationId ?? null,
+    JSON.stringify(request),
+    reason,
+    merged.dispatch.executionPolicy.retries,
+  );
+
+  return { type: 'queued', queueId, reason };
+}
+
+/**
+ * Process pending items in the dispatch queue.
+ * Checks Karvi health first — if unhealthy, returns immediately.
+ * On success, marks items as 'dispatched'. On failure, increments retry_count
+ * with exponential backoff, or marks as 'failed' when retries exhausted.
+ */
+export async function processDispatchQueue(
+  karviClient: KarviClient,
+  db: Database,
+): Promise<{ processed: number; succeeded: number; failed: number }> {
+  const health = await karviClient.getHealth();
+  if (!health.ok) return { processed: 0, succeeded: 0, failed: 0 };
+
+  const pending = db.prepare(
+    `SELECT * FROM dispatch_queue
+     WHERE status = 'pending' AND next_retry_at <= datetime('now')
+     ORDER BY created_at ASC LIMIT 10`,
+  ).all() as Array<Record<string, unknown>>;
+
+  let succeeded = 0;
+  let failed = 0;
+
+  for (const row of pending) {
+    const request = JSON.parse(row.request_json as string) as SkillDispatchRequest;
+    const rowId = row.id as string;
+    try {
+      await karviClient.dispatchSkill(request);
+      db.prepare(
+        `UPDATE dispatch_queue SET status = 'dispatched', updated_at = datetime('now') WHERE id = ?`,
+      ).run(rowId);
+      succeeded++;
+    } catch {
+      const retryCount = (row.retry_count as number) + 1;
+      const maxRetries = row.max_retries as number;
+      if (retryCount >= maxRetries) {
+        db.prepare(
+          `UPDATE dispatch_queue SET status = 'failed', retry_count = ?, updated_at = datetime('now') WHERE id = ?`,
+        ).run(retryCount, rowId);
+      } else {
+        const delayMinutes = Math.pow(2, retryCount - 1);
+        db.prepare(
+          `UPDATE dispatch_queue SET retry_count = ?, next_retry_at = datetime('now', '+' || ? || ' minutes'), updated_at = datetime('now') WHERE id = ?`,
+        ).run(retryCount, delayMinutes, rowId);
+      }
+      failed++;
+    }
+  }
+
+  return { processed: pending.length, succeeded, failed };
 }
 
 // ─── Internal Helpers ───

--- a/src/routes/skills.test.ts
+++ b/src/routes/skills.test.ts
@@ -76,6 +76,7 @@ function makeMinimalSkillObject(overrides?: Partial<SkillObject>): SkillObject {
     },
     dispatch: {
       mode: 'local',
+      fallback: 'local',
       targetSelection: { repoPolicy: 'explicit', runtimeOptions: [] },
       workerClass: [],
       handoff: { inputArtifacts: [], outputArtifacts: [] },

--- a/src/schemas/skill-object.test.ts
+++ b/src/schemas/skill-object.test.ts
@@ -6,6 +6,7 @@ import {
   RiskTierEnum,
   ExecutionModeEnum,
   DispatchModeEnum,
+  FallbackStrategyEnum,
   IdentitySchema,
   PurposeSchema,
   RoutingSchema,
@@ -244,6 +245,18 @@ describe('DispatchModeEnum', () => {
   });
 });
 
+describe('FallbackStrategyEnum', () => {
+  it('accepts all valid values', () => {
+    for (const v of ['local', 'queue', 'reject']) {
+      expect(FallbackStrategyEnum.parse(v)).toBe(v);
+    }
+  });
+
+  it('rejects invalid value', () => {
+    expect(() => FallbackStrategyEnum.parse('retry')).toThrow();
+  });
+});
+
 // ─── Section Schema Tests ───
 
 describe('IdentitySchema', () => {
@@ -428,6 +441,24 @@ describe('DispatchSchema', () => {
         ...validDispatch,
         executionPolicy: { ...validDispatch.executionPolicy, timeoutMinutes: 0 },
       }).success,
+    ).toBe(false);
+  });
+
+  it('defaults fallback to local when omitted', () => {
+    const result = DispatchSchema.parse(validDispatch);
+    expect(result.fallback).toBe('local');
+  });
+
+  it('accepts explicit fallback values', () => {
+    for (const v of ['local', 'queue', 'reject'] as const) {
+      const result = DispatchSchema.parse({ ...validDispatch, fallback: v });
+      expect(result.fallback).toBe(v);
+    }
+  });
+
+  it('rejects invalid fallback value', () => {
+    expect(
+      DispatchSchema.safeParse({ ...validDispatch, fallback: 'retry' }).success,
     ).toBe(false);
   });
 });

--- a/src/schemas/skill-object.ts
+++ b/src/schemas/skill-object.ts
@@ -41,6 +41,9 @@ export type ExecutionMode = z.infer<typeof ExecutionModeEnum>;
 export const DispatchModeEnum = z.enum(['local', 'karvi', 'hybrid']);
 export type DispatchMode = z.infer<typeof DispatchModeEnum>;
 
+export const FallbackStrategyEnum = z.enum(['local', 'queue', 'reject']);
+export type FallbackStrategy = z.infer<typeof FallbackStrategyEnum>;
+
 // ─── Section 1: Identity ───
 
 export const IdentitySchema = z.object({
@@ -173,6 +176,7 @@ const ApprovalSchema = z.object({
 
 export const DispatchSchema = z.object({
   mode: DispatchModeEnum,
+  fallback: FallbackStrategyEnum.default('local'),
   targetSelection: z.object({
     repoPolicy: z.string(),
     runtimeOptions: z.array(z.string()),

--- a/src/skills/crystallizer.ts
+++ b/src/skills/crystallizer.ts
@@ -128,6 +128,7 @@ export function crystallize(candidate: SkillCandidate): CrystallizeResult {
     },
     dispatch: {
       mode: 'local',
+      fallback: 'local',
       targetSelection: { repoPolicy: 'explicit', runtimeOptions: [] },
       workerClass: [],
       handoff: { inputArtifacts: [], outputArtifacts: [] },

--- a/src/skills/overlay-merge.test.ts
+++ b/src/skills/overlay-merge.test.ts
@@ -64,6 +64,7 @@ function makeBaseSkillObject(): SkillObject {
     },
     dispatch: {
       mode: 'local',
+      fallback: 'local',
       targetSelection: { repoPolicy: 'current', runtimeOptions: [] },
       workerClass: [],
       handoff: { inputArtifacts: [], outputArtifacts: [] },

--- a/src/skills/promotion.test.ts
+++ b/src/skills/promotion.test.ts
@@ -84,6 +84,7 @@ function makeSkillObject(
     },
     dispatch: {
       mode: 'local',
+      fallback: 'local',
       targetSelection: { repoPolicy: 'current', runtimeOptions: [] },
       workerClass: [],
       handoff: { inputArtifacts: [], outputArtifacts: [] },


### PR DESCRIPTION
Adds configurable per-skill fallback strategy for Karvi dispatch failures. Closes #160