### PR TITLE
feat(forge): add remaining regime templates (#161)

### DIFF
--- a/src/decision/commit-memo.test.ts
+++ b/src/decision/commit-memo.test.ts
@@ -5,6 +5,10 @@ import type {
   RealizationCandidate,
   EconomicCommitMemo,
   GovernanceCommitMemo,
+  CapabilityCommitMemo,
+  LeverageCommitMemo,
+  ExpressionCommitMemo,
+  IdentityCommitMemo,
 } from '../schemas/decision';
 
 function makeCandidate(overrides: Partial<RealizationCandidate> = {}): RealizationCandidate {
@@ -105,17 +109,80 @@ describe('buildCommitMemo', () => {
     });
   });
 
-  describe('unknown/other regime', () => {
-    it('returns base CommitMemo without specialization for capability regime', () => {
-      const candidate = makeCandidate({ regime: 'capability' });
+  describe('capability regime', () => {
+    it('builds CapabilityCommitMemo with all 5 specialized fields', () => {
+      const candidate = makeCandidate({ regime: 'capability', domain: 'data-analysis' });
       const output = makeEvaluatorOutput();
 
       const memo = buildCommitMemo(output, candidate);
 
       expect(memo.regime).toBe('capability');
       expect(memo.candidateId).toBe('cand-1');
-      expect('buyerHypothesis' in memo).toBe(false);
-      expect('selectedWorldForm' in memo).toBe(false);
+      expect('skillDomain' in memo).toBe(true);
+
+      const cap = memo as CapabilityCommitMemo;
+      expect(cap.skillDomain).toBe('data-analysis');
+      expect(cap.currentLevel).toBeDefined();
+      expect(cap.targetLevel).toBeDefined();
+      expect(cap.proofMethod).toBe('service');
+      expect(cap.milestones).toEqual(output.recommendedNextStep);
+    });
+  });
+
+  describe('leverage regime', () => {
+    it('builds LeverageCommitMemo with all 5 specialized fields', () => {
+      const candidate = makeCandidate({ regime: 'leverage' });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.regime).toBe('leverage');
+      expect('leverageType' in memo).toBe(true);
+
+      const lev = memo as LeverageCommitMemo;
+      expect(lev.leverageType).toBe('service');
+      expect(lev.currentBottleneck).toBeDefined();
+      expect(lev.amplificationTarget).toBeDefined();
+      expect(lev.dependencies).toBeDefined();
+      expect(lev.riskIfNotBuilt).toBeDefined();
+    });
+  });
+
+  describe('expression regime', () => {
+    it('builds ExpressionCommitMemo with all 5 specialized fields', () => {
+      const candidate = makeCandidate({ regime: 'expression', domain: 'indie-dev' });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.regime).toBe('expression');
+      expect('medium' in memo).toBe(true);
+
+      const exp = memo as ExpressionCommitMemo;
+      expect(exp.medium).toBe('service');
+      expect(exp.audience).toBe('indie-dev');
+      expect(exp.coreMessage).toBeDefined();
+      expect(exp.styleConstraints).toBeDefined();
+      expect(exp.existingAssets).toBeDefined();
+    });
+  });
+
+  describe('identity regime', () => {
+    it('builds IdentityCommitMemo with all 5 specialized fields', () => {
+      const candidate = makeCandidate({ regime: 'identity', domain: 'engineering-team' });
+      const output = makeEvaluatorOutput();
+
+      const memo = buildCommitMemo(output, candidate);
+
+      expect(memo.regime).toBe('identity');
+      expect('scope' in memo).toBe(true);
+
+      const id = memo as IdentityCommitMemo;
+      expect(id.scope).toBe('engineering-team');
+      expect(id.coreValues).toEqual(candidate.whyThisCandidate);
+      expect(id.tensions).toEqual(output.unresolvedRisks);
+      expect(id.rituals).toEqual(output.recommendedNextStep);
+      expect(id.boundaries).toEqual(candidate.assumptions);
     });
   });
 

--- a/src/decision/commit-memo.ts
+++ b/src/decision/commit-memo.ts
@@ -1,7 +1,11 @@
 import type {
+  CapabilityCommitMemo,
   CommitMemo,
   EconomicCommitMemo,
+  ExpressionCommitMemo,
   GovernanceCommitMemo,
+  IdentityCommitMemo,
+  LeverageCommitMemo,
   EvaluatorOutput,
   RealizationCandidate,
   GovernanceWorldCandidate,
@@ -159,12 +163,92 @@ function buildGovernanceCommitMemo(
   };
 }
 
+function buildCapabilityCommitMemo(
+  base: CommitMemo,
+  output: EvaluatorOutput,
+  candidate: RealizationCandidate,
+): CapabilityCommitMemo {
+  const skillDomain = candidate.domain ?? candidate.description;
+  const currentLevel = candidate.assumptions.find((a) =>
+    a.toLowerCase().includes('current') || a.toLowerCase().includes('level'),
+  ) ?? 'unknown';
+  const targetLevel = candidate.whyThisCandidate.find((w) =>
+    w.toLowerCase().includes('target') || w.toLowerCase().includes('goal'),
+  ) ?? (output.recommendedNextStep[0] || 'target');
+  const proofMethod = candidate.form;
+
+  return {
+    ...base,
+    skillDomain,
+    currentLevel,
+    targetLevel,
+    proofMethod,
+    milestones: output.recommendedNextStep,
+  };
+}
+
+function buildLeverageCommitMemo(
+  base: CommitMemo,
+  output: EvaluatorOutput,
+  candidate: RealizationCandidate,
+): LeverageCommitMemo {
+  const leverageType = candidate.form;
+  const currentBottleneck = candidate.whyThisCandidate[0] ?? candidate.description;
+  const amplificationTarget = output.recommendedNextStep[0] ?? candidate.description;
+  const riskIfNotBuilt = output.unresolvedRisks[0] ?? '';
+
+  return {
+    ...base,
+    leverageType,
+    currentBottleneck,
+    amplificationTarget,
+    dependencies: candidate.assumptions,
+    riskIfNotBuilt,
+  };
+}
+
+function buildExpressionCommitMemo(
+  base: CommitMemo,
+  output: EvaluatorOutput,
+  candidate: RealizationCandidate,
+): ExpressionCommitMemo {
+  const medium = candidate.form;
+  const audience = candidate.domain ?? 'unknown';
+  const coreMessage = candidate.whyThisCandidate[0] ?? candidate.description;
+
+  return {
+    ...base,
+    medium,
+    audience,
+    coreMessage,
+    styleConstraints: candidate.assumptions,
+    existingAssets: candidate.notes,
+  };
+}
+
+function buildIdentityCommitMemo(
+  base: CommitMemo,
+  output: EvaluatorOutput,
+  candidate: RealizationCandidate,
+): IdentityCommitMemo {
+  const scope = candidate.domain ?? 'unknown';
+
+  return {
+    ...base,
+    scope,
+    coreValues: candidate.whyThisCandidate,
+    tensions: output.unresolvedRisks,
+    rituals: output.recommendedNextStep,
+    boundaries: candidate.assumptions,
+  };
+}
+
 // ─── Main Export ───
 
 export function buildCommitMemo(
   evaluatorOutput: EvaluatorOutput,
   candidate: RealizationCandidate,
-): CommitMemo | EconomicCommitMemo | GovernanceCommitMemo {
+): CommitMemo | EconomicCommitMemo | GovernanceCommitMemo | CapabilityCommitMemo | LeverageCommitMemo | ExpressionCommitMemo | IdentityCommitMemo {
   const baseMemo: CommitMemo = {
     candidateId: candidate.id,
     regime: candidate.regime,
@@ -177,11 +261,18 @@ export function buildCommitMemo(
     recommendedNextStep: evaluatorOutput.recommendedNextStep,
   };
 
-  if (candidate.regime === 'economic') {
-    return buildEconomicCommitMemo(baseMemo, evaluatorOutput, candidate);
+  switch (candidate.regime) {
+    case 'economic':
+      return buildEconomicCommitMemo(baseMemo, evaluatorOutput, candidate);
+    case 'governance':
+      return buildGovernanceCommitMemo(baseMemo, evaluatorOutput, candidate);
+    case 'capability':
+      return buildCapabilityCommitMemo(baseMemo, evaluatorOutput, candidate);
+    case 'leverage':
+      return buildLeverageCommitMemo(baseMemo, evaluatorOutput, candidate);
+    case 'expression':
+      return buildExpressionCommitMemo(baseMemo, evaluatorOutput, candidate);
+    case 'identity':
+      return buildIdentityCommitMemo(baseMemo, evaluatorOutput, candidate);
   }
-  if (candidate.regime === 'governance') {
-    return buildGovernanceCommitMemo(baseMemo, evaluatorOutput, candidate);
-  }
-  return baseMemo;
 }

--- a/src/decision/forge-handoff.test.ts
+++ b/src/decision/forge-handoff.test.ts
@@ -2,8 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { buildForgeBuildRequest, buildSyntheticCommitMemo, type ForgeHandoffContext } from './forge-handoff';
 import { ForgeBuildRequestSchema } from '../karvi-client/schemas';
 import type {
+  CapabilityCommitMemo,
   EconomicCommitMemo,
+  ExpressionCommitMemo,
   GovernanceCommitMemo,
+  IdentityCommitMemo,
+  LeverageCommitMemo,
   CommitMemo,
   PathCheckResult,
 } from '../schemas/decision';
@@ -56,6 +60,86 @@ function makeGovernanceMemo(overrides?: Partial<GovernanceCommitMemo>): Governan
     governancePressureAssessment: 'high',
     firstCycleDesign: ['Weekly review cycle', 'Dispute resolution'],
     thyraHandoffRequirements: ['Chief must approve stall changes', 'Max 50 stalls'],
+    ...overrides,
+  };
+}
+
+function makeCapabilityMemo(overrides?: Partial<CapabilityCommitMemo>): CapabilityCommitMemo {
+  return {
+    candidateId: 'cap-001',
+    regime: 'capability',
+    verdict: 'commit',
+    rationale: ['Skill gap identified in data analysis'],
+    evidenceUsed: ['Self-assessment results'],
+    unresolvedRisks: ['Time commitment uncertain'],
+    whatForgeShouldBuild: ['Practice loop structure', 'Portfolio template'],
+    whatForgeMustNotBuild: ['Full certification program'],
+    recommendedNextStep: ['Start daily practice'],
+    skillDomain: 'data-analysis',
+    currentLevel: 'beginner',
+    targetLevel: 'intermediate',
+    proofMethod: 'portfolio review',
+    milestones: ['Complete 3 case studies', 'Pass skill assessment'],
+    ...overrides,
+  };
+}
+
+function makeLeverageMemo(overrides?: Partial<LeverageCommitMemo>): LeverageCommitMemo {
+  return {
+    candidateId: 'lev-001',
+    regime: 'leverage',
+    verdict: 'commit',
+    rationale: ['Manual process consuming 10h/week'],
+    evidenceUsed: ['Time tracking data'],
+    unresolvedRisks: ['Integration complexity'],
+    whatForgeShouldBuild: ['Automation pipeline', 'Monitoring dashboard'],
+    whatForgeMustNotBuild: ['Full enterprise platform'],
+    recommendedNextStep: ['Deploy MVP automation'],
+    leverageType: 'automation',
+    currentBottleneck: 'Manual data entry consuming 10h/week',
+    amplificationTarget: '5x throughput improvement',
+    dependencies: ['API access', 'Data schema documentation'],
+    riskIfNotBuilt: 'Team burnout from repetitive tasks',
+    ...overrides,
+  };
+}
+
+function makeExpressionMemo(overrides?: Partial<ExpressionCommitMemo>): ExpressionCommitMemo {
+  return {
+    candidateId: 'exp-001',
+    regime: 'expression',
+    verdict: 'commit',
+    rationale: ['Brand identity needs clear articulation'],
+    evidenceUsed: ['Customer feedback', 'Competitor analysis'],
+    unresolvedRisks: ['Audience reception unknown'],
+    whatForgeShouldBuild: ['Landing page', 'Brand guide'],
+    whatForgeMustNotBuild: ['Full marketing campaign'],
+    recommendedNextStep: ['Launch landing page and measure engagement'],
+    medium: 'website',
+    audience: 'indie developers',
+    coreMessage: 'Tools that respect your craft',
+    styleConstraints: ['Minimalist', 'Technical but approachable'],
+    existingAssets: ['Logo draft', 'Color palette'],
+    ...overrides,
+  };
+}
+
+function makeIdentityMemo(overrides?: Partial<IdentityCommitMemo>): IdentityCommitMemo {
+  return {
+    candidateId: 'id-001',
+    regime: 'identity',
+    verdict: 'commit',
+    rationale: ['Team culture needs definition'],
+    evidenceUsed: ['Team survey results'],
+    unresolvedRisks: ['Disagreement on values'],
+    whatForgeShouldBuild: ['Values framework', 'Decision principles'],
+    whatForgeMustNotBuild: ['Rigid hierarchy'],
+    recommendedNextStep: ['Workshop to align on values'],
+    scope: 'engineering-team',
+    coreValues: ['Craft', 'Autonomy', 'Transparency'],
+    tensions: ['Speed vs quality', 'Individual vs team'],
+    rituals: ['Weekly retro', 'Pair programming sessions'],
+    boundaries: ['No blame culture', 'No mandatory overtime'],
     ...overrides,
   };
 }
@@ -196,31 +280,177 @@ describe('buildForgeBuildRequest', () => {
     });
   });
 
-  describe('generic fallback', () => {
-    it('maps non-economic non-governance memo to ForgeBuildRequest with economic regimeContext', () => {
+  describe('capability regime', () => {
+    it('maps CapabilityCommitMemo to ForgeBuildRequest with capability regimeContext', () => {
+      const memo = makeCapabilityMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      expect(result.regime).toBe('capability');
+      expect(result.regimeContext.kind).toBe('capability');
+      expect(result.whatToBuild).toEqual(memo.whatForgeShouldBuild);
+    });
+
+    it('includes all 5 capability regimeContext fields', () => {
+      const memo = makeCapabilityMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      if (result.regimeContext.kind !== 'capability') throw new Error('unreachable');
+
+      expect(result.regimeContext.skillDomain).toBe(memo.skillDomain);
+      expect(result.regimeContext.currentLevel).toBe(memo.currentLevel);
+      expect(result.regimeContext.targetLevel).toBe(memo.targetLevel);
+      expect(result.regimeContext.proofMethod).toBe(memo.proofMethod);
+      expect(result.regimeContext.milestones).toEqual(memo.milestones);
+    });
+
+    it('validates output against ForgeBuildRequestSchema', () => {
+      const result = buildForgeBuildRequest(makeCapabilityMemo(), makeContext());
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  describe('leverage regime', () => {
+    it('maps LeverageCommitMemo to ForgeBuildRequest with leverage regimeContext', () => {
+      const memo = makeLeverageMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      expect(result.regime).toBe('leverage');
+      expect(result.regimeContext.kind).toBe('leverage');
+      expect(result.whatToBuild).toEqual(memo.whatForgeShouldBuild);
+    });
+
+    it('includes all 5 leverage regimeContext fields', () => {
+      const memo = makeLeverageMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      if (result.regimeContext.kind !== 'leverage') throw new Error('unreachable');
+
+      expect(result.regimeContext.leverageType).toBe(memo.leverageType);
+      expect(result.regimeContext.currentBottleneck).toBe(memo.currentBottleneck);
+      expect(result.regimeContext.amplificationTarget).toBe(memo.amplificationTarget);
+      expect(result.regimeContext.dependencies).toEqual(memo.dependencies);
+      expect(result.regimeContext.riskIfNotBuilt).toBe(memo.riskIfNotBuilt);
+    });
+
+    it('validates output against ForgeBuildRequestSchema', () => {
+      const result = buildForgeBuildRequest(makeLeverageMemo(), makeContext());
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  describe('expression regime', () => {
+    it('maps ExpressionCommitMemo to ForgeBuildRequest with expression regimeContext', () => {
+      const memo = makeExpressionMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      expect(result.regime).toBe('expression');
+      expect(result.regimeContext.kind).toBe('expression');
+      expect(result.whatToBuild).toEqual(memo.whatForgeShouldBuild);
+    });
+
+    it('includes all 5 expression regimeContext fields', () => {
+      const memo = makeExpressionMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      if (result.regimeContext.kind !== 'expression') throw new Error('unreachable');
+
+      expect(result.regimeContext.medium).toBe(memo.medium);
+      expect(result.regimeContext.audience).toBe(memo.audience);
+      expect(result.regimeContext.coreMessage).toBe(memo.coreMessage);
+      expect(result.regimeContext.styleConstraints).toEqual(memo.styleConstraints);
+      expect(result.regimeContext.existingAssets).toEqual(memo.existingAssets);
+    });
+
+    it('validates output against ForgeBuildRequestSchema', () => {
+      const result = buildForgeBuildRequest(makeExpressionMemo(), makeContext());
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  describe('identity regime', () => {
+    it('maps IdentityCommitMemo to ForgeBuildRequest with identity regimeContext', () => {
+      const memo = makeIdentityMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      expect(result.regime).toBe('identity');
+      expect(result.regimeContext.kind).toBe('identity');
+      expect(result.whatToBuild).toEqual(memo.whatForgeShouldBuild);
+    });
+
+    it('includes all 5 identity regimeContext fields', () => {
+      const memo = makeIdentityMemo();
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      if (result.regimeContext.kind !== 'identity') throw new Error('unreachable');
+
+      expect(result.regimeContext.scope).toBe(memo.scope);
+      expect(result.regimeContext.coreValues).toEqual(memo.coreValues);
+      expect(result.regimeContext.tensions).toEqual(memo.tensions);
+      expect(result.regimeContext.rituals).toEqual(memo.rituals);
+      expect(result.regimeContext.boundaries).toEqual(memo.boundaries);
+    });
+
+    it('validates output against ForgeBuildRequestSchema', () => {
+      const result = buildForgeBuildRequest(makeIdentityMemo(), makeContext());
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+  });
+
+  describe('base CommitMemo fallback (no regime-specific extension)', () => {
+    it('maps base capability memo to ForgeBuildRequest with capability regimeContext', () => {
       const memo = makeBaseMemo();
       const result = buildForgeBuildRequest(memo, makeContext());
 
       expect(result.regime).toBe('capability');
-      expect(result.regimeContext.kind).toBe('economic');
+      expect(result.regimeContext.kind).toBe('capability');
       expect(result.whatToBuild).toEqual(memo.whatForgeShouldBuild);
     });
 
-    it('uses rationale as fallback for economic fields', () => {
+    it('derives capability context fields from base memo fields', () => {
       const memo = makeBaseMemo();
       const result = buildForgeBuildRequest(memo, makeContext());
 
-      if (result.regimeContext.kind !== 'economic') throw new Error('unreachable');
-      expect(result.regimeContext.buyerHypothesis).toBe(memo.rationale[0]);
-      expect(result.regimeContext.painHypothesis).toBe(memo.rationale.join('; '));
-      expect(result.regimeContext.vehicleType).toBe('unknown');
-      expect(result.regimeContext.paymentEvidence).toEqual([]);
-      expect(result.regimeContext.whyThisVehicleNow).toEqual([]);
-      expect(result.regimeContext.nextSignalAfterBuild).toEqual(memo.recommendedNextStep);
+      if (result.regimeContext.kind !== 'capability') throw new Error('unreachable');
+      expect(result.regimeContext.skillDomain).toBe(memo.rationale[0]);
+      expect(result.regimeContext.currentLevel).toBe('unknown');
+      expect(result.regimeContext.targetLevel).toBe('unknown');
+      expect(result.regimeContext.proofMethod).toBe(memo.recommendedNextStep[0]);
+      expect(result.regimeContext.milestones).toEqual(memo.whatForgeShouldBuild);
     });
 
     it('validates output against ForgeBuildRequestSchema', () => {
       const result = buildForgeBuildRequest(makeBaseMemo(), makeContext());
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    it('handles base memo with leverage regime', () => {
+      const memo = makeBaseMemo({ regime: 'leverage' });
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      expect(result.regimeContext.kind).toBe('leverage');
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    it('handles base memo with expression regime', () => {
+      const memo = makeBaseMemo({ regime: 'expression' });
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      expect(result.regimeContext.kind).toBe('expression');
+      const parsed = ForgeBuildRequestSchema.safeParse(result);
+      expect(parsed.success).toBe(true);
+    });
+
+    it('handles base memo with identity regime', () => {
+      const memo = makeBaseMemo({ regime: 'identity' });
+      const result = buildForgeBuildRequest(memo, makeContext());
+
+      expect(result.regimeContext.kind).toBe('identity');
       const parsed = ForgeBuildRequestSchema.safeParse(result);
       expect(parsed.success).toBe(true);
     });
@@ -275,15 +505,55 @@ describe('buildSyntheticCommitMemo', () => {
     expect(gov.thyraHandoffRequirements).toEqual(['Clear domain', 'Defined participants']);
   });
 
-  it('builds base CommitMemo for non-economic non-governance regime', () => {
+  it('builds capability synthetic CommitMemo from PathCheckResult', () => {
     const pcr = makePathCheckResult();
     const result = buildSyntheticCommitMemo(pcr, 'capability');
 
     expect(result.regime).toBe('capability');
     expect(result.verdict).toBe('commit');
-    expect('buyerHypothesis' in result).toBe(false);
-    expect('selectedWorldForm' in result).toBe(false);
-    expect(result.whatForgeShouldBuild).toContain('Project management tool');
+    expect('skillDomain' in result).toBe(true);
+
+    const cap = result as CapabilityCommitMemo;
+    expect(cap.skillDomain).toBe('freelance-design');
+    expect(cap.proofMethod).toBe('service');
+    expect(cap.milestones).toContain('Project management tool');
+  });
+
+  it('builds leverage synthetic CommitMemo from PathCheckResult', () => {
+    const pcr = makePathCheckResult();
+    const result = buildSyntheticCommitMemo(pcr, 'leverage');
+
+    expect(result.regime).toBe('leverage');
+    expect('leverageType' in result).toBe(true);
+
+    const lev = result as LeverageCommitMemo;
+    expect(lev.leverageType).toBe('service');
+    expect(lev.currentBottleneck).toBe('Automate project tracking');
+  });
+
+  it('builds expression synthetic CommitMemo from PathCheckResult', () => {
+    const pcr = makePathCheckResult();
+    const result = buildSyntheticCommitMemo(pcr, 'expression');
+
+    expect(result.regime).toBe('expression');
+    expect('medium' in result).toBe(true);
+
+    const exp = result as ExpressionCommitMemo;
+    expect(exp.medium).toBe('service');
+    expect(exp.audience).toBe('Freelance designers');
+    expect(exp.coreMessage).toBe('Automate project tracking');
+  });
+
+  it('builds identity synthetic CommitMemo from PathCheckResult', () => {
+    const pcr = makePathCheckResult();
+    const result = buildSyntheticCommitMemo(pcr, 'identity');
+
+    expect(result.regime).toBe('identity');
+    expect('scope' in result).toBe(true);
+
+    const id = result as IdentityCommitMemo;
+    expect(id.scope).toBe('freelance-design');
+    expect(id.coreValues.length).toBeGreaterThan(0);
   });
 
   it('includes unresolved risks from PathCheckResult', () => {

--- a/src/decision/forge-handoff.ts
+++ b/src/decision/forge-handoff.ts
@@ -1,7 +1,11 @@
 import type {
+  CapabilityCommitMemo,
   CommitMemo,
   EconomicCommitMemo,
+  ExpressionCommitMemo,
   GovernanceCommitMemo,
+  IdentityCommitMemo,
+  LeverageCommitMemo,
   PathCheckResult,
   Regime,
   WorldForm,
@@ -26,6 +30,42 @@ function isGovernanceCommitMemo(memo: CommitMemo): memo is GovernanceCommitMemo 
   return memo.regime === 'governance' && 'selectedWorldForm' in memo;
 }
 
+function isCapabilityCommitMemo(memo: CommitMemo): memo is CapabilityCommitMemo {
+  return memo.regime === 'capability' && 'skillDomain' in memo;
+}
+
+function isLeverageCommitMemo(memo: CommitMemo): memo is LeverageCommitMemo {
+  return memo.regime === 'leverage' && 'leverageType' in memo;
+}
+
+function isExpressionCommitMemo(memo: CommitMemo): memo is ExpressionCommitMemo {
+  return memo.regime === 'expression' && 'medium' in memo;
+}
+
+function isIdentityCommitMemo(memo: CommitMemo): memo is IdentityCommitMemo {
+  return memo.regime === 'identity' && 'scope' in memo;
+}
+
+// ─── Shared Request Base ───
+
+function buildRequestBase(memo: CommitMemo, context: ForgeHandoffContext) {
+  return {
+    sessionId: context.sessionId,
+    candidateId: memo.candidateId,
+    regime: memo.regime,
+    verdict: 'commit' as const,
+    whatToBuild: memo.whatForgeShouldBuild,
+    whatNotToBuild: memo.whatForgeMustNotBuild,
+    rationale: memo.rationale,
+    evidenceUsed: memo.evidenceUsed,
+    unresolvedRisks: memo.unresolvedRisks,
+    context: {
+      workingDir: context.workingDir,
+      targetRepo: context.targetRepo,
+    },
+  };
+}
+
 // ─── Economic Translation ───
 
 function buildEconomicRequest(
@@ -33,15 +73,7 @@ function buildEconomicRequest(
   context: ForgeHandoffContext,
 ): ForgeBuildRequest {
   return {
-    sessionId: context.sessionId,
-    candidateId: memo.candidateId,
-    regime: memo.regime,
-    verdict: 'commit',
-    whatToBuild: memo.whatForgeShouldBuild,
-    whatNotToBuild: memo.whatForgeMustNotBuild,
-    rationale: memo.rationale,
-    evidenceUsed: memo.evidenceUsed,
-    unresolvedRisks: memo.unresolvedRisks,
+    ...buildRequestBase(memo, context),
     regimeContext: {
       kind: 'economic',
       buyerHypothesis: memo.buyerHypothesis,
@@ -50,10 +82,6 @@ function buildEconomicRequest(
       paymentEvidence: memo.paymentEvidence,
       whyThisVehicleNow: memo.whyThisVehicleNow,
       nextSignalAfterBuild: memo.nextSignalAfterBuild,
-    },
-    context: {
-      workingDir: context.workingDir,
-      targetRepo: context.targetRepo,
     },
   };
 }
@@ -65,15 +93,7 @@ function buildGovernanceRequest(
   context: ForgeHandoffContext,
 ): ForgeBuildRequest {
   return {
-    sessionId: context.sessionId,
-    candidateId: memo.candidateId,
-    regime: memo.regime,
-    verdict: 'commit',
-    whatToBuild: memo.whatForgeShouldBuild,
-    whatNotToBuild: memo.whatForgeMustNotBuild,
-    rationale: memo.rationale,
-    evidenceUsed: memo.evidenceUsed,
-    unresolvedRisks: memo.unresolvedRisks,
+    ...buildRequestBase(memo, context),
     regimeContext: {
       kind: 'governance',
       worldForm: memo.selectedWorldForm,
@@ -83,41 +103,81 @@ function buildGovernanceRequest(
       governancePressureAssessment: memo.governancePressureAssessment,
       thyraHandoffRequirements: memo.thyraHandoffRequirements,
     },
-    context: {
-      workingDir: context.workingDir,
-      targetRepo: context.targetRepo,
+  };
+}
+
+// ─── Capability Translation ───
+
+function buildCapabilityRequest(
+  memo: CapabilityCommitMemo,
+  context: ForgeHandoffContext,
+): ForgeBuildRequest {
+  return {
+    ...buildRequestBase(memo, context),
+    regimeContext: {
+      kind: 'capability',
+      skillDomain: memo.skillDomain,
+      currentLevel: memo.currentLevel,
+      targetLevel: memo.targetLevel,
+      proofMethod: memo.proofMethod,
+      milestones: memo.milestones,
     },
   };
 }
 
-// ─── Generic Fallback (non-economic, non-governance regimes) ───
+// ─── Leverage Translation ───
 
-function buildFallbackRequest(
-  memo: CommitMemo,
+function buildLeverageRequest(
+  memo: LeverageCommitMemo,
   context: ForgeHandoffContext,
 ): ForgeBuildRequest {
   return {
-    sessionId: context.sessionId,
-    candidateId: memo.candidateId,
-    regime: memo.regime,
-    verdict: 'commit',
-    whatToBuild: memo.whatForgeShouldBuild,
-    whatNotToBuild: memo.whatForgeMustNotBuild,
-    rationale: memo.rationale,
-    evidenceUsed: memo.evidenceUsed,
-    unresolvedRisks: memo.unresolvedRisks,
+    ...buildRequestBase(memo, context),
     regimeContext: {
-      kind: 'economic',
-      buyerHypothesis: memo.rationale[0] || '',
-      painHypothesis: memo.rationale.join('; '),
-      vehicleType: 'unknown',
-      paymentEvidence: [],
-      whyThisVehicleNow: [],
-      nextSignalAfterBuild: memo.recommendedNextStep,
+      kind: 'leverage',
+      leverageType: memo.leverageType,
+      currentBottleneck: memo.currentBottleneck,
+      amplificationTarget: memo.amplificationTarget,
+      dependencies: memo.dependencies,
+      riskIfNotBuilt: memo.riskIfNotBuilt,
     },
-    context: {
-      workingDir: context.workingDir,
-      targetRepo: context.targetRepo,
+  };
+}
+
+// ─── Expression Translation ───
+
+function buildExpressionRequest(
+  memo: ExpressionCommitMemo,
+  context: ForgeHandoffContext,
+): ForgeBuildRequest {
+  return {
+    ...buildRequestBase(memo, context),
+    regimeContext: {
+      kind: 'expression',
+      medium: memo.medium,
+      audience: memo.audience,
+      coreMessage: memo.coreMessage,
+      styleConstraints: memo.styleConstraints,
+      existingAssets: memo.existingAssets,
+    },
+  };
+}
+
+// ─── Identity Translation ───
+
+function buildIdentityRequest(
+  memo: IdentityCommitMemo,
+  context: ForgeHandoffContext,
+): ForgeBuildRequest {
+  return {
+    ...buildRequestBase(memo, context),
+    regimeContext: {
+      kind: 'identity',
+      scope: memo.scope,
+      coreValues: memo.coreValues,
+      tensions: memo.tensions,
+      rituals: memo.rituals,
+      boundaries: memo.boundaries,
     },
   };
 }
@@ -134,12 +194,108 @@ export function buildForgeBuildRequest(
     request = buildEconomicRequest(commitMemo, context);
   } else if (isGovernanceCommitMemo(commitMemo)) {
     request = buildGovernanceRequest(commitMemo, context);
+  } else if (isCapabilityCommitMemo(commitMemo)) {
+    request = buildCapabilityRequest(commitMemo, context);
+  } else if (isLeverageCommitMemo(commitMemo)) {
+    request = buildLeverageRequest(commitMemo, context);
+  } else if (isExpressionCommitMemo(commitMemo)) {
+    request = buildExpressionRequest(commitMemo, context);
+  } else if (isIdentityCommitMemo(commitMemo)) {
+    request = buildIdentityRequest(commitMemo, context);
   } else {
-    request = buildFallbackRequest(commitMemo, context);
+    // Base CommitMemo without regime-specific extension — derive context from regime field
+    request = buildFromBaseCommitMemo(commitMemo, context);
   }
 
   // Validate output against schema (CONTRACT: output must match ForgeBuildRequestSchema)
   return ForgeBuildRequestSchema.parse(request);
+}
+
+// ─── Base CommitMemo Fallback (derives regime context from memo.regime) ───
+
+function buildFromBaseCommitMemo(
+  memo: CommitMemo,
+  context: ForgeHandoffContext,
+): ForgeBuildRequest {
+  const base = buildRequestBase(memo, context);
+  const regime = memo.regime;
+
+  switch (regime) {
+    case 'economic':
+      return {
+        ...base,
+        regimeContext: {
+          kind: 'economic',
+          buyerHypothesis: memo.rationale[0] || '',
+          painHypothesis: memo.rationale.join('; '),
+          vehicleType: 'unknown',
+          paymentEvidence: [],
+          whyThisVehicleNow: [],
+          nextSignalAfterBuild: memo.recommendedNextStep,
+        },
+      };
+    case 'governance':
+      return {
+        ...base,
+        regimeContext: {
+          kind: 'governance',
+          worldForm: 'market',
+          minimumWorldShape: [],
+          firstCycleDesign: memo.recommendedNextStep,
+          stateDensityAssessment: 'medium',
+          governancePressureAssessment: 'medium',
+          thyraHandoffRequirements: [],
+        },
+      };
+    case 'capability':
+      return {
+        ...base,
+        regimeContext: {
+          kind: 'capability',
+          skillDomain: memo.rationale[0] || '',
+          currentLevel: 'unknown',
+          targetLevel: 'unknown',
+          proofMethod: memo.recommendedNextStep[0] || '',
+          milestones: memo.whatForgeShouldBuild,
+        },
+      };
+    case 'leverage':
+      return {
+        ...base,
+        regimeContext: {
+          kind: 'leverage',
+          leverageType: 'unknown',
+          currentBottleneck: memo.rationale[0] || '',
+          amplificationTarget: memo.recommendedNextStep[0] || '',
+          dependencies: [],
+          riskIfNotBuilt: memo.unresolvedRisks[0] || '',
+        },
+      };
+    case 'expression':
+      return {
+        ...base,
+        regimeContext: {
+          kind: 'expression',
+          medium: 'unknown',
+          audience: 'unknown',
+          coreMessage: memo.rationale[0] || '',
+          styleConstraints: [],
+          existingAssets: [],
+        },
+      };
+    case 'identity':
+      return {
+        ...base,
+        regimeContext: {
+          kind: 'identity',
+          scope: 'unknown',
+          coreValues: memo.rationale,
+          tensions: memo.unresolvedRisks,
+          rituals: [],
+          boundaries: memo.whatForgeMustNotBuild,
+        },
+      };
+  }
 }
 
 // ─── Synthetic CommitMemo for Forge Fast-Path ───
@@ -149,57 +305,124 @@ function findFixed(fixedElements: PathCheckResult['fixedElements'], kind: string
   return el ? el.value : '';
 }
 
+type SyntheticFields = {
+  domain: string;
+  form: string;
+  buildTarget: string;
+  buyer: string;
+  intent: string;
+};
+
+function buildSyntheticEconomic(baseMemo: CommitMemo, fields: SyntheticFields, pcr: PathCheckResult): EconomicCommitMemo {
+  return {
+    ...baseMemo,
+    buyerHypothesis: fields.buyer || `${fields.domain} buyer`,
+    painHypothesis: fields.intent || `${fields.domain} pain point`,
+    paymentEvidence: [],
+    whyThisVehicleNow: [fields.form || 'Fast-path vehicle'].filter(Boolean),
+    nextSignalAfterBuild: [pcr.recommendedNextStep],
+  };
+}
+
+function buildSyntheticGovernance(baseMemo: CommitMemo, fields: SyntheticFields, pcr: PathCheckResult): GovernanceCommitMemo {
+  const worldForm: WorldForm = fields.form ? (fields.form as WorldForm) : 'market';
+  return {
+    ...baseMemo,
+    selectedWorldForm: worldForm,
+    minimumWorldShape: pcr.whyReady ?? [],
+    stateDensityAssessment: 'medium',
+    governancePressureAssessment: 'medium',
+    firstCycleDesign: [pcr.recommendedNextStep],
+    thyraHandoffRequirements: pcr.whyReady ?? [],
+  };
+}
+
+function buildSyntheticCapability(baseMemo: CommitMemo, fields: SyntheticFields): CapabilityCommitMemo {
+  return {
+    ...baseMemo,
+    skillDomain: fields.domain || 'unknown',
+    currentLevel: 'unknown',
+    targetLevel: fields.intent || 'target',
+    proofMethod: fields.form || 'demonstration',
+    milestones: baseMemo.whatForgeShouldBuild,
+  };
+}
+
+function buildSyntheticLeverage(baseMemo: CommitMemo, fields: SyntheticFields, pcr: PathCheckResult): LeverageCommitMemo {
+  return {
+    ...baseMemo,
+    leverageType: fields.form || 'unknown',
+    currentBottleneck: fields.intent || `${fields.domain} bottleneck`,
+    amplificationTarget: fields.buildTarget || `${fields.domain} amplification`,
+    dependencies: [],
+    riskIfNotBuilt: pcr.unresolvedElements[0]
+      ? `${pcr.unresolvedElements[0].kind}: ${pcr.unresolvedElements[0].reason}`
+      : '',
+  };
+}
+
+function buildSyntheticExpression(baseMemo: CommitMemo, fields: SyntheticFields): ExpressionCommitMemo {
+  return {
+    ...baseMemo,
+    medium: fields.form || 'unknown',
+    audience: fields.buyer || 'unknown',
+    coreMessage: fields.intent || `${fields.domain} expression`,
+    styleConstraints: [],
+    existingAssets: [],
+  };
+}
+
+function buildSyntheticIdentity(baseMemo: CommitMemo, fields: SyntheticFields): IdentityCommitMemo {
+  return {
+    ...baseMemo,
+    scope: fields.domain || 'unknown',
+    coreValues: baseMemo.rationale,
+    tensions: baseMemo.unresolvedRisks,
+    rituals: [],
+    boundaries: [],
+  };
+}
+
 export function buildSyntheticCommitMemo(
   pathCheckResult: PathCheckResult,
   regime: Regime,
-): CommitMemo | EconomicCommitMemo | GovernanceCommitMemo {
+): CommitMemo | EconomicCommitMemo | GovernanceCommitMemo | CapabilityCommitMemo | LeverageCommitMemo | ExpressionCommitMemo | IdentityCommitMemo {
   const { fixedElements } = pathCheckResult;
 
-  const domain = findFixed(fixedElements, 'domain');
-  const form = findFixed(fixedElements, 'form');
-  const buildTarget = findFixed(fixedElements, 'build_target');
-  const buyer = findFixed(fixedElements, 'buyer');
-  const intent = findFixed(fixedElements, 'intent');
+  const fields: SyntheticFields = {
+    domain: findFixed(fixedElements, 'domain'),
+    form: findFixed(fixedElements, 'form'),
+    buildTarget: findFixed(fixedElements, 'build_target'),
+    buyer: findFixed(fixedElements, 'buyer'),
+    intent: findFixed(fixedElements, 'intent'),
+  };
 
   const baseMemo: CommitMemo = {
     candidateId: `synth-${Date.now()}`,
     regime,
     verdict: 'commit',
-    rationale: [intent || `Fast-path: ${domain} ${form}`].filter(Boolean),
+    rationale: [fields.intent || `Fast-path: ${fields.domain} ${fields.form}`].filter(Boolean),
     evidenceUsed: [`path-check certainty: ${pathCheckResult.certainty}`],
     unresolvedRisks: pathCheckResult.unresolvedElements.map((u) => `${u.kind}: ${u.reason}`),
     whatForgeShouldBuild: [
-      buildTarget || `Build ${form} for ${domain}`,
+      fields.buildTarget || `Build ${fields.form} for ${fields.domain}`,
     ].filter(Boolean),
     whatForgeMustNotBuild: [],
     recommendedNextStep: [pathCheckResult.recommendedNextStep],
   };
 
-  if (regime === 'economic') {
-    const economicMemo: EconomicCommitMemo = {
-      ...baseMemo,
-      buyerHypothesis: buyer || `${domain} buyer`,
-      painHypothesis: intent || `${domain} pain point`,
-      paymentEvidence: [],
-      whyThisVehicleNow: [form || 'Fast-path vehicle'].filter(Boolean),
-      nextSignalAfterBuild: [pathCheckResult.recommendedNextStep],
-    };
-    return economicMemo;
+  switch (regime) {
+    case 'economic':
+      return buildSyntheticEconomic(baseMemo, fields, pathCheckResult);
+    case 'governance':
+      return buildSyntheticGovernance(baseMemo, fields, pathCheckResult);
+    case 'capability':
+      return buildSyntheticCapability(baseMemo, fields);
+    case 'leverage':
+      return buildSyntheticLeverage(baseMemo, fields, pathCheckResult);
+    case 'expression':
+      return buildSyntheticExpression(baseMemo, fields);
+    case 'identity':
+      return buildSyntheticIdentity(baseMemo, fields);
   }
-
-  if (regime === 'governance') {
-    const worldForm: WorldForm = form ? (form as WorldForm) : 'market';
-    const governanceMemo: GovernanceCommitMemo = {
-      ...baseMemo,
-      selectedWorldForm: worldForm,
-      minimumWorldShape: pathCheckResult.whyReady ?? [],
-      stateDensityAssessment: 'medium',
-      governancePressureAssessment: 'medium',
-      firstCycleDesign: [pathCheckResult.recommendedNextStep],
-      thyraHandoffRequirements: pathCheckResult.whyReady ?? [],
-    };
-    return governanceMemo;
-  }
-
-  return baseMemo;
 }

--- a/src/karvi-client/schemas.ts
+++ b/src/karvi-client/schemas.ts
@@ -236,6 +236,42 @@ const GovernanceForgeContextSchema = z.object({
   thyraHandoffRequirements: z.array(z.string()),
 });
 
+const CapabilityForgeContextSchema = z.object({
+  kind: z.literal('capability'),
+  skillDomain: z.string(),
+  currentLevel: z.string(),
+  targetLevel: z.string(),
+  proofMethod: z.string(),
+  milestones: z.array(z.string()),
+});
+
+const LeverageForgeContextSchema = z.object({
+  kind: z.literal('leverage'),
+  leverageType: z.string(),
+  currentBottleneck: z.string(),
+  amplificationTarget: z.string(),
+  dependencies: z.array(z.string()),
+  riskIfNotBuilt: z.string(),
+});
+
+const ExpressionForgeContextSchema = z.object({
+  kind: z.literal('expression'),
+  medium: z.string(),
+  audience: z.string(),
+  coreMessage: z.string(),
+  styleConstraints: z.array(z.string()),
+  existingAssets: z.array(z.string()),
+});
+
+const IdentityForgeContextSchema = z.object({
+  kind: z.literal('identity'),
+  scope: z.string(),
+  coreValues: z.array(z.string()),
+  tensions: z.array(z.string()),
+  rituals: z.array(z.string()),
+  boundaries: z.array(z.string()),
+});
+
 export const ForgeBuildRequestSchema = z.object({
   sessionId: z.string(),
   candidateId: z.string(),
@@ -246,7 +282,14 @@ export const ForgeBuildRequestSchema = z.object({
   rationale: z.array(z.string()),
   evidenceUsed: z.array(z.string()),
   unresolvedRisks: z.array(z.string()),
-  regimeContext: z.discriminatedUnion('kind', [EconomicForgeContextSchema, GovernanceForgeContextSchema]),
+  regimeContext: z.discriminatedUnion('kind', [
+    EconomicForgeContextSchema,
+    GovernanceForgeContextSchema,
+    CapabilityForgeContextSchema,
+    LeverageForgeContextSchema,
+    ExpressionForgeContextSchema,
+    IdentityForgeContextSchema,
+  ]),
   context: z.object({
     workingDir: z.string().optional(),
     targetRepo: z.string().optional(),

--- a/src/schemas/decision.test.ts
+++ b/src/schemas/decision.test.ts
@@ -16,6 +16,10 @@ import {
   CommitMemoSchema,
   EconomicCommitMemoSchema,
   GovernanceCommitMemoSchema,
+  CapabilityCommitMemoSchema,
+  LeverageCommitMemoSchema,
+  ExpressionCommitMemoSchema,
+  IdentityCommitMemoSchema,
 } from './decision';
 
 // ─── Enum Tests ───
@@ -485,6 +489,134 @@ describe('GovernanceCommitMemoSchema', () => {
       Object.entries(validGovMemo).filter(([k]) => k !== 'selectedWorldForm'),
     );
     const result = GovernanceCommitMemoSchema.safeParse(without);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('CapabilityCommitMemoSchema', () => {
+  const validCapMemo = {
+    candidateId: 'cand-1',
+    regime: 'capability',
+    verdict: 'commit',
+    rationale: ['skill gap'],
+    evidenceUsed: ['assessment'],
+    unresolvedRisks: [],
+    whatForgeShouldBuild: ['practice loop'],
+    whatForgeMustNotBuild: [],
+    recommendedNextStep: ['start practice'],
+    skillDomain: 'data-analysis',
+    currentLevel: 'beginner',
+    targetLevel: 'intermediate',
+    proofMethod: 'portfolio',
+    milestones: ['case study 1', 'case study 2'],
+  };
+
+  it('parses valid capability commit memo', () => {
+    const result = CapabilityCommitMemoSchema.safeParse(validCapMemo);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing capability-specific fields', () => {
+    const without = Object.fromEntries(
+      Object.entries(validCapMemo).filter(([k]) => k !== 'skillDomain'),
+    );
+    const result = CapabilityCommitMemoSchema.safeParse(without);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('LeverageCommitMemoSchema', () => {
+  const validLevMemo = {
+    candidateId: 'cand-1',
+    regime: 'leverage',
+    verdict: 'commit',
+    rationale: ['bottleneck identified'],
+    evidenceUsed: ['time tracking'],
+    unresolvedRisks: [],
+    whatForgeShouldBuild: ['automation pipeline'],
+    whatForgeMustNotBuild: [],
+    recommendedNextStep: ['deploy MVP'],
+    leverageType: 'automation',
+    currentBottleneck: 'manual data entry',
+    amplificationTarget: '5x throughput',
+    dependencies: ['API access'],
+    riskIfNotBuilt: 'team burnout',
+  };
+
+  it('parses valid leverage commit memo', () => {
+    const result = LeverageCommitMemoSchema.safeParse(validLevMemo);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing leverage-specific fields', () => {
+    const without = Object.fromEntries(
+      Object.entries(validLevMemo).filter(([k]) => k !== 'leverageType'),
+    );
+    const result = LeverageCommitMemoSchema.safeParse(without);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ExpressionCommitMemoSchema', () => {
+  const validExpMemo = {
+    candidateId: 'cand-1',
+    regime: 'expression',
+    verdict: 'commit',
+    rationale: ['brand needed'],
+    evidenceUsed: ['feedback'],
+    unresolvedRisks: [],
+    whatForgeShouldBuild: ['landing page'],
+    whatForgeMustNotBuild: [],
+    recommendedNextStep: ['launch'],
+    medium: 'website',
+    audience: 'developers',
+    coreMessage: 'tools for craft',
+    styleConstraints: ['minimalist'],
+    existingAssets: ['logo'],
+  };
+
+  it('parses valid expression commit memo', () => {
+    const result = ExpressionCommitMemoSchema.safeParse(validExpMemo);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing expression-specific fields', () => {
+    const without = Object.fromEntries(
+      Object.entries(validExpMemo).filter(([k]) => k !== 'medium'),
+    );
+    const result = ExpressionCommitMemoSchema.safeParse(without);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('IdentityCommitMemoSchema', () => {
+  const validIdMemo = {
+    candidateId: 'cand-1',
+    regime: 'identity',
+    verdict: 'commit',
+    rationale: ['culture definition needed'],
+    evidenceUsed: ['survey'],
+    unresolvedRisks: [],
+    whatForgeShouldBuild: ['values framework'],
+    whatForgeMustNotBuild: [],
+    recommendedNextStep: ['workshop'],
+    scope: 'engineering-team',
+    coreValues: ['craft', 'autonomy'],
+    tensions: ['speed vs quality'],
+    rituals: ['weekly retro'],
+    boundaries: ['no blame'],
+  };
+
+  it('parses valid identity commit memo', () => {
+    const result = IdentityCommitMemoSchema.safeParse(validIdMemo);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects missing identity-specific fields', () => {
+    const without = Object.fromEntries(
+      Object.entries(validIdMemo).filter(([k]) => k !== 'scope'),
+    );
+    const result = IdentityCommitMemoSchema.safeParse(without);
     expect(result.success).toBe(false);
   });
 });

--- a/src/schemas/decision.ts
+++ b/src/schemas/decision.ts
@@ -175,6 +175,42 @@ export const GovernanceCommitMemoSchema = CommitMemoSchema.extend({
 });
 export type GovernanceCommitMemo = z.infer<typeof GovernanceCommitMemoSchema>;
 
+export const CapabilityCommitMemoSchema = CommitMemoSchema.extend({
+  skillDomain: z.string(),
+  currentLevel: z.string(),
+  targetLevel: z.string(),
+  proofMethod: z.string(),
+  milestones: z.array(z.string()),
+});
+export type CapabilityCommitMemo = z.infer<typeof CapabilityCommitMemoSchema>;
+
+export const LeverageCommitMemoSchema = CommitMemoSchema.extend({
+  leverageType: z.string(),
+  currentBottleneck: z.string(),
+  amplificationTarget: z.string(),
+  dependencies: z.array(z.string()),
+  riskIfNotBuilt: z.string(),
+});
+export type LeverageCommitMemo = z.infer<typeof LeverageCommitMemoSchema>;
+
+export const ExpressionCommitMemoSchema = CommitMemoSchema.extend({
+  medium: z.string(),
+  audience: z.string(),
+  coreMessage: z.string(),
+  styleConstraints: z.array(z.string()),
+  existingAssets: z.array(z.string()),
+});
+export type ExpressionCommitMemo = z.infer<typeof ExpressionCommitMemoSchema>;
+
+export const IdentityCommitMemoSchema = CommitMemoSchema.extend({
+  scope: z.string(),
+  coreValues: z.array(z.string()),
+  tensions: z.array(z.string()),
+  rituals: z.array(z.string()),
+  boundaries: z.array(z.string()),
+});
+export type IdentityCommitMemo = z.infer<typeof IdentityCommitMemoSchema>;
+
 // ─── Section 6: Canonical Cycle (type-only, no Zod for v0) ───
 
 export type WorldMode = 'setup' | 'open' | 'peak' | 'managed' | 'cooldown' | 'closed';


### PR DESCRIPTION
Add 4 new CommitMemo schema extensions and ForgeContext schemas for capability, leverage, expression, identity regimes. Replace generic economic-fallback with regime-specific builders. 1231 tests passing. Closes #161