### PR TITLE
fix(routes): unify dispatch path prefixes

### DIFF
--- a/src/routes/approvals.test.ts
+++ b/src/routes/approvals.test.ts
@@ -159,7 +159,7 @@ describe('approvalRoutes', () => {
     initSchema(db);
   });
 
-  describe('POST /api/dispatch', () => {
+  describe('POST /api/dispatches', () => {
     it('returns dispatched when no approval required', async () => {
       const client = makeMockKarviClient();
       // Insert skill instance for telemetry
@@ -187,7 +187,7 @@ describe('approvalRoutes', () => {
 
       const app = createTestApp(db, makeSkillObject(), client);
 
-      const res = await jsonPost(app, '/api/dispatch', {
+      const res = await jsonPost(app, '/api/dispatches', {
         skillId: 'skill.deploy-service',
         userMessage: 'Deploy checkout-service',
         inputs: {},
@@ -208,7 +208,7 @@ describe('approvalRoutes', () => {
 
       const app = createTestApp(db, makeSkillObject(), client);
 
-      const res = await jsonPost(app, '/api/dispatch', {
+      const res = await jsonPost(app, '/api/dispatches', {
         skillId: 'skill.deploy-service',
         userMessage: 'Deploy checkout-service',
         inputs: {},
@@ -244,7 +244,7 @@ describe('approvalRoutes', () => {
       const client = makeMockKarviClient();
       const app = createTestApp(db, null, client);
 
-      const res = await jsonPost(app, '/api/dispatch', {
+      const res = await jsonPost(app, '/api/dispatches', {
         skillId: 'skill.nonexistent',
         userMessage: 'Do something',
         inputs: {},
@@ -260,12 +260,12 @@ describe('approvalRoutes', () => {
       const client = makeMockKarviClient();
       const app = createTestApp(db, makeSkillObject(), client);
 
-      const res = await jsonPost(app, '/api/dispatch', { userMessage: 'test' });
+      const res = await jsonPost(app, '/api/dispatches', { userMessage: 'test' });
       expect(res.status).toBe(400);
     });
   });
 
-  describe('POST /api/dispatch/approve', () => {
+  describe('POST /api/dispatches/approve', () => {
     it('re-submits with approval token on approve within TTL', async () => {
       const client = makeMockKarviClient();
 
@@ -316,7 +316,7 @@ describe('approvalRoutes', () => {
 
       const app = createTestApp(db, makeSkillObject(), client);
 
-      const res = await jsonPost(app, '/api/dispatch/approve', {
+      const res = await jsonPost(app, '/api/dispatches/approve', {
         pendingId: 'appr_abc123',
         approvedBy: 'alice',
       });
@@ -364,7 +364,7 @@ describe('approvalRoutes', () => {
 
       const app = createTestApp(db, makeSkillObject(), client);
 
-      const res = await jsonPost(app, '/api/dispatch/approve', {
+      const res = await jsonPost(app, '/api/dispatches/approve', {
         pendingId: 'appr_expired',
       });
 
@@ -384,7 +384,7 @@ describe('approvalRoutes', () => {
       const client = makeMockKarviClient();
       const app = createTestApp(db, makeSkillObject(), client);
 
-      const res = await jsonPost(app, '/api/dispatch/approve', {
+      const res = await jsonPost(app, '/api/dispatches/approve', {
         pendingId: 'appr_nonexistent',
       });
 
@@ -434,7 +434,7 @@ describe('approvalRoutes', () => {
 
       const app = createTestApp(db, makeSkillObject(), client);
 
-      await jsonPost(app, '/api/dispatch/approve', { pendingId: 'appr_default' });
+      await jsonPost(app, '/api/dispatches/approve', { pendingId: 'appr_default' });
 
       const sentRequest = client.dispatchSkill.mock.calls[0][0] as Record<string, unknown>;
       const token = sentRequest.approvalToken as Record<string, unknown>;
@@ -442,7 +442,7 @@ describe('approvalRoutes', () => {
     });
   });
 
-  describe('POST /api/dispatch/deny', () => {
+  describe('POST /api/dispatches/deny', () => {
     it('records denial and returns success', async () => {
       const client = makeMockKarviClient();
 
@@ -464,7 +464,7 @@ describe('approvalRoutes', () => {
 
       const app = createTestApp(db, makeSkillObject(), client);
 
-      const res = await jsonPost(app, '/api/dispatch/deny', {
+      const res = await jsonPost(app, '/api/dispatches/deny', {
         pendingId: 'appr_deny_me',
       });
 
@@ -489,7 +489,7 @@ describe('approvalRoutes', () => {
       const client = makeMockKarviClient();
       const app = createTestApp(db, makeSkillObject(), client);
 
-      const res = await jsonPost(app, '/api/dispatch/deny', {
+      const res = await jsonPost(app, '/api/dispatches/deny', {
         pendingId: 'appr_nonexistent',
       });
 
@@ -500,7 +500,7 @@ describe('approvalRoutes', () => {
       const client = makeMockKarviClient();
       const app = createTestApp(db, makeSkillObject(), client);
 
-      const res = await jsonPost(app, '/api/dispatch/deny', {});
+      const res = await jsonPost(app, '/api/dispatches/deny', {});
       expect(res.status).toBe(400);
     });
   });

--- a/src/routes/approvals.ts
+++ b/src/routes/approvals.ts
@@ -53,8 +53,8 @@ export function approvalRoutes(deps: ApprovalDeps): Hono {
     dispatchOverlay: deps.dispatchOverlay,
   };
 
-  // ─── POST /api/dispatch ───
-  app.post('/api/dispatch', async (c) => {
+  // ─── POST /api/dispatches ───
+  app.post('/api/dispatches', async (c) => {
     const body: unknown = await c.req.json();
     const parsed = DispatchInputSchema.safeParse(body);
     if (!parsed.success) {
@@ -121,8 +121,8 @@ export function approvalRoutes(deps: ApprovalDeps): Hono {
     return ok(c, { type: 'fallback_local' as const, reason: outcome.reason });
   });
 
-  // ─── POST /api/dispatch/approve ───
-  app.post('/api/dispatch/approve', async (c) => {
+  // ─── POST /api/dispatches/approve ───
+  app.post('/api/dispatches/approve', async (c) => {
     const body: unknown = await c.req.json();
     const parsed = ApproveInputSchema.safeParse(body);
     if (!parsed.success) {
@@ -179,8 +179,8 @@ export function approvalRoutes(deps: ApprovalDeps): Hono {
     return ok(c, { type: 'fallback_local' as const, reason: outcome.type === 'fallback_local' ? outcome.reason : 'Unexpected outcome' });
   });
 
-  // ─── POST /api/dispatch/deny ───
-  app.post('/api/dispatch/deny', async (c) => {
+  // ─── POST /api/dispatches/deny ───
+  app.post('/api/dispatches/deny', async (c) => {
     const body: unknown = await c.req.json();
     const parsed = DenyInputSchema.safeParse(body);
     if (!parsed.success) {


### PR DESCRIPTION
Renamed routes in approvals.ts from /api/dispatch to /api/dispatches to match dispatches.ts. Updated tests. Closes #232