### PR TITLE
fix(decision): replace unsafe WorldForm cast with safeParse

### DIFF
--- a/src/decision/forge-handoff.test.ts
+++ b/src/decision/forge-handoff.test.ts
@@ -563,6 +563,21 @@ describe('buildSyntheticCommitMemo', () => {
     expect(result.unresolvedRisks).toContain('signal: No pricing data yet');
   });
 
+  it('falls back to market when governance form is invalid', () => {
+    const pcr = makePathCheckResult({
+      fixedElements: [
+        { kind: 'domain', value: 'community-garden' },
+        { kind: 'form', value: 'invalid_form_value' },
+        { kind: 'build_target', value: 'Garden governance world' },
+      ],
+    });
+    const result = buildSyntheticCommitMemo(pcr, 'governance');
+
+    expect(result.regime).toBe('governance');
+    const gov = result as GovernanceCommitMemo;
+    expect(gov.selectedWorldForm).toBe('market');
+  });
+
   it('handles missing fixedElements gracefully', () => {
     const pcr = makePathCheckResult({
       fixedElements: [],

--- a/src/decision/forge-handoff.ts
+++ b/src/decision/forge-handoff.ts
@@ -10,6 +10,7 @@ import type {
   Regime,
   WorldForm,
 } from '../schemas/decision';
+import { WorldFormEnum } from '../schemas/decision';
 import { ForgeBuildRequestSchema, type ForgeBuildRequest } from '../karvi-client/schemas';
 
 // ─── Context for Forge Handoff ───
@@ -325,7 +326,8 @@ function buildSyntheticEconomic(baseMemo: CommitMemo, fields: SyntheticFields, p
 }
 
 function buildSyntheticGovernance(baseMemo: CommitMemo, fields: SyntheticFields, pcr: PathCheckResult): GovernanceCommitMemo {
-  const worldForm: WorldForm = fields.form ? (fields.form as WorldForm) : 'market';
+  const parsed = WorldFormEnum.safeParse(fields.form);
+  const worldForm: WorldForm = parsed.success ? parsed.data : 'market';
   return {
     ...baseMemo,
     selectedWorldForm: worldForm,


### PR DESCRIPTION
Replaces unsafe as WorldForm cast with WorldFormEnum.safeParse() in buildSyntheticGovernance. Invalid form values fall back to market. Adds test. Closes #233