### PR TITLE
fix(routes): use Zod safeParse consistently across all endpoints

### DIFF
--- a/src/routes/containers.ts
+++ b/src/routes/containers.ts
@@ -1,10 +1,11 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import { ok, error } from './response';
 import { selectContainer, getConfidenceBehavior } from '../containers/router';
 import { checkContainerTransition } from '../containers/transitions';
 import type { SkillLookup } from '../skills/types';
-import type { Container, RoutingContext } from '../containers/types';
-import type { IntentType } from '../schemas/intent';
+import type { RoutingContext } from '../containers/types';
+import { IntentType } from '../schemas/intent';
 
 // ─── DI Interface ───
 
@@ -12,13 +13,22 @@ export interface ContainerDeps {
   skillLookup: SkillLookup;
 }
 
-// ─── Helpers ───
+// ─── Input Schemas ───
 
-const VALID_CONTAINERS: Container[] = ['world', 'shape', 'skill', 'task', 'review', 'harvest'];
+const ContainerEnum = z.enum(['world', 'shape', 'skill', 'task', 'review', 'harvest']);
 
-function isValidContainer(value: string): value is Container {
-  return (VALID_CONTAINERS as string[]).includes(value);
-}
+const ContainerSelectInput = z.object({
+  userMessage: z.string().min(1),
+  intentType: IntentType.optional(),
+  hasActiveWorld: z.boolean().optional(),
+  conversationHistory: z.array(z.string()).optional(),
+});
+
+const ContainerTransitionInput = z.object({
+  current: ContainerEnum,
+  proposed: ContainerEnum,
+  reason: z.string().min(1),
+});
 
 // ─── Route Factory ───
 
@@ -28,24 +38,22 @@ export function containerRoutes(deps: ContainerDeps): Hono {
   // ─── POST /api/containers/select ───
   // Container selection (0 LLM calls — keyword heuristics)
   app.post('/api/containers/select', async (c) => {
-    const body: Record<string, unknown> = await c.req.json();
-    const userMessage = body.userMessage;
-
-    if (!userMessage || typeof userMessage !== 'string') {
-      return error(c, 'INVALID_INPUT', 'userMessage is required', 400);
+    const body: unknown = await c.req.json();
+    const parsed = ContainerSelectInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
 
-    const ctx: RoutingContext = { userMessage };
+    const ctx: RoutingContext = { userMessage: parsed.data.userMessage };
 
-    if (typeof body.intentType === 'string') {
-      ctx.intentType = body.intentType as IntentType;
+    if (parsed.data.intentType) {
+      ctx.intentType = parsed.data.intentType;
     }
-    if (typeof body.hasActiveWorld === 'boolean') {
-      ctx.hasActiveWorld = body.hasActiveWorld;
+    if (parsed.data.hasActiveWorld !== undefined) {
+      ctx.hasActiveWorld = parsed.data.hasActiveWorld;
     }
-    if (Array.isArray(body.conversationHistory)) {
-      ctx.conversationHistory = (body.conversationHistory as unknown[])
-        .filter((s): s is string => typeof s === 'string');
+    if (parsed.data.conversationHistory) {
+      ctx.conversationHistory = parsed.data.conversationHistory;
     }
 
     const selection = selectContainer(ctx, deps.skillLookup);
@@ -57,29 +65,13 @@ export function containerRoutes(deps: ContainerDeps): Hono {
   // ─── POST /api/containers/transition ───
   // Validate container transition (0 LLM calls — pure function)
   app.post('/api/containers/transition', async (c) => {
-    const body: Record<string, unknown> = await c.req.json();
-    const current = body.current;
-    const proposed = body.proposed;
-    const reason = body.reason;
-
-    if (!current || typeof current !== 'string') {
-      return error(c, 'INVALID_INPUT', 'current container is required', 400);
-    }
-    if (!proposed || typeof proposed !== 'string') {
-      return error(c, 'INVALID_INPUT', 'proposed container is required', 400);
-    }
-    if (!reason || typeof reason !== 'string') {
-      return error(c, 'INVALID_INPUT', 'reason is required', 400);
+    const body: unknown = await c.req.json();
+    const parsed = ContainerTransitionInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
 
-    if (!isValidContainer(current)) {
-      return error(c, 'INVALID_INPUT', `Invalid container: ${current}`, 400);
-    }
-    if (!isValidContainer(proposed)) {
-      return error(c, 'INVALID_INPUT', `Invalid container: ${proposed}`, 400);
-    }
-
-    const result = checkContainerTransition(current, proposed, reason);
+    const result = checkContainerTransition(parsed.data.current, parsed.data.proposed, parsed.data.reason);
     return ok(c, result);
   });
 

--- a/src/routes/conversations.test.ts
+++ b/src/routes/conversations.test.ts
@@ -135,7 +135,7 @@ describe('Conversation Routes', () => {
 
     const err = json.error as Record<string, unknown>;
     expect(err.code).toBe('INVALID_INPUT');
-    expect(err.message).toContain('Invalid mode');
+    expect(err.message).toContain('Invalid enum value');
   });
 
   it('creates conversation with village_id association', async () => {

--- a/src/routes/conversations.ts
+++ b/src/routes/conversations.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import type { Database } from 'bun:sqlite';
 import { ok, error } from './response';
 import type { LLMClient } from '../llm/client';
@@ -8,7 +9,13 @@ import { handleTurn } from '../conductor/turn-handler';
 import { handleManagementTurn } from '../conductor/management-handler';
 import { loadVillageState } from '../cards/village-loader';
 import type { SkillData } from '../thyra-client/schemas';
-import type { ConversationMode } from '../schemas/conversation';
+import { CreateConversationInput, type ConversationMode } from '../schemas/conversation';
+
+// ─── Input Schemas ───
+
+const SendMessageInput = z.object({
+  content: z.string().min(1),
+});
 
 export interface ConversationDeps {
   db: Database;
@@ -22,14 +29,14 @@ export function conversationRoutes(deps: ConversationDeps): Hono {
 
   // POST /api/conversations
   app.post('/api/conversations', async (c) => {
-    const body: Record<string, unknown> = await c.req.json();
-    const mode = typeof body.mode === 'string' ? body.mode : 'world_design';
-    const villageId = typeof body.village_id === 'string' ? body.village_id : undefined;
-
-    const validModes = ['world_design', 'workflow_design', 'task', 'pipeline_design', 'adapter_config', 'commerce_design', 'org_design', 'world_management'];
-    if (!validModes.includes(mode)) {
-      return error(c, 'INVALID_INPUT', `Invalid mode: ${mode}`, 400);
+    const body: unknown = await c.req.json();
+    const parsed = CreateConversationInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
+
+    const mode = parsed.data.mode;
+    const villageId = parsed.data.village_id;
 
     if (mode === 'world_management' && !villageId) {
       return error(c, 'INVALID_INPUT', 'village_id is required for world_management mode', 400);
@@ -105,12 +112,13 @@ export function conversationRoutes(deps: ConversationDeps): Hono {
   // POST /api/conversations/:id/messages
   app.post('/api/conversations/:id/messages', async (c) => {
     const conversationId = c.req.param('id');
-    const body: Record<string, unknown> = await c.req.json();
-    const content = body.content;
-
-    if (!content || typeof content !== 'string') {
+    const body: unknown = await c.req.json();
+    const msgParsed = SendMessageInput.safeParse(body);
+    if (!msgParsed.success) {
       return error(c, 'INVALID_INPUT', 'content is required', 400);
     }
+
+    const content = msgParsed.data.content;
 
     const conv = deps.db
       .query('SELECT phase, mode, nomod_streak, skills_json, village_id FROM conversations WHERE id = ?')

--- a/src/routes/decisions.ts
+++ b/src/routes/decisions.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import type { Database } from 'bun:sqlite';
 import { ok, error } from './response';
 import type { LLMClient } from '../llm/client';
@@ -33,6 +34,53 @@ export interface DecisionDeps {
   sessionManager: DecisionSessionManager;
   karvi?: KarviClient;
 }
+
+// ─── Input Schemas ───
+
+const StartDecisionInput = z.object({
+  userMessage: z.string().min(1),
+  conversationId: z.string().optional(),
+  userId: z.string().optional(),
+  title: z.string().optional(),
+});
+
+const ReclassifyInput = z.object({
+  userMessage: z.string().min(1),
+});
+
+const PathCheckInput = z.object({
+  domain: z.string().optional(),
+  form: z.string().optional(),
+  buyer: z.string().optional(),
+  loop: z.string().optional(),
+  buildTarget: z.string().optional(),
+  rawSignals: z.array(z.string()).optional(),
+});
+
+const SpaceBuildInput = z.object({
+  userMessage: z.string().optional(),
+  edgeProfile: z.array(z.string()).optional(),
+  timeHorizon: z.enum(['short', 'medium', 'long']).optional(),
+  maxSearchFriction: z.enum(['low', 'medium', 'high']).optional(),
+});
+
+const EvaluateInput = z.object({
+  candidateId: z.string().min(1),
+  signals: z.array(z.unknown()).optional(),
+});
+
+const RetryEvaluateInput = z.object({
+  candidateId: z.string().min(1),
+  additionalSignals: z.array(z.unknown()).optional(),
+});
+
+const ForgeInput = z.object({
+  confirmation: z.literal(true),
+  workingDir: z.string().optional(),
+  targetRepo: z.string().optional(),
+});
+
+const DecisionStatusFilter = z.enum(['active', 'paused', 'promoted', 'archived']);
 
 // ─── Helpers ───
 
@@ -84,26 +132,6 @@ function parseSignals(
     }
   }
   return signals;
-}
-
-function parseConstraints(body: Record<string, unknown>): KillFilterConstraints {
-  const constraints: KillFilterConstraints = {};
-  if (Array.isArray(body.edgeProfile)) {
-    constraints.edgeProfile = filterStrings(body.edgeProfile as unknown[]);
-  }
-  if (typeof body.timeHorizon === 'string') {
-    const th = body.timeHorizon;
-    if (th === 'short' || th === 'medium' || th === 'long') {
-      constraints.timeHorizon = th;
-    }
-  }
-  if (typeof body.maxSearchFriction === 'string') {
-    const msf = body.maxSearchFriction;
-    if (msf === 'low' || msf === 'medium' || msf === 'high') {
-      constraints.maxSearchFriction = msf;
-    }
-  }
-  return constraints;
 }
 
 function candidateToRealization(candidate: CandidateRow): RealizationCandidate {
@@ -201,16 +229,13 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
   // ─── POST /api/decisions/start ───
   // Create session + classify intent (1 LLM call)
   app.post('/api/decisions/start', async (c) => {
-    const body: Record<string, unknown> = await c.req.json();
-    const userMessage = body.userMessage;
-
-    if (!userMessage || typeof userMessage !== 'string') {
-      return error(c, 'INVALID_INPUT', 'userMessage is required', 400);
+    const body: unknown = await c.req.json();
+    const parsed = StartDecisionInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
 
-    const conversationId = typeof body.conversationId === 'string' ? body.conversationId : undefined;
-    const userId = typeof body.userId === 'string' ? body.userId : undefined;
-    const title = typeof body.title === 'string' ? body.title : undefined;
+    const { userMessage, conversationId, userId, title } = parsed.data;
 
     // LLM call #1: classify intent
     const intentRoute = await classifyIntent(deps.llm, userMessage);
@@ -241,12 +266,13 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
       return error(c, 'INVALID_STAGE', `Expected routing, got ${session.stage}`, 400);
     }
 
-    const body: Record<string, unknown> = await c.req.json();
-    const userMessage = body.userMessage;
-
-    if (!userMessage || typeof userMessage !== 'string') {
-      return error(c, 'INVALID_INPUT', 'userMessage is required', 400);
+    const body: unknown = await c.req.json();
+    const parsed = ReclassifyInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
+
+    const { userMessage } = parsed.data;
 
     // Build context with previous route
     const context: ClassifyIntentContext = {};
@@ -282,18 +308,20 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
       return error(c, 'MISSING_REGIME', 'No primaryRegime set (run start first)', 400);
     }
 
-    const body: Record<string, unknown> = await c.req.json();
-
-    // Build PathCheckContext from request body
-    const context: PathCheckContext = {};
-    if (typeof body.domain === 'string') context.domain = body.domain;
-    if (typeof body.form === 'string') context.form = body.form;
-    if (typeof body.buyer === 'string') context.buyer = body.buyer;
-    if (typeof body.loop === 'string') context.loop = body.loop;
-    if (typeof body.buildTarget === 'string') context.buildTarget = body.buildTarget;
-    if (Array.isArray(body.rawSignals)) {
-      context.rawSignals = filterStrings(body.rawSignals as unknown[]);
+    const body: unknown = await c.req.json();
+    const parsed = PathCheckInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
+
+    // Build PathCheckContext from validated data
+    const context: PathCheckContext = {};
+    if (parsed.data.domain) context.domain = parsed.data.domain;
+    if (parsed.data.form) context.form = parsed.data.form;
+    if (parsed.data.buyer) context.buyer = parsed.data.buyer;
+    if (parsed.data.loop) context.loop = parsed.data.loop;
+    if (parsed.data.buildTarget) context.buildTarget = parsed.data.buildTarget;
+    if (parsed.data.rawSignals) context.rawSignals = parsed.data.rawSignals;
 
     const intentRoute = buildIntentRouteFromSession(session);
     const pathCheckResult = checkPath(intentRoute, context);
@@ -321,12 +349,19 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
       return error(c, 'MISSING_REGIME', 'No primaryRegime set', 400);
     }
 
-    const body: Record<string, unknown> = await c.req.json();
-    const userMessage = typeof body.userMessage === 'string'
-      ? body.userMessage
-      : session.currentSummary ?? '';
+    const body: unknown = await c.req.json();
+    const parsed = SpaceBuildInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
+    }
 
-    const constraints = parseConstraints(body);
+    const userMessage = parsed.data.userMessage ?? session.currentSummary ?? '';
+
+    const constraints: KillFilterConstraints = {};
+    if (parsed.data.edgeProfile) constraints.edgeProfile = parsed.data.edgeProfile;
+    if (parsed.data.timeHorizon) constraints.timeHorizon = parsed.data.timeHorizon;
+    if (parsed.data.maxSearchFriction) constraints.maxSearchFriction = parsed.data.maxSearchFriction;
+
     const intentRoute = buildIntentRouteFromSession(session);
 
     const pathCheck: PathCheckResult = {
@@ -381,11 +416,13 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
       return error(c, 'INVALID_STAGE', `Expected space-building, got ${session.stage}`, 400);
     }
 
-    const body: Record<string, unknown> = await c.req.json();
-    const candidateId = body.candidateId;
-    if (!candidateId || typeof candidateId !== 'string') {
-      return error(c, 'INVALID_INPUT', 'candidateId is required', 400);
+    const body: unknown = await c.req.json();
+    const parsed = EvaluateInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
+
+    const { candidateId } = parsed.data;
 
     const candidates = deps.sessionManager.getCandidates(session.id);
     const candidate = candidates.find((cd) => cd.id === candidateId);
@@ -399,7 +436,7 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
     }
 
     const probeableForm = packageProbe(realizationCandidate);
-    const rawSignals = Array.isArray(body.signals) ? body.signals as unknown[] : [];
+    const rawSignals = parsed.data.signals ?? [];
     const signals = parseSignals(rawSignals, candidateId, session.primaryRegime ?? 'economic');
 
     const commitMemo = buildCommitMemoFromSignals(
@@ -426,13 +463,14 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
       return error(c, 'INVALID_STAGE', `Expected commit-review, got ${session.stage}`, 400);
     }
 
-    const body: Record<string, unknown> = await c.req.json();
-    const candidateId = body.candidateId;
-    if (!candidateId || typeof candidateId !== 'string') {
-      return error(c, 'INVALID_INPUT', 'candidateId is required', 400);
+    const body: unknown = await c.req.json();
+    const parsed = RetryEvaluateInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
 
-    const rawSignals = Array.isArray(body.additionalSignals) ? body.additionalSignals as unknown[] : [];
+    const { candidateId } = parsed.data;
+    const rawSignals = parsed.data.additionalSignals ?? [];
     const additionalSignals = parseSignals(rawSignals, candidateId, session.primaryRegime ?? 'economic');
 
     // Reset to space-building, then re-advance
@@ -468,16 +506,24 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
 
     if (!session) return error(c, 'NOT_FOUND', 'Session not found', 404);
 
-    const body: Record<string, unknown> = await c.req.json();
+    const body: unknown = await c.req.json();
 
     // SETTLE-01: Forge requires explicit user confirmation
-    if (body.confirmation !== true) {
-      return error(c, 'CONFIRMATION_REQUIRED', 'Forge requires confirmation: true (CONTRACT SETTLE-01)', 400);
+    const parsed = ForgeInput.safeParse(body);
+    if (!parsed.success) {
+      // Check if it's specifically a confirmation issue
+      const isConfirmationIssue = parsed.error.issues.some(
+        (issue) => issue.path.includes('confirmation'),
+      );
+      if (isConfirmationIssue) {
+        return error(c, 'CONFIRMATION_REQUIRED', 'Forge requires confirmation: true (CONTRACT SETTLE-01)', 400);
+      }
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
 
-    // Extract context fields from request body
-    const workingDir = typeof body.workingDir === 'string' ? body.workingDir : undefined;
-    const targetRepo = typeof body.targetRepo === 'string' ? body.targetRepo : undefined;
+    // Extract context fields from validated data
+    const workingDir = parsed.data.workingDir;
+    const targetRepo = parsed.data.targetRepo;
 
     // Fast-path: forge-fast-path at path-check stage
     if (session.routeDecision === 'forge-fast-path' && session.stage === 'path-check') {
@@ -524,7 +570,7 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
       return error(c, 'INVALID_STAGE', `Expected done, got ${session.stage}`, 400);
     }
 
-    const body: Record<string, unknown> = await c.req.json();
+    const body: unknown = await c.req.json();
     const parsed = ForgeBuildResultSchema.safeParse(body);
     if (!parsed.success) {
       return error(c, 'INVALID_INPUT', `Invalid ForgeBuildResult: ${parsed.error.message}`, 400);
@@ -546,9 +592,12 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
     let query = 'SELECT * FROM decision_sessions';
     const params: string[] = [];
 
-    if (status && ['active', 'paused', 'promoted', 'archived'].includes(status)) {
-      query += ' WHERE status = ?';
-      params.push(status);
+    if (status) {
+      const statusParsed = DecisionStatusFilter.safeParse(status);
+      if (statusParsed.success) {
+        query += ' WHERE status = ?';
+        params.push(statusParsed.data);
+      }
     }
 
     query += ' ORDER BY updated_at DESC';

--- a/src/routes/dispatches.ts
+++ b/src/routes/dispatches.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import type { Database } from 'bun:sqlite';
 import { ok, error } from './response';
 import { KarviClient } from '../karvi-client/client';
@@ -12,6 +13,13 @@ export interface DispatchRouteDeps {
   db: Database;
 }
 
+// ─── Input Schemas ───
+
+const CancelDispatchInput = z.object({
+  sessionId: z.string().optional(),
+  reason: z.string().default('user_cancel'),
+});
+
 // ─── Route Factory ───
 
 export function dispatchRoutes(deps: DispatchRouteDeps): Hono {
@@ -21,9 +29,10 @@ export function dispatchRoutes(deps: DispatchRouteDeps): Hono {
   // Cancel an in-progress dispatch or build on Karvi (0 LLM calls)
   app.post('/api/dispatches/:id/cancel', async (c) => {
     const id = c.req.param('id');
-    const body: Record<string, unknown> = await c.req.json().catch(() => ({})) as Record<string, unknown>;
-    const sessionId = typeof body.sessionId === 'string' ? body.sessionId : null;
-    const reason = typeof body.reason === 'string' ? body.reason : 'user_cancel';
+    const rawBody: unknown = await c.req.json().catch(() => ({}));
+    const parsed = CancelDispatchInput.safeParse(rawBody);
+    const sessionId = parsed.success ? (parsed.data.sessionId ?? null) : null;
+    const reason = parsed.success ? parsed.data.reason : 'user_cancel';
 
     try {
       const result = await deps.karvi.cancelDispatch(id);

--- a/src/routes/skills.ts
+++ b/src/routes/skills.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { z } from 'zod';
 import type { Database } from 'bun:sqlite';
 import { ok, error } from './response';
 import type { LLMClient } from '../llm/client';
@@ -8,7 +9,7 @@ import { recordRun, getMetrics } from '../skills/telemetry';
 import { evaluatePromotionGates } from '../skills/promotion';
 import { capturePattern } from '../skills/harvest';
 import { crystallize } from '../skills/crystallizer';
-import type { SkillStatus } from '../schemas/skill-object';
+import { SkillStatusEnum } from '../schemas/skill-object';
 
 // ─── DI Interface ───
 
@@ -17,6 +18,42 @@ export interface SkillDeps {
   llm: LLMClient;
   registry: SkillRegistry;
 }
+
+// ─── Input Schemas ───
+
+const SkillRunInput = z.object({
+  outcome: z.enum(['success', 'failure', 'partial']).default('success'),
+  durationMs: z.number().optional(),
+  notes: z.string().optional(),
+  conversationId: z.string().optional(),
+});
+
+const SkillMatchInput = z.object({
+  context: z.string().min(1),
+});
+
+const SkillHarvestInput = z.object({
+  context: z.string().min(1),
+  history: z.array(z.object({
+    role: z.string(),
+    content: z.string(),
+  })).min(1),
+});
+
+const SkillCrystallizeInput = z.object({
+  confirmation: z.literal(true),
+  candidate: z.object({
+    name: z.string(),
+    summary: z.string(),
+    problemShapes: z.array(z.string()).default([]),
+    desiredOutcomes: z.array(z.string()).default([]),
+    nonGoals: z.array(z.string()).default([]),
+    triggerWhen: z.array(z.string()).default([]),
+    doNotTriggerWhen: z.array(z.string()).default([]),
+    methodOutline: z.array(z.string()).default([]),
+    observedGotchas: z.array(z.string()).default([]),
+  }),
+});
 
 // ─── Route Factory ───
 
@@ -30,14 +67,14 @@ export function skillRoutes(deps: SkillDeps): Hono {
     const domain = c.req.query('domain');
     const tags = c.req.query('tags');
 
-    const filter: { minStatus?: SkillStatus; domain?: string; tags?: string[] } = {};
+    const filter: { minStatus?: z.infer<typeof SkillStatusEnum>; domain?: string; tags?: string[] } = {};
 
     if (status) {
-      const validStatuses: SkillStatus[] = ['draft', 'sandbox', 'promoted', 'core', 'deprecated', 'superseded'];
-      if (!validStatuses.includes(status as SkillStatus)) {
+      const statusParsed = SkillStatusEnum.safeParse(status);
+      if (!statusParsed.success) {
         return error(c, 'INVALID_INPUT', `Invalid status filter: ${status}`, 400);
       }
-      filter.minStatus = status as SkillStatus;
+      filter.minStatus = statusParsed.data;
     }
 
     if (domain) {
@@ -79,12 +116,17 @@ export function skillRoutes(deps: SkillDeps): Hono {
   // Record a skill run (telemetry) (0 LLM calls)
   app.post('/api/skills/:id/run', async (c) => {
     const skillId = c.req.param('id');
-    const body: Record<string, unknown> = await c.req.json();
+    const body: unknown = await c.req.json();
 
     // Verify skill exists in registry
     const skillObject = deps.registry.get(skillId);
     if (!skillObject) {
       return error(c, 'NOT_FOUND', `Skill ${skillId} not found`, 404);
+    }
+
+    const parsed = SkillRunInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
 
     // Look up or create skill_instance row
@@ -103,22 +145,12 @@ export function skillRoutes(deps: SkillDeps): Hono {
       );
     }
 
-    const outcome = typeof body.outcome === 'string' ? body.outcome : 'success';
-    const validOutcomes = ['success', 'failure', 'partial'];
-    if (!validOutcomes.includes(outcome)) {
-      return error(c, 'INVALID_INPUT', `Invalid outcome: ${outcome}`, 400);
-    }
-
-    const durationMs = typeof body.durationMs === 'number' ? body.durationMs : undefined;
-    const notes = typeof body.notes === 'string' ? body.notes : undefined;
-    const conversationId = typeof body.conversationId === 'string' ? body.conversationId : undefined;
-
     const runId = recordRun(deps.db, {
       skillInstanceId: instanceId,
-      conversationId,
-      outcome: outcome as 'success' | 'failure' | 'partial',
-      durationMs,
-      notes,
+      conversationId: parsed.data.conversationId,
+      outcome: parsed.data.outcome,
+      durationMs: parsed.data.durationMs,
+      notes: parsed.data.notes,
     });
 
     return ok(c, { runId, skillId, instanceId }, 201);
@@ -165,15 +197,14 @@ export function skillRoutes(deps: SkillDeps): Hono {
   // ─── POST /api/skills/match ───
   // Trigger matching against context (0 LLM calls)
   app.post('/api/skills/match', async (c) => {
-    const body: Record<string, unknown> = await c.req.json();
-    const context = body.context;
-
-    if (!context || typeof context !== 'string') {
-      return error(c, 'INVALID_INPUT', 'context is required', 400);
+    const body: unknown = await c.req.json();
+    const parsed = SkillMatchInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
 
     const entries = deps.registry.list();
-    const matches = matchSkills(context, entries);
+    const matches = matchSkills(parsed.data.context, entries);
 
     return ok(c, { matches });
   });
@@ -182,33 +213,18 @@ export function skillRoutes(deps: SkillDeps): Hono {
   // Pattern capture step 1 of 2 (SETTLE-01: returns candidate for review)
   // 1 LLM call — NOT inside handleTurn, satisfies COND-02
   app.post('/api/skills/harvest', async (c) => {
-    const body: Record<string, unknown> = await c.req.json();
-    const context = body.context;
-    const history = body.history;
-
-    if (!context || typeof context !== 'string') {
-      return error(c, 'INVALID_INPUT', 'context is required', 400);
+    const body: unknown = await c.req.json();
+    const parsed = SkillHarvestInput.safeParse(body);
+    if (!parsed.success) {
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
 
-    if (!Array.isArray(history) || history.length === 0) {
-      return error(c, 'INVALID_INPUT', 'history is required (non-empty array of {role, content})', 400);
-    }
+    const conversationHistory = parsed.data.history.map((msg) => ({
+      role: msg.role,
+      content: msg.content,
+    }));
 
-    const conversationHistory = history
-      .filter(
-        (msg): msg is { role: string; content: string } =>
-          typeof msg === 'object' &&
-          msg !== null &&
-          typeof (msg as Record<string, unknown>).role === 'string' &&
-          typeof (msg as Record<string, unknown>).content === 'string',
-      )
-      .map((msg) => ({ role: msg.role, content: msg.content }));
-
-    if (conversationHistory.length === 0) {
-      return error(c, 'INVALID_INPUT', 'history must contain messages with role and content', 400);
-    }
-
-    const result = await capturePattern(deps.llm, conversationHistory, context);
+    const result = await capturePattern(deps.llm, conversationHistory, parsed.data.context);
 
     if (!result.ok) {
       return error(c, 'LLM_ERROR', result.error, 500);
@@ -226,57 +242,25 @@ export function skillRoutes(deps: SkillDeps): Hono {
   // Crystallize candidate step 2 of 2 (SETTLE-01: requires confirmation)
   // 0 LLM calls — pure function
   app.post('/api/skills/crystallize', async (c) => {
-    const body: Record<string, unknown> = await c.req.json();
-
-    // SETTLE-01: requires explicit confirmation
-    if (body.confirmation !== true) {
-      return error(
-        c,
-        'CONFIRMATION_REQUIRED',
-        'Crystallize requires confirmation: true (CONTRACT SETTLE-01)',
-        400,
+    const body: unknown = await c.req.json();
+    const parsed = SkillCrystallizeInput.safeParse(body);
+    if (!parsed.success) {
+      // Check if it's specifically a confirmation issue
+      const isConfirmationIssue = parsed.error.issues.some(
+        (issue) => issue.path.includes('confirmation'),
       );
+      if (isConfirmationIssue) {
+        return error(
+          c,
+          'CONFIRMATION_REQUIRED',
+          'Crystallize requires confirmation: true (CONTRACT SETTLE-01)',
+          400,
+        );
+      }
+      return error(c, 'INVALID_INPUT', parsed.error.issues[0].message, 400);
     }
 
-    const candidate = body.candidate;
-    if (!candidate || typeof candidate !== 'object') {
-      return error(c, 'INVALID_INPUT', 'candidate is required', 400);
-    }
-
-    const candidateRecord = candidate as Record<string, unknown>;
-
-    // Validate required fields
-    const name = candidateRecord.name;
-    const summary = candidateRecord.summary;
-    if (typeof name !== 'string' || typeof summary !== 'string') {
-      return error(c, 'INVALID_INPUT', 'candidate must have name and summary', 400);
-    }
-
-    const skillCandidate = {
-      name,
-      summary,
-      problemShapes: Array.isArray(candidateRecord.problemShapes)
-        ? (candidateRecord.problemShapes as unknown[]).filter((s): s is string => typeof s === 'string')
-        : [],
-      desiredOutcomes: Array.isArray(candidateRecord.desiredOutcomes)
-        ? (candidateRecord.desiredOutcomes as unknown[]).filter((s): s is string => typeof s === 'string')
-        : [],
-      nonGoals: Array.isArray(candidateRecord.nonGoals)
-        ? (candidateRecord.nonGoals as unknown[]).filter((s): s is string => typeof s === 'string')
-        : [],
-      triggerWhen: Array.isArray(candidateRecord.triggerWhen)
-        ? (candidateRecord.triggerWhen as unknown[]).filter((s): s is string => typeof s === 'string')
-        : [],
-      doNotTriggerWhen: Array.isArray(candidateRecord.doNotTriggerWhen)
-        ? (candidateRecord.doNotTriggerWhen as unknown[]).filter((s): s is string => typeof s === 'string')
-        : [],
-      methodOutline: Array.isArray(candidateRecord.methodOutline)
-        ? (candidateRecord.methodOutline as unknown[]).filter((s): s is string => typeof s === 'string')
-        : [],
-      observedGotchas: Array.isArray(candidateRecord.observedGotchas)
-        ? (candidateRecord.observedGotchas as unknown[]).filter((s): s is string => typeof s === 'string')
-        : [],
-    };
+    const skillCandidate = parsed.data.candidate;
 
     try {
       const result = crystallize(skillCandidate);

--- a/src/schemas/conversation.ts
+++ b/src/schemas/conversation.ts
@@ -36,7 +36,7 @@ export type Message = z.infer<typeof MessageSchema>;
 // ─── Input DTOs ───
 
 export const CreateConversationInput = z.object({
-  mode: ConversationMode,
+  mode: ConversationMode.default('world_design'),
   village_id: z.string().optional(),
 });
 export type CreateConversationInput = z.infer<typeof CreateConversationInput>;


### PR DESCRIPTION
Replaces manual typeof checks with Zod safeParse across conversations.ts, decisions.ts, skills.ts, containers.ts, dispatches.ts. Reuses existing Zod schemas. All 242 route tests pass, zero lint/type errors. Closes #229