### PR TITLE
fix(db): add missing indexes on skill_runs and forge_builds created_at

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -279,4 +279,6 @@ export function initSchema(db: Database): void {
   db.run('CREATE INDEX IF NOT EXISTS idx_candidate_records_session ON candidate_records(session_id)');
   db.run('CREATE INDEX IF NOT EXISTS idx_approval_audits_pending ON approval_audits(pending_id)');
   db.run('CREATE INDEX IF NOT EXISTS idx_dispatch_queue_status ON dispatch_queue(status, next_retry_at)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_skill_runs_created ON skill_runs(created_at)');
+  db.run('CREATE INDEX IF NOT EXISTS idx_forge_builds_created ON forge_builds(created_at)');
 }

--- a/src/decision/dispatch-admission.test.ts
+++ b/src/decision/dispatch-admission.test.ts
@@ -327,4 +327,22 @@ describe('dispatch-admission', () => {
       expect(payload.reason).toContain('Only promoted skills');
     });
   });
+
+  describe('schema indexes', () => {
+    it('creates indexes on skill_runs.created_at and forge_builds.created_at', () => {
+      const indexes = db
+        .query(
+          `SELECT name, tbl_name FROM sqlite_master
+           WHERE type = 'index' AND name IN ('idx_skill_runs_created', 'idx_forge_builds_created')
+           ORDER BY name`,
+        )
+        .all() as Record<string, unknown>[];
+
+      expect(indexes).toHaveLength(2);
+      expect(indexes[0].name).toBe('idx_forge_builds_created');
+      expect(indexes[0].tbl_name).toBe('forge_builds');
+      expect(indexes[1].name).toBe('idx_skill_runs_created');
+      expect(indexes[1].tbl_name).toBe('skill_runs');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `idx_skill_runs_created` and `idx_forge_builds_created` indexes on `created_at` columns in `initSchema()`
- These indexes support time-range queries (`WHERE created_at > ?`) used by `checkRateLimit()` in `dispatch-admission.ts`
- Add test verifying both indexes exist in schema

Closes #246

## Test plan

- [x] New test confirms both indexes present via `sqlite_master` query
- [x] All 1370 existing tests pass (0 regressions)
- [x] `bun run build` and `bun run lint` pass clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)