### PR TITLE
fix(skills): deep-merge nested objects in overlay-merge

### DIFF
--- a/src/skills/overlay-merge.test.ts
+++ b/src/skills/overlay-merge.test.ts
@@ -308,6 +308,66 @@ describe('mergeSkillObject', () => {
     expect(result.environment.executionMode).toBe('assistive');
   });
 
+  // --- Deep merge: partial dispatch.executionPolicy preserves base fields ---
+  it('deep-merges partial dispatch.executionPolicy without clobbering base fields', () => {
+    const base = makeBaseSkillObject();
+    const dispatchOverlay = {
+      dispatch: {
+        executionPolicy: { retries: 3 },
+      },
+    };
+
+    const result = mergeSkillObject(base, dispatchOverlay);
+
+    expect(result.dispatch.executionPolicy.retries).toBe(3);
+    // Base fields preserved
+    expect(result.dispatch.executionPolicy.sync).toBe(true);
+    expect(result.dispatch.executionPolicy.timeoutMinutes).toBe(10);
+    expect(result.dispatch.executionPolicy.escalationOnFailure).toBe(false);
+  });
+
+  // --- Deep merge: partial dispatch.approval preserves base fields ---
+  it('deep-merges partial dispatch.approval without clobbering base fields', () => {
+    const base = makeBaseSkillObject();
+    const dispatchOverlay = {
+      dispatch: {
+        approval: { requireHumanBeforeDispatch: true },
+      },
+    };
+
+    const result = mergeSkillObject(base, dispatchOverlay);
+
+    expect(result.dispatch.approval.requireHumanBeforeDispatch).toBe(true);
+    // Base field preserved
+    expect(result.dispatch.approval.requireHumanBeforeMerge).toBe(false);
+  });
+
+  // --- Deep merge: partial environment.permissions preserves base fields ---
+  it('deep-merges partial environment.permissions without clobbering base fields', () => {
+    const base = makeBaseSkillObject();
+    const runtimeOverlay = {
+      environment: {
+        permissions: {
+          filesystem: { read: true, write: true },
+        },
+      },
+    };
+
+    const result = mergeSkillObject(base, undefined, runtimeOverlay);
+
+    expect(result.environment.permissions.filesystem).toEqual({
+      read: true,
+      write: true,
+    });
+    // Other permissions preserved from base
+    expect(result.environment.permissions.network).toEqual({
+      read: false,
+      write: false,
+    });
+    expect(result.environment.permissions.process).toEqual({ spawn: false });
+    expect(result.environment.permissions.secrets).toEqual({ read: [] });
+  });
+
   // --- No overlay: returns base unchanged ---
   it('returns base unchanged when no overlays provided', () => {
     const base = makeBaseSkillObject();

--- a/src/skills/overlay-merge.ts
+++ b/src/skills/overlay-merge.ts
@@ -80,6 +80,40 @@ function validateOverlayScope(
   }
 }
 
+// ─── Deep Merge Helper ───
+
+/**
+ * Merge overlay into base one level deep: for each key in overlay,
+ * if both base[key] and overlay[key] are plain objects, spread-merge them;
+ * otherwise overlay[key] wins (replaces arrays, scalars, etc.).
+ */
+function mergeOneLevel<T extends Record<string, unknown>>(
+  base: T,
+  overlay: Record<string, unknown>,
+): T {
+  const result = { ...base };
+  for (const key of Object.keys(overlay)) {
+    const baseVal = (base as Record<string, unknown>)[key];
+    const overVal = overlay[key];
+    if (
+      baseVal !== null &&
+      typeof baseVal === 'object' &&
+      !Array.isArray(baseVal) &&
+      overVal !== null &&
+      typeof overVal === 'object' &&
+      !Array.isArray(overVal)
+    ) {
+      (result as Record<string, unknown>)[key] = {
+        ...(baseVal as Record<string, unknown>),
+        ...(overVal as Record<string, unknown>),
+      };
+    } else {
+      (result as Record<string, unknown>)[key] = overVal;
+    }
+  }
+  return result;
+}
+
 // ─── Merge ───
 
 /**
@@ -105,10 +139,10 @@ export function mergeSkillObject(
       'dispatch',
     );
     if (dispatchOverlay.dispatch) {
-      merged.dispatch = {
-        ...merged.dispatch,
-        ...(dispatchOverlay.dispatch as typeof merged.dispatch),
-      };
+      merged.dispatch = mergeOneLevel(
+        merged.dispatch,
+        dispatchOverlay.dispatch as Record<string, unknown>,
+      );
     }
   }
 
@@ -119,16 +153,16 @@ export function mergeSkillObject(
       'runtime',
     );
     if (runtimeOverlay.environment) {
-      merged.environment = {
-        ...merged.environment,
-        ...(runtimeOverlay.environment as typeof merged.environment),
-      };
+      merged.environment = mergeOneLevel(
+        merged.environment,
+        runtimeOverlay.environment as Record<string, unknown>,
+      );
     }
     if (runtimeOverlay.verification) {
-      merged.verification = {
-        ...merged.verification,
-        ...(runtimeOverlay.verification as typeof merged.verification),
-      };
+      merged.verification = mergeOneLevel(
+        merged.verification,
+        runtimeOverlay.verification as Record<string, unknown>,
+      );
     }
     if (
       runtimeOverlay.governance &&


### PR DESCRIPTION
## Summary

- Fix shallow spread in `overlay-merge.ts` that clobbered nested dispatch sub-objects (`executionPolicy`, `approval`, `targetSelection`, `handoff`) and environment sub-objects (`permissions`) when partial overlays were provided
- Add `mergeOneLevel` helper that spread-merges nested plain objects while replacing scalars/arrays, consistent with the existing `governance.mutability` deep-merge pattern
- Add 3 new tests covering partial overlay scenarios for `dispatch.executionPolicy`, `dispatch.approval`, and `environment.permissions`

Closes #256

## Test plan

- [x] New test: partial `dispatch.executionPolicy` overlay preserves base fields (`sync`, `timeoutMinutes`, `escalationOnFailure`)
- [x] New test: partial `dispatch.approval` overlay preserves `requireHumanBeforeMerge`
- [x] New test: partial `environment.permissions` overlay preserves `network`, `process`, `secrets`
- [x] All 14 overlay-merge tests pass
- [x] Full suite: 1372 tests pass, 0 fail
- [x] `bun run build` and `bun run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)