### PR TITLE
fix(routes): sanitize 500 error responses to prevent info leakage

### DIFF
--- a/src/routes/conversations.test.ts
+++ b/src/routes/conversations.test.ts
@@ -361,6 +361,7 @@ describe('Conversation Routes', () => {
 
     const err = json.error as Record<string, unknown>;
     expect(err.code).toBe('INTERNAL_ERROR');
+    expect(err.message).toBe('Internal server error');
   });
 
   // ─── Without Thyra client ───

--- a/src/routes/conversations.ts
+++ b/src/routes/conversations.ts
@@ -213,10 +213,11 @@ export function conversationRoutes(deps: ConversationDeps): Hono {
         cardVersion: result.cardVersion,
       });
     } catch (err) {
+      console.error('[handleTurn] error:', err);
       return error(
         c,
         'INTERNAL_ERROR',
-        err instanceof Error ? err.message : 'Unknown error',
+        'Internal server error',
         500,
       );
     }


### PR DESCRIPTION
## Summary
- Replace `err.message` with generic `'Internal server error'` in the 500 catch block of POST `/api/conversations/:id/messages` to prevent leaking API keys or internal paths to clients
- Add `console.error('[handleTurn] error:', err)` for server-side logging of the real error
- Add test assertion verifying the response message is generic, not the internal error string

Closes #247

## Test plan
- [x] Existing test "returns 500 when handleTurn throws" now also verifies `err.message === 'Internal server error'`
- [x] `bun run build` — zero type errors
- [x] `bun run lint` — zero lint errors
- [x] `bun test src/routes/conversations.test.ts` — all 20 tests pass (70 expect() calls)

🤖 Generated with [Claude Code](https://claude.com/claude-code)