### PR TITLE
test(settlement): add edge case tests for settlement builders (GH-258)

### DIFF
--- a/src/settlement/adapter-config-builder.test.ts
+++ b/src/settlement/adapter-config-builder.test.ts
@@ -65,4 +65,39 @@ describe('buildAdapterConfig', () => {
     expect(parsed).toHaveLength(4);
     expect(parsed.map((p) => p.platform)).toEqual(['x', 'discord', 'telegram', 'owned_page']);
   });
+
+  it('preserves special characters in role', () => {
+    const card: AdapterCard = {
+      platforms: [
+        { platform: 'discord', enabled: true, role: 'support: "tier-1"\nnotes' },
+      ],
+      version: 1,
+    };
+    const parsed = JSON.parse(buildAdapterConfig(card)) as Array<Record<string, unknown>>;
+    expect(parsed[0].role).toBe('support: "tier-1"\nnotes');
+  });
+
+  it('preserves empty string role', () => {
+    const card: AdapterCard = {
+      platforms: [
+        { platform: 'x', enabled: true, role: '' },
+      ],
+      version: 1,
+    };
+    const parsed = JSON.parse(buildAdapterConfig(card)) as Array<Record<string, unknown>>;
+    expect(parsed[0].role).toBe('');
+  });
+
+  it('handles single platform entry', () => {
+    const card: AdapterCard = {
+      platforms: [
+        { platform: 'telegram', enabled: false, role: 'alerts' },
+      ],
+      version: 1,
+    };
+    const result = buildAdapterConfig(card);
+    const parsed = JSON.parse(result) as Array<Record<string, unknown>>;
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]).toEqual({ platform: 'telegram', enabled: false, role: 'alerts' });
+  });
 });

--- a/src/settlement/commerce-spec-builder.test.ts
+++ b/src/settlement/commerce-spec-builder.test.ts
@@ -93,4 +93,63 @@ describe('buildCommerceSpec', () => {
     expect(offerings[0].capacity).toBeNull();
     expect(offerings[0].duration).toBeNull();
   });
+
+  it('preserves zero base_price and zero capacity', () => {
+    const card = makeCommerceCard({
+      offerings: [
+        { type: 'stall_slot', name: 'Free Stall', description: 'free', base_price: 0, capacity: 0, duration: null },
+      ],
+    });
+    const parsed = JSON.parse(buildCommerceSpec(card)) as Record<string, unknown>;
+    const offerings = parsed.offerings as Array<Record<string, unknown>>;
+    expect(offerings[0].base_price).toBe(0);
+    expect(offerings[0].capacity).toBe(0);
+  });
+
+  it('preserves zero adjustment_pct', () => {
+    const card = makeCommerceCard({
+      pricing_rules: [
+        { name: 'No Change', condition: 'always', adjustment_pct: 0 },
+      ],
+    });
+    const parsed = JSON.parse(buildCommerceSpec(card)) as Record<string, unknown>;
+    const rules = parsed.pricing_rules as Array<Record<string, unknown>>;
+    expect(rules[0].adjustment_pct).toBe(0);
+  });
+
+  it('handles empty strings in offering fields', () => {
+    const card = makeCommerceCard({
+      offerings: [
+        { type: 'membership', name: '', description: '', base_price: 100, capacity: null, duration: '' },
+      ],
+    });
+    const parsed = JSON.parse(buildCommerceSpec(card)) as Record<string, unknown>;
+    const offerings = parsed.offerings as Array<Record<string, unknown>>;
+    expect(offerings[0].name).toBe('');
+    expect(offerings[0].description).toBe('');
+    expect(offerings[0].duration).toBe('');
+  });
+
+  it('handles empty string in pricing rule condition', () => {
+    const card = makeCommerceCard({
+      pricing_rules: [
+        { name: '', condition: '', adjustment_pct: 10 },
+      ],
+    });
+    const parsed = JSON.parse(buildCommerceSpec(card)) as Record<string, unknown>;
+    const rules = parsed.pricing_rules as Array<Record<string, unknown>>;
+    expect(rules[0].name).toBe('');
+    expect(rules[0].condition).toBe('');
+  });
+
+  it('handles large negative adjustment_pct', () => {
+    const card = makeCommerceCard({
+      pricing_rules: [
+        { name: 'Massive Discount', condition: 'fire sale', adjustment_pct: -99 },
+      ],
+    });
+    const parsed = JSON.parse(buildCommerceSpec(card)) as Record<string, unknown>;
+    const rules = parsed.pricing_rules as Array<Record<string, unknown>>;
+    expect(rules[0].adjustment_pct).toBe(-99);
+  });
 });

--- a/src/settlement/org-hierarchy-builder.test.ts
+++ b/src/settlement/org-hierarchy-builder.test.ts
@@ -84,4 +84,63 @@ describe('buildOrgHierarchy', () => {
     expect(director.role).toBe('leader');
     expect(director.style).toBe('neutral');
   });
+
+  it('handles YAML-sensitive characters in names', () => {
+    const card = makeOrgCard({
+      director: { name: 'Alice: "The Boss"', role: 'CTO #1', style: 'hands-on\ncollaborative' },
+      departments: [
+        { name: 'R&D: core', chief: 'Bob #2', workers: ['Carol: "dev"'], pipeline_refs: ['ci: main'] },
+      ],
+    });
+    const result = buildOrgHierarchy(card);
+    const parsed = yaml.load(result) as Record<string, Record<string, unknown>>;
+    const director = parsed.organization.director as Record<string, string>;
+    expect(director.name).toBe('Alice: "The Boss"');
+    expect(director.role).toBe('CTO #1');
+    expect(director.style).toBe('hands-on\ncollaborative');
+    const depts = parsed.organization.departments as Array<Record<string, unknown>>;
+    expect(depts[0].name).toBe('R&D: core');
+    expect(depts[0].chief).toBe('Bob #2');
+    expect((depts[0].workers as string[])[0]).toBe('Carol: "dev"');
+  });
+
+  it('handles department with empty workers and pipeline_refs', () => {
+    const card = makeOrgCard({
+      departments: [
+        { name: 'Empty Dept', chief: null, workers: [], pipeline_refs: [] },
+      ],
+    });
+    const parsed = yaml.load(buildOrgHierarchy(card)) as Record<string, Record<string, unknown>>;
+    const depts = parsed.organization.departments as Array<Record<string, unknown>>;
+    expect(depts).toHaveLength(1);
+    expect(depts[0].chief).toBeNull();
+    expect(depts[0].workers).toEqual([]);
+    expect(depts[0].pipelines).toEqual([]);
+  });
+
+  it('handles director with mixed null and non-null fields', () => {
+    const card = makeOrgCard({
+      director: { name: 'Alice', role: null, style: 'strict' },
+    });
+    const parsed = yaml.load(buildOrgHierarchy(card)) as Record<string, Record<string, unknown>>;
+    const director = parsed.organization.director as Record<string, string>;
+    expect(director.name).toBe('Alice');
+    expect(director.role).toBe('leader');
+    expect(director.style).toBe('strict');
+  });
+
+  it('handles many departments', () => {
+    const departments = Array.from({ length: 6 }, (_, i) => ({
+      name: `Dept-${i}`,
+      chief: i % 2 === 0 ? `Chief-${i}` : null,
+      workers: [`Worker-${i}-a`, `Worker-${i}-b`],
+      pipeline_refs: [`pipeline-${i}`],
+    }));
+    const card = makeOrgCard({ departments });
+    const parsed = yaml.load(buildOrgHierarchy(card)) as Record<string, Record<string, unknown>>;
+    const depts = parsed.organization.departments as Array<Record<string, unknown>>;
+    expect(depts).toHaveLength(6);
+    expect(depts[0].chief).toBe('Chief-0');
+    expect(depts[1].chief).toBeNull();
+  });
 });

--- a/src/settlement/task-spec-builder.test.ts
+++ b/src/settlement/task-spec-builder.test.ts
@@ -54,4 +54,37 @@ describe('buildTaskSpec', () => {
     const result = JSON.parse(buildTaskSpec(card)) as Record<string, unknown>;
     expect(result.success_condition).toBeNull();
   });
+
+  it('handles empty string intent', () => {
+    const card: TaskCard = { ...baseCard, intent: '' };
+    const result = JSON.parse(buildTaskSpec(card)) as Record<string, unknown>;
+    expect(result.intent).toBe('');
+  });
+
+  it('preserves special characters in inputs', () => {
+    const card: TaskCard = {
+      ...baseCard,
+      inputs: { 'key:with:colons': 'value\nwith\nnewlines', '"quoted"': 'backslash\\path' },
+    };
+    const result = JSON.parse(buildTaskSpec(card)) as Record<string, unknown>;
+    const inputs = result.inputs as Record<string, string>;
+    expect(inputs['key:with:colons']).toBe('value\nwith\nnewlines');
+    expect(inputs['"quoted"']).toBe('backslash\\path');
+  });
+
+  it('preserves large constraints array', () => {
+    const constraints = Array.from({ length: 25 }, (_, i) => `constraint-${i}`);
+    const card: TaskCard = { ...baseCard, constraints };
+    const result = JSON.parse(buildTaskSpec(card)) as Record<string, unknown>;
+    expect(result.constraints).toEqual(constraints);
+    expect((result.constraints as string[]).length).toBe(25);
+  });
+
+  it('preserves many input entries', () => {
+    const inputs: Record<string, string> = {};
+    for (let i = 0; i < 15; i++) inputs[`key${i}`] = `value${i}`;
+    const card: TaskCard = { ...baseCard, inputs };
+    const result = JSON.parse(buildTaskSpec(card)) as Record<string, unknown>;
+    expect(Object.keys(result.inputs as Record<string, unknown>)).toHaveLength(15);
+  });
 });

--- a/src/settlement/workflow-spec-builder.test.ts
+++ b/src/settlement/workflow-spec-builder.test.ts
@@ -97,4 +97,75 @@ describe('buildWorkflowSpec', () => {
     expect(result.exit_conditions).toEqual([]);
     expect(result.failure_handling).toEqual([]);
   });
+
+  it('handles YAML-sensitive characters in step descriptions', () => {
+    const card: WorkflowCard = {
+      ...baseCard,
+      steps: [
+        { order: 0, description: 'check: "status" #important', skill: null, conditions: 'if: ready' },
+      ],
+    };
+    const result = yaml.load(buildWorkflowSpec(card)) as Record<string, unknown>;
+    const steps = result.steps as Array<Record<string, unknown>>;
+    expect(steps[0].description).toBe('check: "status" #important');
+    expect(steps[0].conditions).toBe('if: ready');
+  });
+
+  it('handles single step', () => {
+    const card: WorkflowCard = {
+      ...baseCard,
+      steps: [
+        { order: 0, description: 'only step', skill: 'solo', conditions: null },
+      ],
+    };
+    const result = yaml.load(buildWorkflowSpec(card)) as Record<string, unknown>;
+    const steps = result.steps as Array<Record<string, unknown>>;
+    expect(steps).toHaveLength(1);
+    expect(steps[0].description).toBe('only step');
+  });
+
+  it('handles non-sequential step order values', () => {
+    const card: WorkflowCard = {
+      ...baseCard,
+      steps: [
+        { order: 0, description: 'first', skill: null, conditions: null },
+        { order: 5, description: 'middle', skill: null, conditions: null },
+        { order: 10, description: 'last', skill: null, conditions: null },
+      ],
+    };
+    const result = yaml.load(buildWorkflowSpec(card)) as Record<string, unknown>;
+    const steps = result.steps as Array<Record<string, unknown>>;
+    expect(steps).toHaveLength(3);
+    expect(steps[0].order).toBe(0);
+    expect(steps[1].order).toBe(5);
+    expect(steps[2].order).toBe(10);
+  });
+
+  it('handles step with all nullable fields null', () => {
+    const card: WorkflowCard = {
+      ...baseCard,
+      steps: [
+        { order: 0, description: 'basic step', skill: null, conditions: null },
+      ],
+    };
+    const result = yaml.load(buildWorkflowSpec(card)) as Record<string, unknown>;
+    const steps = result.steps as Array<Record<string, unknown>>;
+    expect(steps[0].skill).toBeNull();
+    expect(steps[0].conditions).toBeNull();
+  });
+
+  it('handles triggers with special characters', () => {
+    const card: WorkflowCard = {
+      ...baseCard,
+      confirmed: {
+        triggers: ['cron: "0 * * * *"', 'webhook: /api/trigger#deploy'],
+        exit_conditions: ['status: healthy'],
+        failure_handling: ['alert: "ops team"'],
+      },
+    };
+    const result = yaml.load(buildWorkflowSpec(card)) as Record<string, unknown>;
+    expect(result.triggers).toEqual(['cron: "0 * * * *"', 'webhook: /api/trigger#deploy']);
+    expect(result.exit_conditions).toEqual(['status: healthy']);
+    expect(result.failure_handling).toEqual(['alert: "ops team"']);
+  });
 });


### PR DESCRIPTION
## Summary

- Add 21 new edge case tests across 5 settlement builder test files
- Cover boundary conditions: empty strings, zero/falsy values, special characters, YAML-sensitive input, large arrays, mixed null/non-null fields
- All 1390 tests pass, zero lint/type errors

Closes #258

## Test plan

- [x] `bun test src/settlement/` — 100 tests pass (79 existing + 21 new)
- [x] `bun test` — 1390 tests pass, 0 failures
- [x] `bun run build` — zero type errors
- [x] `bun run lint` — zero lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)