### PR TITLE
test(cli): add real integration tests for processInput

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,123 +1,319 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createDb, initSchema } from './db';
+import { CardManager } from './cards/card-manager';
+import { processInput, type CliState, type CliDeps } from './cli';
 import type { Database } from 'bun:sqlite';
+import type { LLMClient } from './llm/client';
+import type { ThyraClient } from './thyra-client/client';
+import type { TurnResult } from './conductor/turn-handler';
 
-/**
- * Tests for CLI message persistence logic (issue #34).
- *
- * Since cli.ts is a script entry point with a `for await (const line of console)` loop,
- * we test the persistence pattern (INSERT/UPDATE statements) directly against the DB.
- */
-describe('CLI message persistence', () => {
+function createMockLlm(): LLMClient {
+  return {
+    generateStructured: vi.fn(),
+    generateText: vi.fn(),
+  } as unknown as LLMClient;
+}
+
+function createMockThyra(): ThyraClient {
+  return {
+    applyVillagePack: vi.fn().mockResolvedValue({
+      village_id: 'v1',
+      constitution_id: 'c1',
+      chief_id: null,
+      skills: [],
+    }),
+    createVillage: vi.fn(),
+    createConstitution: vi.fn(),
+    createChief: vi.fn(),
+    createSkill: vi.fn(),
+    getHealth: vi.fn(),
+    getVillage: vi.fn(),
+    getActiveConstitution: vi.fn(),
+    getChiefs: vi.fn(),
+    getSkills: vi.fn().mockResolvedValue([]),
+  } as unknown as ThyraClient;
+}
+
+function defaultTurnResult(): TurnResult {
+  return {
+    reply: 'test reply',
+    intent: { type: 'confirm', summary: 'ok' },
+    phase: 'explore',
+    phaseChanged: false,
+    strategy: 'mirror',
+    cardVersion: 1,
+    nomodStreak: 0,
+  };
+}
+
+describe('CLI processInput', () => {
   let db: Database;
+  let cardManager: CardManager;
+  let llm: LLMClient;
+  let thyra: ThyraClient;
   let conversationId: string;
+  let state: CliState;
+  let deps: CliDeps;
+  let mockHandleTurn: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     db = createDb(':memory:');
     initSchema(db);
+    llm = createMockLlm();
+    thyra = createMockThyra();
+    cardManager = new CardManager(db);
+
     conversationId = crypto.randomUUID();
     db.run(
       "INSERT INTO conversations (id, mode, phase) VALUES (?, 'world_design', 'explore')",
       [conversationId],
     );
+
+    state = {
+      phase: 'explore',
+      mode: 'world_design',
+      turn: 0,
+      nomodStreak: 0,
+      awaitingSettleConfirm: false,
+      pendingSettlementId: null,
+    };
+
+    mockHandleTurn = vi.fn().mockResolvedValue(defaultTurnResult());
+
+    deps = {
+      db, llm, cardManager, thyra, conversationId,
+      handleTurn: mockHandleTurn,
+      classifySettlement: vi.fn().mockReturnValue('village_pack'),
+      buildVillagePack: vi.fn().mockReturnValue('name: test-village\n'),
+    };
   });
 
-  it('persists user and assistant messages with correct roles', () => {
-    const turn = 1;
+  // ─── Quit / Skip ───
 
-    db.run(
-      'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-      [crypto.randomUUID(), conversationId, 'user', 'hello world', turn],
+  it('returns quit for "q"', async () => {
+    const result = await processInput('q', state, deps);
+    expect(result).toEqual({ action: 'quit' });
+  });
+
+  it('returns quit for "exit"', async () => {
+    const result = await processInput('exit', state, deps);
+    expect(result).toEqual({ action: 'quit' });
+  });
+
+  it('returns skip for empty input', async () => {
+    const result = await processInput('', state, deps);
+    expect(result).toEqual({ action: 'skip' });
+  });
+
+  it('returns skip for whitespace-only input', async () => {
+    const result = await processInput('   ', state, deps);
+    expect(result).toEqual({ action: 'skip' });
+  });
+
+  // ─── Normal Turn ───
+
+  it('dispatches normal input to handleTurn and returns updated state', async () => {
+    const result = await processInput('I want a fantasy world', state, deps);
+
+    expect(result.action).toBe('continue');
+    if (result.action !== 'continue') return;
+
+    expect(result.state.turn).toBe(1);
+    expect(result.state.phase).toBe('explore');
+    expect(result.output).toContain('test reply');
+
+    expect(mockHandleTurn).toHaveBeenCalledWith(
+      llm, cardManager, conversationId,
+      'I want a fantasy world', 'explore', 'world_design', 0,
     );
-    db.run(
-      'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-      [crypto.randomUUID(), conversationId, 'assistant', 'hi there', turn],
-    );
+  });
+
+  it('persists user and assistant messages to DB', async () => {
+    await processInput('hello', state, deps);
 
     const messages = db
-      .prepare('SELECT * FROM messages WHERE conversation_id = ? ORDER BY turn, role')
+      .prepare('SELECT role, content, turn FROM messages WHERE conversation_id = ? ORDER BY created_at')
       .all(conversationId) as Record<string, unknown>[];
 
     expect(messages).toHaveLength(2);
-    // ORDER BY role: 'assistant' < 'user' alphabetically
-    expect(messages[0]).toMatchObject({ role: 'assistant', content: 'hi there', turn: 1 });
-    expect(messages[1]).toMatchObject({ role: 'user', content: 'hello world', turn: 1 });
+    expect(messages[0]).toMatchObject({ role: 'user', content: 'hello', turn: 1 });
+    expect(messages[1]).toMatchObject({ role: 'assistant', content: 'test reply', turn: 1 });
   });
 
-  it('increments turn number across multiple turns', () => {
-    for (let turn = 1; turn <= 3; turn++) {
-      db.run(
-        'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-        [crypto.randomUUID(), conversationId, 'user', `msg ${turn}`, turn],
-      );
-      db.run(
-        'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-        [crypto.randomUUID(), conversationId, 'assistant', `reply ${turn}`, turn],
-      );
-    }
+  it('updates conversation phase in DB after turn', async () => {
+    mockHandleTurn.mockResolvedValueOnce({
+      ...defaultTurnResult(),
+      reply: 'focusing now',
+      phase: 'focus',
+      phaseChanged: true,
+      cardVersion: 2,
+    });
 
-    const turns = db
-      .prepare(
-        "SELECT DISTINCT turn FROM messages WHERE conversation_id = ? AND role = 'user' ORDER BY turn",
-      )
-      .all(conversationId) as Record<string, unknown>[];
+    const result = await processInput('confirmed rules', state, deps);
+    if (result.action !== 'continue') return;
 
-    expect(turns).toHaveLength(3);
-    expect(turns.map((r) => r.turn)).toEqual([1, 2, 3]);
-  });
-
-  it('syncs phase change to conversations table', () => {
-    const newPhase = 'focus';
-    db.run(
-      "UPDATE conversations SET phase = ?, updated_at = datetime('now') WHERE id = ?",
-      [newPhase, conversationId],
-    );
+    expect(result.state.phase).toBe('focus');
 
     const conv = db
       .prepare('SELECT phase FROM conversations WHERE id = ?')
       .get(conversationId) as Record<string, unknown>;
-
     expect(conv.phase).toBe('focus');
   });
 
-  it('does not update phase when phaseChanged is false', () => {
-    // Simulate: phaseChanged = false, so no UPDATE is issued
-    const conv = db
-      .prepare('SELECT phase FROM conversations WHERE id = ?')
-      .get(conversationId) as Record<string, unknown>;
+  it('updates conversation mode when detectedMode is returned', async () => {
+    mockHandleTurn.mockResolvedValueOnce({
+      ...defaultTurnResult(),
+      reply: 'workflow mode',
+      detectedMode: 'workflow_design',
+    });
 
-    expect(conv.phase).toBe('explore');
+    const result = await processInput('define a CI pipeline', state, deps);
+    if (result.action !== 'continue') return;
+
+    expect(result.state.mode).toBe('workflow_design');
+
+    const conv = db
+      .prepare('SELECT mode FROM conversations WHERE id = ?')
+      .get(conversationId) as Record<string, unknown>;
+    expect(conv.mode).toBe('workflow_design');
   });
 
-  it('persists settlement confirmation messages', () => {
-    // Simulate settlement confirmation turn
-    const turn = 2;
+  it('increments turn across multiple inputs', async () => {
+    const r1 = await processInput('msg 1', state, deps);
+    if (r1.action !== 'continue') return;
 
-    // User says "y"
-    db.run(
-      'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-      [crypto.randomUUID(), conversationId, 'user', 'y', turn],
-    );
+    const r2 = await processInput('msg 2', r1.state, deps);
+    if (r2.action !== 'continue') return;
 
-    // System responds with settlement result
-    const settleReply = 'Settlement cancelled.';
-    db.run(
-      'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-      [crypto.randomUUID(), conversationId, 'assistant', settleReply, turn],
-    );
+    expect(r2.state.turn).toBe(2);
 
     const messages = db
-      .prepare('SELECT * FROM messages WHERE conversation_id = ? AND turn = ?')
-      .all(conversationId, turn) as Record<string, unknown>[];
+      .prepare("SELECT DISTINCT turn FROM messages WHERE conversation_id = ? AND role = 'user' ORDER BY turn")
+      .all(conversationId) as Record<string, unknown>[];
+    expect(messages.map(r => r.turn)).toEqual([1, 2]);
+  });
+
+  // ─── Settlement Confirmation ───
+
+  it('cancels settlement when user says "n"', async () => {
+    const settlementId = crypto.randomUUID();
+    const cardId = crypto.randomUUID();
+
+    db.run(
+      'INSERT INTO cards (id, conversation_id, type, version, content) VALUES (?, ?, ?, ?, ?)',
+      [cardId, conversationId, 'world', 1, '{}'],
+    );
+    db.run(
+      'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+      [settlementId, conversationId, cardId, 'village_pack', 'name: test\n', 'draft'],
+    );
+
+    const settleState: CliState = {
+      ...state,
+      awaitingSettleConfirm: true,
+      pendingSettlementId: settlementId,
+    };
+
+    const result = await processInput('n', settleState, deps);
+    if (result.action !== 'continue') return;
+
+    expect(result.output).toBe('Settlement cancelled.');
+    expect(result.state.awaitingSettleConfirm).toBe(false);
+    expect(result.state.pendingSettlementId).toBeNull();
+  });
+
+  it('applies settlement when user says "y"', async () => {
+    const settlementId = crypto.randomUUID();
+    const cardId = crypto.randomUUID();
+
+    db.run(
+      'INSERT INTO cards (id, conversation_id, type, version, content) VALUES (?, ?, ?, ?, ?)',
+      [cardId, conversationId, 'world', 1, '{}'],
+    );
+    db.run(
+      'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+      [settlementId, conversationId, cardId, 'village_pack', 'name: test\n', 'draft'],
+    );
+
+    const settleState: CliState = {
+      ...state,
+      awaitingSettleConfirm: true,
+      pendingSettlementId: settlementId,
+    };
+
+    const result = await processInput('y', settleState, deps);
+    if (result.action !== 'continue') return;
+
+    expect(result.output).toContain('Village Pack applied');
+    expect(result.state.awaitingSettleConfirm).toBe(false);
+
+    const settlement = db
+      .prepare('SELECT status FROM settlements WHERE id = ?')
+      .get(settlementId) as Record<string, unknown>;
+    expect(settlement.status).toBe('applied');
+  });
+
+  it('handles thyra failure during settlement apply', async () => {
+    const settlementId = crypto.randomUUID();
+    const cardId = crypto.randomUUID();
+
+    db.run(
+      'INSERT INTO cards (id, conversation_id, type, version, content) VALUES (?, ?, ?, ?, ?)',
+      [cardId, conversationId, 'world', 1, '{}'],
+    );
+    db.run(
+      'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+      [settlementId, conversationId, cardId, 'village_pack', 'name: test\n', 'draft'],
+    );
+
+    (thyra.applyVillagePack as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('Thyra offline'),
+    );
+
+    const settleState: CliState = {
+      ...state,
+      awaitingSettleConfirm: true,
+      pendingSettlementId: settlementId,
+    };
+
+    const result = await processInput('y', settleState, deps);
+    if (result.action !== 'continue') return;
+
+    expect(result.output).toContain('Failed to apply Village Pack');
+
+    const settlement = db
+      .prepare('SELECT status FROM settlements WHERE id = ?')
+      .get(settlementId) as Record<string, unknown>;
+    expect(settlement.status).toBe('failed');
+  });
+
+  it('persists settlement confirmation messages in DB', async () => {
+    const settlementId = crypto.randomUUID();
+    const cardId = crypto.randomUUID();
+
+    db.run(
+      'INSERT INTO cards (id, conversation_id, type, version, content) VALUES (?, ?, ?, ?, ?)',
+      [cardId, conversationId, 'world', 1, '{}'],
+    );
+    db.run(
+      'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+      [settlementId, conversationId, cardId, 'village_pack', 'name: test\n', 'draft'],
+    );
+
+    const settleState: CliState = {
+      ...state,
+      awaitingSettleConfirm: true,
+      pendingSettlementId: settlementId,
+    };
+
+    await processInput('n', settleState, deps);
+
+    const messages = db
+      .prepare('SELECT role, content FROM messages WHERE conversation_id = ? ORDER BY created_at')
+      .all(conversationId) as Record<string, unknown>[];
 
     expect(messages).toHaveLength(2);
-
-    const userMsg = messages.find((m) => m.role === 'user');
-    const assistantMsg = messages.find((m) => m.role === 'assistant');
-
-    expect(userMsg).toBeDefined();
-    expect(userMsg).toMatchObject({ content: 'y', turn: 2 });
-    expect(assistantMsg).toBeDefined();
-    expect(assistantMsg).toMatchObject({ content: 'Settlement cancelled.', turn: 2 });
+    expect(messages[0]).toMatchObject({ role: 'user', content: 'n' });
+    expect(messages[1]).toMatchObject({ role: 'assistant', content: 'Settlement cancelled.' });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,173 @@
 import { createDb, initSchema } from './db';
 import { LLMClient } from './llm/client';
 import { CardManager } from './cards/card-manager';
-import { handleTurn } from './conductor/turn-handler';
-import { classifySettlement } from './settlement/router';
-import { buildVillagePack } from './settlement/village-pack-builder';
+import { handleTurn as defaultHandleTurn, type TurnResult } from './conductor/turn-handler';
+import { classifySettlement as defaultClassifySettlement } from './settlement/router';
+import { buildVillagePack as defaultBuildVillagePack } from './settlement/village-pack-builder';
 import { ThyraClient } from './thyra-client/client';
+import type { Database } from 'bun:sqlite';
 import type { Phase } from './conductor/state-machine';
 import type { ConversationMode } from './schemas/conversation';
-import type { WorldCard } from './schemas/card';
+import type { AnyCard, CardType, WorldCard } from './schemas/card';
+
+// ─── Exported Types ───
+
+export interface CliState {
+  phase: Phase;
+  mode: ConversationMode;
+  turn: number;
+  nomodStreak: number;
+  awaitingSettleConfirm: boolean;
+  pendingSettlementId: string | null;
+}
+
+export interface CliDeps {
+  db: Database;
+  llm: LLMClient;
+  cardManager: CardManager;
+  thyra: ThyraClient;
+  conversationId: string;
+  handleTurn?: (
+    llm: LLMClient, cardManager: CardManager, conversationId: string,
+    userMessage: string, currentPhase: Phase, mode: ConversationMode, nomodStreak: number,
+  ) => Promise<TurnResult>;
+  classifySettlement?: (cardType: CardType, card: AnyCard) => string | null;
+  buildVillagePack?: (card: WorldCard) => string;
+}
+
+export type InputResult =
+  | { action: 'quit' }
+  | { action: 'skip' }
+  | { action: 'continue'; state: CliState; output: string };
+
+// ─── Core Logic ───
+
+export async function processInput(
+  input: string,
+  state: CliState,
+  deps: CliDeps,
+): Promise<InputResult> {
+  const trimmed = input.trim();
+  if (trimmed === 'q' || trimmed === 'exit') return { action: 'quit' };
+  if (!trimmed) return { action: 'skip' };
+
+  const { db, llm, cardManager, thyra, conversationId } = deps;
+  const handleTurn = deps.handleTurn ?? defaultHandleTurn;
+  const classifySettlement = deps.classifySettlement ?? defaultClassifySettlement;
+  const buildVillagePack = deps.buildVillagePack ?? defaultBuildVillagePack;
+  const next = { ...state };
+
+  // Handle settlement confirmation
+  if (state.awaitingSettleConfirm && state.pendingSettlementId) {
+    next.turn += 1;
+    db.run(
+      'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
+      [crypto.randomUUID(), conversationId, 'user', trimmed, next.turn],
+    );
+
+    let settleReply: string;
+    if (trimmed === 'y' || trimmed === 'yes') {
+      const settlement = db
+        .query('SELECT * FROM settlements WHERE id = ? AND status = ?')
+        .get(state.pendingSettlementId, 'draft') as Record<string, unknown> | null;
+
+      if (settlement) {
+        db.run(
+          'UPDATE settlements SET status = ? WHERE id = ?',
+          ['confirmed', state.pendingSettlementId],
+        );
+        try {
+          const result = await thyra.applyVillagePack(settlement.payload as string);
+          db.run(
+            'UPDATE settlements SET status = ?, thyra_response = ? WHERE id = ?',
+            ['applied', JSON.stringify(result), state.pendingSettlementId],
+          );
+          settleReply = `Village Pack applied: village=${result.village_id}, constitution=${result.constitution_id}, chief=${result.chief_id ?? 'none'}, skills=${result.skills.length}`;
+        } catch (err) {
+          db.run(
+            'UPDATE settlements SET status = ? WHERE id = ?',
+            ['failed', state.pendingSettlementId],
+          );
+          settleReply = 'Failed to apply Village Pack: ' + String(err);
+        }
+      } else {
+        settleReply = 'No draft settlement found.';
+      }
+    } else {
+      settleReply = 'Settlement cancelled.';
+    }
+
+    db.run(
+      'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
+      [crypto.randomUUID(), conversationId, 'assistant', settleReply, next.turn],
+    );
+
+    next.awaitingSettleConfirm = false;
+    next.pendingSettlementId = null;
+    return { action: 'continue', state: next, output: settleReply };
+  }
+
+  // Normal turn
+  next.turn += 1;
+  db.run(
+    'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
+    [crypto.randomUUID(), conversationId, 'user', trimmed, next.turn],
+  );
+
+  const result = await handleTurn(
+    llm,
+    cardManager,
+    conversationId,
+    trimmed,
+    state.phase,
+    state.mode,
+    state.nomodStreak,
+  );
+  next.phase = result.phase;
+  next.nomodStreak = result.nomodStreak;
+
+  if (result.detectedMode) {
+    next.mode = result.detectedMode;
+    db.run(
+      "UPDATE conversations SET mode = ?, updated_at = datetime('now') WHERE id = ?",
+      [next.mode, conversationId],
+    );
+  }
+
+  db.run(
+    'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
+    [crypto.randomUUID(), conversationId, 'assistant', result.reply, next.turn],
+  );
+
+  db.run(
+    "UPDATE conversations SET phase = ?, nomod_streak = ?, updated_at = datetime('now') WHERE id = ?",
+    [result.phase, result.nomodStreak, conversationId],
+  );
+
+  const output = `[${result.strategy}] ${result.reply}`;
+
+  // Check for settlement trigger
+  if (result.phase === 'settle' && result.intent.type === 'settle_signal') {
+    const card = cardManager.getLatest(conversationId);
+    if (card) {
+      const target = classifySettlement(card.type, card.content);
+      if (target === 'village_pack') {
+        const yaml = buildVillagePack(card.content as WorldCard);
+        const settlementId = crypto.randomUUID();
+        db.run(
+          'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
+          [settlementId, conversationId, card.id, target, yaml, 'draft'],
+        );
+        next.awaitingSettleConfirm = true;
+        next.pendingSettlementId = settlementId;
+      }
+    }
+  }
+
+  return { action: 'continue', state: next, output };
+}
+
+// ─── CLI Entry Point ───
 
 async function runCli() {
   const dbPath = process.env.VOLVA_DB_PATH || ':memory:';
@@ -23,135 +183,25 @@ async function runCli() {
     [conversationId],
   );
 
-  let phase: Phase = 'explore';
-  let mode: ConversationMode = 'world_design';
-  let turn = 0;
-  let nomodStreak = 0;
-  let awaitingSettleConfirm = false;
-  let pendingSettlementId: string | null = null;
+  let state: CliState = {
+    phase: 'explore',
+    mode: 'world_design',
+    turn: 0,
+    nomodStreak: 0,
+    awaitingSettleConfirm: false,
+    pendingSettlementId: null,
+  };
+
+  const deps: CliDeps = { db, llm, cardManager, thyra, conversationId };
 
   console.log('Volva CLI — type your thoughts, q to quit\n');
 
   for await (const line of console) {
-    const input = line.trim();
-    if (input === 'q' || input === 'exit') break;
-    if (!input) continue;
-
-    // Handle settlement confirmation
-    if (awaitingSettleConfirm && pendingSettlementId) {
-      turn += 1;
-      db.run(
-        'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-        [crypto.randomUUID(), conversationId, 'user', input, turn],
-      );
-
-      let settleReply: string;
-      if (input === 'y' || input === 'yes') {
-        const settlement = db
-          .query('SELECT * FROM settlements WHERE id = ? AND status = ?')
-          .get(pendingSettlementId, 'draft') as Record<string, unknown> | null;
-
-        if (settlement) {
-          // Transition: draft -> confirmed
-          db.run(
-            'UPDATE settlements SET status = ? WHERE id = ?',
-            ['confirmed', pendingSettlementId],
-          );
-          try {
-            const result = await thyra.applyVillagePack(settlement.payload as string);
-            // Transition: confirmed -> applied
-            db.run(
-              'UPDATE settlements SET status = ?, thyra_response = ? WHERE id = ?',
-              ['applied', JSON.stringify(result), pendingSettlementId],
-            );
-            settleReply = `Village Pack applied: village=${result.village_id}, constitution=${result.constitution_id}, chief=${result.chief_id ?? 'none'}, skills=${result.skills.length}`;
-            console.log('\n' + settleReply);
-          } catch (err) {
-            // Transition: confirmed -> failed
-            db.run(
-              'UPDATE settlements SET status = ? WHERE id = ?',
-              ['failed', pendingSettlementId],
-            );
-            settleReply = 'Failed to apply Village Pack: ' + String(err);
-            console.error('\n' + settleReply);
-          }
-        } else {
-          settleReply = 'No draft settlement found.';
-          console.log('\n' + settleReply);
-        }
-      } else {
-        settleReply = 'Settlement cancelled.';
-        console.log('\n' + settleReply);
-      }
-
-      db.run(
-        'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-        [crypto.randomUUID(), conversationId, 'assistant', settleReply, turn],
-      );
-
-      awaitingSettleConfirm = false;
-      pendingSettlementId = null;
-      continue;
-    }
-
-    turn += 1;
-    db.run(
-      'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-      [crypto.randomUUID(), conversationId, 'user', input, turn],
-    );
-
-    const result = await handleTurn(
-      llm,
-      cardManager,
-      conversationId,
-      input,
-      phase,
-      mode,
-      nomodStreak,
-    );
-    phase = result.phase;
-    nomodStreak = result.nomodStreak;
-
-    if (result.detectedMode) {
-      mode = result.detectedMode;
-      db.run(
-        "UPDATE conversations SET mode = ?, updated_at = datetime('now') WHERE id = ?",
-        [mode, conversationId],
-      );
-    }
-
-    db.run(
-      'INSERT INTO messages (id, conversation_id, role, content, turn) VALUES (?, ?, ?, ?, ?)',
-      [crypto.randomUUID(), conversationId, 'assistant', result.reply, turn],
-    );
-
-    db.run(
-      "UPDATE conversations SET phase = ?, nomod_streak = ?, updated_at = datetime('now') WHERE id = ?",
-      [result.phase, result.nomodStreak, conversationId],
-    );
-
-    console.log(`\n[${result.strategy}] ${result.reply}\n`);
-
-    // Check for settlement trigger
-    if (result.phase === 'settle' && result.intent.type === 'settle_signal') {
-      const card = cardManager.getLatest(conversationId);
-      if (card) {
-        const target = classifySettlement(card.type, card.content);
-        if (target === 'village_pack') {
-          const yaml = buildVillagePack(card.content as WorldCard);
-          const settlementId = crypto.randomUUID();
-          db.run(
-            'INSERT INTO settlements (id, conversation_id, card_id, target, payload, status) VALUES (?, ?, ?, ?, ?, ?)',
-            [settlementId, conversationId, card.id, target, yaml, 'draft'],
-          );
-          console.log('\n--- Village Pack YAML ---\n');
-          console.log(yaml);
-          console.log('\nApply to Thyra? (y/n)');
-          awaitingSettleConfirm = true;
-          pendingSettlementId = settlementId;
-        }
-      }
-    }
+    const result = await processInput(line, state, deps);
+    if (result.action === 'quit') break;
+    if (result.action === 'skip') continue;
+    console.log('\n' + result.output + '\n');
+    state = result.state;
   }
 
   db.close();


### PR DESCRIPTION
## Summary
- Extract core loop body from `cli.ts` into a testable `processInput()` function with `CliState`/`CliDeps`/`InputResult` types
- Rewrite `cli.test.ts` to test actual CLI logic (13 tests) instead of raw DB SQL (5 tests)
- Covers: quit/skip commands, normal turn dispatch, phase/mode DB sync, settlement confirmation (accept/reject/failure), message persistence

Closes #259

## Test plan
- [x] `bun run build` — zero type errors
- [x] `bun run lint` — zero lint errors
- [x] `bun test` — 1377 pass, 0 fail (no regressions)
- [x] `bun test src/cli.test.ts` — 13 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)