### PR TITLE
refactor: unify LLM error handling pattern (GH-248)

### DIFF
--- a/src/conductor/management-handler.test.ts
+++ b/src/conductor/management-handler.test.ts
@@ -101,34 +101,6 @@ describe('handleManagementTurn', () => {
     expect(mockGenerateReply).toHaveBeenCalledTimes(1);
   });
 
-  it('returns fallback when parseIntent throws (LLM-02)', async () => {
-    setupThyraMocks();
-    mockParseIntent.mockRejectedValueOnce(new Error('LLM network error'));
-    mockGenerateReply.mockResolvedValueOnce('抱歉，請再說一次');
-
-    const result = await handleManagementTurn(mockLlm, mockThyra, 'v1', '你好');
-
-    expect(result.intent.type).toBe('off_topic');
-    expect(result.intent.summary).toBe('你好');
-    expect(result.reply).toBe('抱歉，請再說一次');
-    expect(result.action).toBe('none');
-  });
-
-  it('returns fallback reply when generateReply throws (LLM-02)', async () => {
-    setupThyraMocks();
-    mockParseIntent.mockResolvedValueOnce({
-      ok: true,
-      data: { type: 'query_status', summary: '狀態' },
-    });
-    mockGenerateReply.mockRejectedValueOnce(new Error('LLM timeout'));
-
-    const result = await handleManagementTurn(mockLlm, mockThyra, 'v1', '目前狀態');
-
-    expect(result.intent.type).toBe('query_status');
-    expect(result.reply).toContain('System error');
-    expect(result.action).toBe('query');
-  });
-
   it('handles Thyra failure gracefully', async () => {
     (mockThyra.getVillage as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Connection refused'));
     (mockThyra.getActiveConstitution as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('Connection refused'));

--- a/src/conductor/management-handler.ts
+++ b/src/conductor/management-handler.ts
@@ -48,14 +48,8 @@ export async function handleManagementTurn(
   // Use village context as "card snapshot" for intent parsing
   const villageContext = await fetchVillageContext(thyra, villageId);
 
-  // LLM #1: parse intent (CONTRACT LLM-02: must try/catch)
-  let intent: Intent;
-  try {
-    intent = await parseIntent(llm, userMessage, villageContext);
-  } catch (error) {
-    console.error('[handleManagementTurn] parseIntent threw:', error);
-    intent = { type: 'off_topic', summary: userMessage };
-  }
+  // LLM #1: parse intent (CONTRACT LLM-02 satisfied by LLMClient)
+  const intent = await parseIntent(llm, userMessage, villageContext);
 
   const isQuery = intent.type === 'query_status' || intent.type === 'query_history';
   const action: 'query' | 'none' = isQuery ? 'query' : 'none';
@@ -64,14 +58,8 @@ export async function handleManagementTurn(
   const replyContext = isQuery ? villageContext : `(Management mode — village: ${villageId})`;
   const strategy: Strategy = 'probe';
 
-  // LLM #2: generate reply (CONTRACT LLM-02: must try/catch)
-  let reply: string;
-  try {
-    reply = await generateReply(llm, strategy, replyContext, userMessage);
-  } catch (error) {
-    console.error('[handleManagementTurn] generateReply threw:', error);
-    reply = '(System error during reply generation. Please try again.)';
-  }
+  // LLM #2: generate reply (CONTRACT LLM-02 satisfied by LLMClient)
+  const reply = await generateReply(llm, strategy, replyContext, userMessage);
 
   return { reply, intent, action, strategy };
 }

--- a/src/conductor/turn-handler.test.ts
+++ b/src/conductor/turn-handler.test.ts
@@ -550,40 +550,6 @@ describe('handleTurn', () => {
     expect(card!.type).toBe('world');
   });
 
-  it('returns fallback when parseIntent throws (LLM-02)', async () => {
-    mockParseIntent.mockRejectedValueOnce(new Error('LLM network error'));
-    mockGenerateReply.mockResolvedValueOnce('抱歉，請再說一次');
-
-    const db = createDb(':memory:');
-    initSchema(db);
-    db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'world_design', 'explore')");
-    const mgr = new CardManager(db);
-    const result = await handleTurn(mockLlm, mgr, 'conv1', '你好', 'explore');
-
-    expect(result.intent.type).toBe('off_topic');
-    expect(result.intent.summary).toBe('你好');
-    expect(result.reply).toBe('抱歉，請再說一次');
-    expect(result.phase).toBe('explore');
-  });
-
-  it('returns fallback reply when generateReply throws (LLM-02)', async () => {
-    mockParseIntent.mockResolvedValueOnce({
-      ok: true,
-      data: { type: 'new_intent', summary: '做客服' },
-    });
-    mockGenerateReply.mockRejectedValueOnce(new Error('LLM timeout'));
-
-    const db = createDb(':memory:');
-    initSchema(db);
-    db.run("INSERT INTO conversations (id, mode, phase) VALUES ('conv1', 'world_design', 'explore')");
-    const mgr = new CardManager(db);
-    const result = await handleTurn(mockLlm, mgr, 'conv1', '做客服', 'explore');
-
-    expect(result.intent.type).toBe('new_intent');
-    expect(result.reply).toContain('System error');
-    expect(result.phase).toBe('explore');
-  });
-
   it('falls back to off_topic when parseIntent LLM fails, card state and phase unchanged', async () => {
     // First turn: create a card with real content
     mockParseIntent.mockResolvedValueOnce({

--- a/src/conductor/turn-handler.ts
+++ b/src/conductor/turn-handler.ts
@@ -91,14 +91,8 @@ export async function handleTurn(
   const cardContent = currentCard ? currentCard.content : createEmptyCard(mode);
   const cardSnapshot = JSON.stringify(cardContent, null, 2);
 
-  // LLM #1: parse intent (CONTRACT LLM-02: must try/catch)
-  let intent: Intent;
-  try {
-    intent = await parseIntent(llm, userMessage, cardSnapshot);
-  } catch (error) {
-    console.error('[handleTurn] parseIntent threw:', error);
-    intent = { type: 'off_topic', summary: userMessage };
-  }
+  // LLM #1: parse intent (CONTRACT LLM-02 satisfied by LLMClient)
+  const intent = await parseIntent(llm, userMessage, cardSnapshot);
 
   // Auto-detect mode on first turn if LLM returned detected_mode
   let effectiveMode = mode;
@@ -134,14 +128,8 @@ export async function handleTurn(
   const hasPending = cardHasPending(cardType, updatedContent);
   const strategy = pickStrategy(transition.newPhase, intent.type, hasPending, effectiveMode);
 
-  // LLM #2: generate reply (CONTRACT LLM-02: must try/catch)
-  let reply: string;
-  try {
-    reply = await generateReply(llm, strategy, JSON.stringify(updatedContent, null, 2), userMessage, availableSkills);
-  } catch (error) {
-    console.error('[handleTurn] generateReply threw:', error);
-    reply = '(System error during reply generation. Please try again.)';
-  }
+  // LLM #2: generate reply (CONTRACT LLM-02 satisfied by LLMClient)
+  const reply = await generateReply(llm, strategy, JSON.stringify(updatedContent, null, 2), userMessage, availableSkills);
 
   return {
     reply,

--- a/src/decision/evaluators/economic.test.ts
+++ b/src/decision/evaluators/economic.test.ts
@@ -97,15 +97,15 @@ describe('evaluateEconomic', () => {
     expect(result.rationale[0]).toContain('Evaluation could not complete');
   });
 
-  it('returns hold when LLM throws an exception', async () => {
+  it('returns hold when LLM returns error result', async () => {
     const llm = {
-      generateStructured: vi.fn().mockRejectedValue(new Error('Network timeout')),
+      generateStructured: vi.fn().mockResolvedValue({ ok: false, error: 'Network timeout' }),
       generateText: vi.fn(),
     } as unknown as LLMClient;
 
     const result = await evaluateEconomic(llm, makeEvaluatorInput());
 
     expect(result.verdict).toBe('hold');
-    expect(result.rationale[0]).toContain('Network timeout');
+    expect(result.rationale[0]).toContain('Economic evaluation failed');
   });
 });

--- a/src/decision/evaluators/economic.ts
+++ b/src/decision/evaluators/economic.ts
@@ -46,20 +46,16 @@ export async function evaluateEconomic(
   llm: LLMClient,
   input: EvaluatorInput,
 ): Promise<EvaluatorOutput> {
-  try {
-    const result = await llm.generateStructured({
-      system: ECONOMIC_EVALUATOR_PROMPT,
-      messages: [{ role: 'user', content: buildEconomicPrompt(input) }],
-      schema: EvaluatorOutputSchema,
-      schemaDescription: 'Economic evaluator verdict with rationale, evidenceUsed, unresolvedRisks, recommendedNextStep',
-    });
+  const result = await llm.generateStructured({
+    system: ECONOMIC_EVALUATOR_PROMPT,
+    messages: [{ role: 'user', content: buildEconomicPrompt(input) }],
+    schema: EvaluatorOutputSchema,
+    schemaDescription: 'Economic evaluator verdict with rationale, evidenceUsed, unresolvedRisks, recommendedNextStep',
+  });
 
-    if (!result.ok) {
-      return defaultHoldOutput('Economic evaluation failed: ' + result.error);
-    }
-
-    return result.data;
-  } catch (error) {
-    return defaultHoldOutput(error instanceof Error ? error.message : 'Unknown error');
+  if (!result.ok) {
+    return defaultHoldOutput('Economic evaluation failed: ' + result.error);
   }
+
+  return result.data;
 }

--- a/src/decision/evaluators/governance.test.ts
+++ b/src/decision/evaluators/governance.test.ts
@@ -99,15 +99,15 @@ describe('evaluateGovernance', () => {
     expect(result.rationale[0]).toContain('Evaluation could not complete');
   });
 
-  it('returns hold when LLM throws an exception', async () => {
+  it('returns hold when LLM returns error result', async () => {
     const llm = {
-      generateStructured: vi.fn().mockRejectedValue(new Error('API rate limited')),
+      generateStructured: vi.fn().mockResolvedValue({ ok: false, error: 'API rate limited' }),
       generateText: vi.fn(),
     } as unknown as LLMClient;
 
     const result = await evaluateGovernance(llm, makeEvaluatorInput());
 
     expect(result.verdict).toBe('hold');
-    expect(result.rationale[0]).toContain('API rate limited');
+    expect(result.rationale[0]).toContain('Governance evaluation failed');
   });
 });

--- a/src/decision/evaluators/governance.ts
+++ b/src/decision/evaluators/governance.ts
@@ -46,20 +46,16 @@ export async function evaluateGovernance(
   llm: LLMClient,
   input: EvaluatorInput,
 ): Promise<EvaluatorOutput> {
-  try {
-    const result = await llm.generateStructured({
-      system: GOVERNANCE_EVALUATOR_PROMPT,
-      messages: [{ role: 'user', content: buildGovernancePrompt(input) }],
-      schema: EvaluatorOutputSchema,
-      schemaDescription: 'Governance evaluator verdict with rationale, evidenceUsed, unresolvedRisks, recommendedNextStep',
-    });
+  const result = await llm.generateStructured({
+    system: GOVERNANCE_EVALUATOR_PROMPT,
+    messages: [{ role: 'user', content: buildGovernancePrompt(input) }],
+    schema: EvaluatorOutputSchema,
+    schemaDescription: 'Governance evaluator verdict with rationale, evidenceUsed, unresolvedRisks, recommendedNextStep',
+  });
 
-    if (!result.ok) {
-      return defaultHoldOutput('Governance evaluation failed: ' + result.error);
-    }
-
-    return result.data;
-  } catch (error) {
-    return defaultHoldOutput(error instanceof Error ? error.message : 'Unknown error');
+  if (!result.ok) {
+    return defaultHoldOutput('Governance evaluation failed: ' + result.error);
   }
+
+  return result.data;
 }

--- a/src/decision/space-builder.test.ts
+++ b/src/decision/space-builder.test.ts
@@ -25,9 +25,9 @@ function mockLLMClientFailure(error: string): LLMClient {
   } as unknown as LLMClient;
 }
 
-function mockLLMClientThrows(): LLMClient {
+function mockLLMClientFails(): LLMClient {
   return {
-    generateStructured: vi.fn().mockRejectedValueOnce(new Error('API down')),
+    generateStructured: vi.fn().mockResolvedValueOnce({ ok: false, error: 'API down' }),
     generateText: vi.fn(),
   } as unknown as LLMClient;
 }
@@ -230,8 +230,8 @@ describe('buildSpace: error handling', () => {
     expect(result).toEqual([]);
   });
 
-  it('returns empty array on LLM exception (API down)', async () => {
-    const llm = mockLLMClientThrows();
+  it('returns empty array on LLM failure (API down)', async () => {
+    const llm = mockLLMClientFails();
     const intentRoute = makeIntentRoute();
     const pathCheck = makePathCheck();
 
@@ -243,7 +243,7 @@ describe('buildSpace: error handling', () => {
   });
 
   it('never throws on LLM error', async () => {
-    const llm = mockLLMClientThrows();
+    const llm = mockLLMClientFails();
     const intentRoute = makeIntentRoute();
     const pathCheck = makePathCheck();
 

--- a/src/decision/space-builder.ts
+++ b/src/decision/space-builder.ts
@@ -179,32 +179,24 @@ export async function buildSpace(
   pathCheck: PathCheckResult,
   context: SpaceBuilderContext,
 ): Promise<RealizationCandidate[]> {
-  try {
-    const result = await llm.generateStructured({
-      system: SPACE_BUILDER_SYSTEM_PROMPT,
-      messages: [
-        {
-          role: 'user',
-          content: buildUserPrompt(intentRoute, pathCheck, context),
-        },
-      ],
-      schema: z.array(RealizationCandidateSchema),
-      schemaDescription:
-        'Array of RealizationCandidate objects, each with id, regime, form, description, whyThisCandidate (string[]), assumptions (string[]), probeReadinessHints (string[]), timeToSignal, notes (string[]). Optional: domain, vehicle, worldForm.',
-      maxTokens: 4000,
-    });
+  const result = await llm.generateStructured({
+    system: SPACE_BUILDER_SYSTEM_PROMPT,
+    messages: [
+      {
+        role: 'user',
+        content: buildUserPrompt(intentRoute, pathCheck, context),
+      },
+    ],
+    schema: z.array(RealizationCandidateSchema),
+    schemaDescription:
+      'Array of RealizationCandidate objects, each with id, regime, form, description, whyThisCandidate (string[]), assumptions (string[]), probeReadinessHints (string[]), timeToSignal, notes (string[]). Optional: domain, vehicle, worldForm.',
+    maxTokens: 4000,
+  });
 
-    if (!result.ok) {
-      console.warn('[space-builder] LLM validation failed:', result.error);
-      return [];
-    }
-
-    return result.data;
-  } catch (error) {
-    console.error(
-      '[space-builder] LLM call failed:',
-      error instanceof Error ? error.message : 'Unknown error',
-    );
+  if (!result.ok) {
+    console.warn('[space-builder] LLM validation failed:', result.error);
     return [];
   }
+
+  return result.data;
 }

--- a/src/llm/client.ts
+++ b/src/llm/client.ts
@@ -56,6 +56,10 @@ export class LLMClient {
     this.model = config?.model ?? process.env.VOLVA_MODEL ?? 'claude-sonnet-4-20250514';
   }
 
+  /**
+   * Generate a text response from the LLM.
+   * @returns Always returns a string (fallback on error). Never throws.
+   */
   async generateText(options: LLMCallOptions): Promise<string> {
     try {
       const response = await this.client.messages.create({
@@ -74,6 +78,10 @@ export class LLMClient {
     }
   }
 
+  /**
+   * Generate a structured (JSON + Zod-validated) response from the LLM.
+   * @returns Always returns `{ok: true, data}` or `{ok: false, error}`. Never throws.
+   */
   async generateStructured<T extends z.ZodType>(
     options: LLMStructuredOptions<T>
   ): Promise<{ ok: true; data: z.infer<T> } | { ok: false; error: string }> {

--- a/src/skills/harvest.test.ts
+++ b/src/skills/harvest.test.ts
@@ -13,13 +13,6 @@ function createMockLlm(
   } as unknown as LLMClient;
 }
 
-function createThrowingLlm(error: Error): LLMClient {
-  return {
-    generateText: vi.fn(),
-    generateStructured: vi.fn().mockRejectedValue(error),
-  } as unknown as LLMClient;
-}
-
 const VALID_CANDIDATE = {
   name: 'deploy-service',
   summary: 'Deploy a service to staging/production with smoke tests',
@@ -102,28 +95,14 @@ describe('capturePattern', () => {
     }
   });
 
-  it('returns error when LLM throws (no crash)', async () => {
-    const llm = createThrowingLlm(new Error('API rate limit exceeded'));
+  it('returns error when LLM returns failure result', async () => {
+    const llm = createMockLlm({ ok: false, error: 'API rate limit exceeded' });
 
     const result = await capturePattern(llm, SAMPLE_HISTORY, 'test');
 
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.error).toBe('API rate limit exceeded');
-    }
-  });
-
-  it('handles non-Error throws gracefully', async () => {
-    const llm = {
-      generateText: vi.fn(),
-      generateStructured: vi.fn().mockRejectedValue('string error'),
-    } as unknown as LLMClient;
-
-    const result = await capturePattern(llm, SAMPLE_HISTORY, 'test');
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toBe('Unknown error');
     }
   });
 });

--- a/src/skills/harvest.ts
+++ b/src/skills/harvest.ts
@@ -52,31 +52,23 @@ function formatHistory(
  * Called as an independent request (e.g. POST /api/skills/harvest),
  * NOT inside handleTurn() — satisfies COND-02.
  *
- * LLM call wrapped in try/catch with Zod validation (CONTRACT LLM-01 + LLM-02).
+ * LLM call with Zod validation (CONTRACT LLM-01). Never throws (CONTRACT LLM-02 satisfied by LLMClient).
  */
 export async function capturePattern(
   llm: LLMClient,
   conversationHistory: ReadonlyArray<{ role: string; content: string }>,
   context: string,
 ): Promise<{ ok: true; data: SkillCandidate } | { ok: false; error: string }> {
-  try {
-    const result = await llm.generateStructured({
-      system: CAPTURE_SYSTEM_PROMPT,
-      messages: [
-        {
-          role: 'user' as const,
-          content: `Context: ${context}\n\nConversation:\n${formatHistory(conversationHistory)}`,
-        },
-      ],
-      schema: SkillCandidateSchema,
-      schemaDescription:
-        'SkillCandidate with name, summary, problemShapes[], desiredOutcomes[], nonGoals[], triggerWhen[], doNotTriggerWhen[], methodOutline[], observedGotchas[]',
-    });
-    return result;
-  } catch (error) {
-    return {
-      ok: false,
-      error: error instanceof Error ? error.message : 'Unknown error',
-    };
-  }
+  return llm.generateStructured({
+    system: CAPTURE_SYSTEM_PROMPT,
+    messages: [
+      {
+        role: 'user' as const,
+        content: `Context: ${context}\n\nConversation:\n${formatHistory(conversationHistory)}`,
+      },
+    ],
+    schema: SkillCandidateSchema,
+    schemaDescription:
+      'SkillCandidate with name, summary, problemShapes[], desiredOutcomes[], nonGoals[], triggerWhen[], doNotTriggerWhen[], methodOutline[], observedGotchas[]',
+  });
 }


### PR DESCRIPTION
## Summary

- Document `LLMClient.generateStructured` and `generateText` never-throw contract via JSDoc
- Remove redundant outer try/catch from 6 callers: space-builder, economic/governance evaluators, harvest, management-handler, turn-handler
- Update tests to mock `{ok: false}` result instead of rejection (matching real contract)

Closes #248

## Test plan

- [x] `bun run build` — zero type errors
- [x] `bun run lint` — zero lint errors
- [x] `bun test` — 1364 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)