### PR TITLE
refactor: unify ID generation to crypto.randomUUID() (GH-249)

### DIFF
--- a/src/karvi-client/test-server.ts
+++ b/src/karvi-client/test-server.ts
@@ -34,7 +34,7 @@ export function createMockKarviServer(): MockKarviServer {
         const body = await req.json() as SkillDispatchRequest;
         state.receivedRequests.push(body);
 
-        const dispatchId = `disp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+        const dispatchId = `disp_${crypto.randomUUID()}`;
         const now = new Date().toISOString();
 
         state.dispatches.set(dispatchId, {

--- a/src/routes/approvals.ts
+++ b/src/routes/approvals.ts
@@ -80,7 +80,7 @@ export function approvalRoutes(deps: ApprovalDeps): Hono {
       const expiresAt = new Date(now.getTime() + APPROVAL_TTL_MS).toISOString();
 
       // Persist audit row
-      const auditId = `audit_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      const auditId = `audit_${crypto.randomUUID()}`;
       deps.db.run(
         `INSERT INTO approval_audits
          (id, pending_id, skill_id, skill_name, execution_mode, permissions_json, external_side_effects, dispatch_context_json, decision)

--- a/src/routes/dispatches.ts
+++ b/src/routes/dispatches.ts
@@ -40,7 +40,7 @@ export function dispatchRoutes(deps: DispatchRouteDeps): Hono {
       // Record cancellation event if session context is provided
       if (sessionId) {
         try {
-          const eventId = `evt_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+          const eventId = `evt_${crypto.randomUUID()}`;
           deps.db.prepare(
             `INSERT INTO decision_events (id, session_id, event_type, object_type, object_id, payload_json)
              VALUES (?, ?, 'dispatch_cancelled', 'session', ?, ?)`,

--- a/src/routes/skill-dispatcher.ts
+++ b/src/routes/skill-dispatcher.ts
@@ -271,7 +271,7 @@ function enqueueDispatch(
   ctx: SkillDispatchContext,
   reason: string,
 ): SkillDispatchOutcome {
-  const queueId = `dq_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const queueId = `dq_${crypto.randomUUID()}`;
   const request = buildDispatchRequest(merged, ctx, '');
 
   db.prepare(

--- a/src/routes/skills.ts
+++ b/src/routes/skills.ts
@@ -138,7 +138,7 @@ export function skillRoutes(deps: SkillDeps): Hono {
     if (instanceRow) {
       instanceId = instanceRow.id as string;
     } else {
-      instanceId = `inst_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+      instanceId = `inst_${crypto.randomUUID()}`;
       deps.db.run(
         'INSERT INTO skill_instances (id, skill_id, name, status, current_stage) VALUES (?, ?, ?, ?, ?)',
         [instanceId, skillId, skillObject.name, skillObject.status, skillObject.lifecycle?.currentStage ?? 'capture'],

--- a/src/skills/telemetry.ts
+++ b/src/skills/telemetry.ts
@@ -34,7 +34,7 @@ export interface SkillMetrics {
 }
 
 export function recordRun(db: Database, run: RunRecord): string {
-  const id = `run_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const id = `run_${crypto.randomUUID()}`;
 
   db.prepare(
     `INSERT INTO skill_runs (id, skill_instance_id, conversation_id, outcome, duration_ms, tokens_used, cost_usd, runtime, model, notes)
@@ -66,7 +66,7 @@ export function recordRun(db: Database, run: RunRecord): string {
 }
 
 export function recordForgeBuild(db: Database, record: ForgeRunRecord): string {
-  const id = `forge_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+  const id = `forge_${crypto.randomUUID()}`;
 
   const failedStepsJson = record.failedSteps && record.failedSteps.length > 0
     ? JSON.stringify(record.failedSteps)


### PR DESCRIPTION
## Summary

- Replace all `Date.now() + Math.random()` ID generation with `crypto.randomUUID()` across 7 call sites in 6 files
- Preserves existing prefixes (`run_`, `forge_`, `audit_`, `evt_`, `inst_`, `dq_`, `disp_`)
- Aligns with the rest of the codebase which already uses `crypto.randomUUID()`

Closes #249

## Test plan

- [x] `bun run build` passes (tsc --noEmit, zero errors)
- [x] `bun test` passes (1397 tests, 0 failures)
- [x] Grep confirms zero remaining `Date.now().*Math.random()` patterns in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)