### PR TITLE
fix(cards): wrap multi-step DB writes in db.transaction() (GH-250)

### DIFF
--- a/src/cards/card-manager.test.ts
+++ b/src/cards/card-manager.test.ts
@@ -310,6 +310,41 @@ describe('CardManager.getVersion', () => {
   });
 });
 
+// ─── Transaction Atomicity Tests ───
+
+describe('CardManager.update transaction atomicity', () => {
+  it('rolls back card insert when version conflict occurs', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+
+    // Manually insert version=2 to cause UNIQUE constraint conflict
+    db.run(
+      "INSERT INTO cards (id, conversation_id, type, version, content) VALUES (?, 'conv1', 'world', 2, '{}')",
+      [crypto.randomUUID()],
+    );
+
+    expect(() => mgr.update(card.id, { ...minimalWorldCard, goal: 'conflict' }))
+      .toThrow(CardVersionConflictError);
+
+    // Verify no orphan card_diffs were created
+    const diffs = db.query('SELECT * FROM card_diffs').all() as Record<string, unknown>[];
+    expect(diffs).toHaveLength(0);
+  });
+
+  it('both card and diff are written atomically on success', () => {
+    const card = mgr.create('conv1', 'world', minimalWorldCard);
+    mgr.update(card.id, { ...minimalWorldCard, goal: 'v2' });
+
+    const cards = db.query("SELECT * FROM cards WHERE conversation_id = 'conv1'")
+      .all() as Record<string, unknown>[];
+    const diffs = db.query('SELECT * FROM card_diffs').all() as Record<string, unknown>[];
+
+    expect(cards).toHaveLength(2);
+    expect(diffs).toHaveLength(1);
+    // card_diffs.card_id should reference the v2 card
+    expect(diffs[0].card_id).toBe(cards[1].id);
+  });
+});
+
 // ─── Edge Cases ───
 
 describe('CardManager edge cases', () => {

--- a/src/cards/card-manager.ts
+++ b/src/cards/card-manager.ts
@@ -152,23 +152,26 @@ export class CardManager {
     );
 
     const newId = crypto.randomUUID();
-    try {
-      this.db.run(
-        'INSERT INTO cards (id, conversation_id, type, version, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
-        [newId, conversationId, type, newVersion, JSON.stringify(mergedContent), originalCreatedAt, now],
-      );
-    } catch (err) {
-      if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
-        throw new CardVersionConflictError(conversationId, newVersion);
-      }
-      throw err;
-    }
-
     const diffId = crypto.randomUUID();
-    this.db.run(
-      'INSERT INTO card_diffs (id, card_id, from_version, to_version, diff, created_at) VALUES (?, ?, ?, ?, ?, ?)',
-      [diffId, newId, oldVersion, newVersion, JSON.stringify(diff), now],
-    );
+
+    this.db.transaction(() => {
+      try {
+        this.db.run(
+          'INSERT INTO cards (id, conversation_id, type, version, content, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
+          [newId, conversationId, type, newVersion, JSON.stringify(mergedContent), originalCreatedAt, now],
+        );
+      } catch (err) {
+        if (err instanceof Error && err.message.includes('UNIQUE constraint failed')) {
+          throw new CardVersionConflictError(conversationId, newVersion);
+        }
+        throw err;
+      }
+
+      this.db.run(
+        'INSERT INTO card_diffs (id, card_id, from_version, to_version, diff, created_at) VALUES (?, ?, ?, ?, ?, ?)',
+        [diffId, newId, oldVersion, newVersion, JSON.stringify(diff), now],
+      );
+    })();
 
     const updatedCard: CardEnvelope = {
       id: newId,

--- a/src/decision/dispatch-admission.ts
+++ b/src/decision/dispatch-admission.ts
@@ -147,44 +147,46 @@ export function checkDispatchAdmission(
   db: Database,
   ctx: AdmissionContext,
 ): DispatchAdmissionResult {
-  const allWarnings: string[] = [];
+  return db.transaction(() => {
+    const allWarnings: string[] = [];
 
-  // 1. Permission check
-  const permResult = checkPermission(ctx);
-  if (!permResult.admitted) {
-    recordAdmissionEvent(db, ctx, permResult);
-    return permResult;
-  }
-  if (permResult.warnings) allWarnings.push(...permResult.warnings);
+    // 1. Permission check
+    const permResult = checkPermission(ctx);
+    if (!permResult.admitted) {
+      recordAdmissionEvent(db, ctx, permResult);
+      return permResult;
+    }
+    if (permResult.warnings) allWarnings.push(...permResult.warnings);
 
-  // 2. Skill readiness check
-  const readinessResult = checkSkillReadiness(ctx);
-  if (!readinessResult.admitted) {
-    recordAdmissionEvent(db, ctx, readinessResult);
-    return readinessResult;
-  }
+    // 2. Skill readiness check
+    const readinessResult = checkSkillReadiness(ctx);
+    if (!readinessResult.admitted) {
+      recordAdmissionEvent(db, ctx, readinessResult);
+      return readinessResult;
+    }
 
-  // 3. Budget check
-  const budgetResult = checkBudget(db, ctx);
-  if (!budgetResult.admitted) {
-    recordAdmissionEvent(db, ctx, budgetResult);
-    return budgetResult;
-  }
+    // 3. Budget check
+    const budgetResult = checkBudget(db, ctx);
+    if (!budgetResult.admitted) {
+      recordAdmissionEvent(db, ctx, budgetResult);
+      return budgetResult;
+    }
 
-  // 4. Rate limit check
-  const rateResult = checkRateLimit(db, ctx);
-  if (!rateResult.admitted) {
-    recordAdmissionEvent(db, ctx, rateResult);
-    return rateResult;
-  }
+    // 4. Rate limit check
+    const rateResult = checkRateLimit(db, ctx);
+    if (!rateResult.admitted) {
+      recordAdmissionEvent(db, ctx, rateResult);
+      return rateResult;
+    }
 
-  const finalResult: DispatchAdmissionResult = {
-    admitted: true,
-    warnings: allWarnings.length > 0 ? allWarnings : undefined,
-  };
+    const finalResult: DispatchAdmissionResult = {
+      admitted: true,
+      warnings: allWarnings.length > 0 ? allWarnings : undefined,
+    };
 
-  recordAdmissionEvent(db, ctx, finalResult);
-  return finalResult;
+    recordAdmissionEvent(db, ctx, finalResult);
+    return finalResult;
+  })();
 }
 
 // ─── Event Recording ───

--- a/src/decision/governance-settlement.test.ts
+++ b/src/decision/governance-settlement.test.ts
@@ -340,6 +340,33 @@ describe('settleGovernanceBuild', () => {
     expect(events.length).toBe(1);
   });
 
+  it('pre-Thyra writes (forge_build + settlement_initiated) are atomic', async () => {
+    const session = sessionManager.createSession({ title: 'Gov test' });
+    const input = makeInput();
+    input.sessionId = session.id;
+
+    // Create deps with a sessionManager whose addEvent throws after recordForgeBuild succeeds
+    const brokenSessionManager = {
+      addEvent: vi.fn().mockImplementation(() => { throw new Error('Simulated addEvent failure'); }),
+    } as unknown as DecisionSessionManager;
+
+    const deps: GovernanceSettlementDeps = {
+      db,
+      thyra: makeThyraClient(),
+      sessionManager: brokenSessionManager,
+      buildVillagePack,
+    };
+
+    await expect(settleGovernanceBuild(input, deps)).rejects.toThrow('Simulated addEvent failure');
+
+    // Both forge_build and decision_events should be rolled back
+    const forgeBuilds = db.query('SELECT * FROM forge_builds WHERE session_id = ?').all(session.id) as Record<string, unknown>[];
+    expect(forgeBuilds).toHaveLength(0);
+
+    const events = db.query('SELECT * FROM decision_events WHERE session_id = ?').all(session.id) as Record<string, unknown>[];
+    expect(events).toHaveLength(0);
+  });
+
   it('does not record settlement_completed when Thyra fails', async () => {
     const session = sessionManager.createSession({ title: 'Gov test' });
     const input = makeInput();

--- a/src/decision/governance-settlement.ts
+++ b/src/decision/governance-settlement.ts
@@ -128,21 +128,25 @@ export async function settleGovernanceBuild(
     };
   }
 
-  // 4. Record forge build
-  const buildId = recordForgeBuild(deps.db, sessionId, buildResult, 'governance');
+  // 4. Record forge build + settlement_initiated event atomically
+  const buildId = deps.db.transaction(() => {
+    const id = recordForgeBuild(deps.db, sessionId, buildResult, 'governance');
 
-  // 5. Record settlement_initiated event
-  deps.sessionManager.addEvent(sessionId, {
-    eventType: 'settlement_initiated',
-    objectType: 'settlement',
-    objectId: buildId,
-    payload: {
-      regime: 'governance',
-      artifactCount: buildResult.artifacts.length,
-      thyraHandoffRequirements,
-      verification,
-    },
-  });
+    // 5. Record settlement_initiated event
+    deps.sessionManager.addEvent(sessionId, {
+      eventType: 'settlement_initiated',
+      objectType: 'settlement',
+      objectId: id,
+      payload: {
+        regime: 'governance',
+        artifactCount: buildResult.artifacts.length,
+        thyraHandoffRequirements,
+        verification,
+      },
+    });
+
+    return id;
+  })();
 
   // 6. Build village pack from worldCard
   const villagePack = deps.buildVillagePack(worldCard);


### PR DESCRIPTION
## Summary

- Wrap `CardManager.update()` card + card_diff INSERTs in `db.transaction()` to prevent orphan card rows without diffs
- Wrap `checkDispatchAdmission()` read checks + event recording in `db.transaction()` for snapshot isolation
- Wrap `settleGovernanceBuild()` pre-Thyra DB writes (`recordForgeBuild` + `settlement_initiated` event) in `db.transaction()` for atomicity

## Test plan

- [x] All 78 existing + new tests pass across card-manager, dispatch-admission, governance-settlement
- [x] New test: CardManager.update rolls back card INSERT when version conflict causes card_diff to never execute
- [x] New test: settleGovernanceBuild rolls back forge_build when addEvent fails
- [x] `bun run build` passes (tsc --noEmit zero errors)
- [x] eslint clean on all changed files

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)