### PR TITLE
fix(routes): return 400 on malformed JSON in dispatches cancel

### DIFF
--- a/src/routes/dispatches.test.ts
+++ b/src/routes/dispatches.test.ts
@@ -159,6 +159,39 @@ describe('POST /api/dispatches/:id/cancel', () => {
     expect(payload.cancelled).toBe(true);
   });
 
+  it('returns 400 on malformed JSON body', async () => {
+    const app = makeApp();
+    const req = new Request('http://localhost/api/dispatches/disp-bad/cancel', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{invalid json!!!',
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(400);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.ok).toBe(false);
+    const err = json.error as Record<string, unknown>;
+    expect(err.code).toBe('INVALID_JSON');
+  });
+
+  it('succeeds with no body and no content-type (uses defaults)', async () => {
+    karvi.cancelDispatch.mockResolvedValueOnce({
+      id: 'disp-nobody',
+      cancelled: true,
+    });
+
+    const app = makeApp();
+    const req = new Request('http://localhost/api/dispatches/disp-nobody/cancel', {
+      method: 'POST',
+    });
+    const res = await app.fetch(req);
+    expect(res.status).toBe(200);
+
+    const json = await res.json() as Record<string, unknown>;
+    expect(json.ok).toBe(true);
+  });
+
   it('succeeds even without sessionId (no event recorded)', async () => {
     karvi.cancelDispatch.mockResolvedValueOnce({
       id: 'disp-004',

--- a/src/routes/dispatches.ts
+++ b/src/routes/dispatches.ts
@@ -29,7 +29,15 @@ export function dispatchRoutes(deps: DispatchRouteDeps): Hono {
   // Cancel an in-progress dispatch or build on Karvi (0 LLM calls)
   app.post('/api/dispatches/:id/cancel', async (c) => {
     const id = c.req.param('id');
-    const rawBody: unknown = await c.req.json().catch(() => ({}));
+    let rawBody: unknown = {};
+    const contentType = c.req.header('content-type');
+    if (contentType?.includes('application/json')) {
+      try {
+        rawBody = await c.req.json();
+      } catch {
+        return error(c, 'INVALID_JSON', 'Malformed JSON in request body', 400);
+      }
+    }
     const parsed = CancelDispatchInput.safeParse(rawBody);
     const sessionId = parsed.success ? (parsed.data.sessionId ?? null) : null;
     const reason = parsed.success ? parsed.data.reason : 'user_cancel';


### PR DESCRIPTION
## Summary

- Replace silent `.catch(() => ({}))` in `dispatches.ts:32` with explicit content-type check and try/catch that returns a structured `INVALID_JSON` 400 error on malformed JSON body
- Empty body (no content-type header) still works with defaults since both `sessionId` and `reason` are optional/defaulted
- Add 2 new test cases: malformed JSON returns 400, no-body request uses defaults

Closes #254

## Test plan

- [x] Malformed JSON with `content-type: application/json` returns 400 with `INVALID_JSON` error code
- [x] No body / no content-type proceeds successfully with defaults
- [x] All 1402 existing + new tests pass
- [x] `bun run build` and `bun run lint` pass with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)