### PR TITLE
fix(routes): return 400 for invalid status query param in GET /api/decisions

### DIFF
--- a/src/routes/decisions.test.ts
+++ b/src/routes/decisions.test.ts
@@ -914,6 +914,14 @@ describe('Decision Routes E2E', () => {
       const getRes = await jsonGet(app, '/api/decisions/ds_nonexistent');
       expect(getRes.status).toBe(404);
     });
+
+    it('GET /api/decisions returns 400 for invalid status filter', async () => {
+      const res = await jsonGet(app, '/api/decisions?status=invalid');
+      expect(res.status).toBe(400);
+      const body = await res.json() as { ok: boolean; error: { code: string } };
+      expect(body.ok).toBe(false);
+      expect(body.error.code).toBe('INVALID_INPUT');
+    });
   });
 
   // ═══════════════════════════════════════════

--- a/src/routes/decisions.ts
+++ b/src/routes/decisions.ts
@@ -658,6 +658,8 @@ export function decisionRoutes(deps: DecisionDeps): Hono {
       if (statusParsed.success) {
         query += ' WHERE status = ?';
         params.push(statusParsed.data);
+      } else {
+        return error(c, 'INVALID_INPUT', `Invalid status filter: ${status}. Must be one of: active, paused, promoted, archived`, 400);
       }
     }
 


### PR DESCRIPTION
## Summary

- Return HTTP 400 when `?status` query param fails `DecisionStatusFilter.safeParse()` in `GET /api/decisions`, instead of silently ignoring the invalid filter and returning all sessions
- Add test case verifying 400 response for invalid status filter

Closes #255

## Test plan

- [x] Existing 29 tests still pass
- [x] New test: `GET /api/decisions returns 400 for invalid status filter` passes
- [x] `bun run build` (tsc --noEmit) — zero errors
- [x] `bun run lint` — zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)