### PR TITLE
fix(routes): use 202 Accepted for async dispatch in approvals (GH-257)

### DIFF
--- a/src/routes/approvals.test.ts
+++ b/src/routes/approvals.test.ts
@@ -193,7 +193,7 @@ describe('approvalRoutes', () => {
         inputs: {},
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202);
       const json = await res.json() as Record<string, unknown>;
       expect(json.ok).toBe(true);
       const data = json.data as Record<string, unknown>;
@@ -321,7 +321,7 @@ describe('approvalRoutes', () => {
         approvedBy: 'alice',
       });
 
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202);
       const json = await res.json() as Record<string, unknown>;
       expect(json.ok).toBe(true);
       const data = json.data as Record<string, unknown>;

--- a/src/routes/approvals.ts
+++ b/src/routes/approvals.ts
@@ -72,7 +72,7 @@ export function approvalRoutes(deps: ApprovalDeps): Hono {
     const outcome = await dispatchToKarvi(ctx, dispatchDeps);
 
     if (outcome.type === 'dispatched') {
-      return ok(c, { type: 'dispatched' as const, dispatchId: outcome.dispatchId, status: outcome.status });
+      return ok(c, { type: 'dispatched' as const, dispatchId: outcome.dispatchId, status: outcome.status }, 202);
     }
 
     if (outcome.type === 'approval_required') {
@@ -172,7 +172,7 @@ export function approvalRoutes(deps: ApprovalDeps): Hono {
     );
 
     if (outcome.type === 'dispatched') {
-      return ok(c, { type: 'dispatched' as const, dispatchId: outcome.dispatchId, status: outcome.status });
+      return ok(c, { type: 'dispatched' as const, dispatchId: outcome.dispatchId, status: outcome.status }, 202);
     }
     
     // fallback_local on resubmit


### PR DESCRIPTION
## Summary
- Return HTTP 202 instead of 200 for `dispatched` outcomes in `POST /api/dispatches` and `POST /api/dispatches/approve`, since these are async operations where the result is not immediately available.
- Update corresponding test assertions from 200 to 202.

Closes #257

## Test plan
- [x] All 11 existing approvals tests pass (status assertions updated)
- [x] `bun run build` — zero type errors
- [x] `bun run lint` — zero lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)