### PR TITLE
chore: remove unnecessary backward-compat re-exports

### DIFF
--- a/src/conductor/commerce-card.test.ts
+++ b/src/conductor/commerce-card.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { applyIntentToCommerceCard, createEmptyCommerceCard } from './turn-handler';
+import { applyIntentToCommerceCard } from './card-mutations';
+import { createEmptyCommerceCard } from './card-factories';
 import type { CommerceCard } from '../schemas/card';
 import type { Intent } from '../schemas/intent';
 

--- a/src/conductor/org-card.test.ts
+++ b/src/conductor/org-card.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { applyIntentToOrgCard, createEmptyOrgCard } from './turn-handler';
+import { applyIntentToOrgCard } from './card-mutations';
+import { createEmptyOrgCard } from './card-factories';
 import type { OrgCard } from '../schemas/card';
 import type { Intent } from '../schemas/intent';
 

--- a/src/conductor/pipeline-card.test.ts
+++ b/src/conductor/pipeline-card.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import {
-  createEmptyPipelineCard,
-  applyIntentToPipelineCard,
-  modeToCardType,
-  createEmptyCard,
-} from './turn-handler';
+import { createEmptyPipelineCard, modeToCardType, createEmptyCard } from './card-factories';
+import { applyIntentToPipelineCard } from './card-mutations';
 import type { PipelineCard } from '../schemas/card';
 import type { Intent } from '../schemas/intent';
 

--- a/src/conductor/state-machine.ts
+++ b/src/conductor/state-machine.ts
@@ -1,8 +1,6 @@
 import type { WorldCard, WorkflowCard, TaskCard, PipelineCard, AdapterCard, CommerceCard, OrgCard, AnyCard, CardType } from '../schemas/card';
 import type { IntentType } from '../schemas/intent';
 
-export type { IntentType } from '../schemas/intent';
-
 export type Phase = 'explore' | 'focus' | 'settle';
 
 export interface TransitionResult {

--- a/src/conductor/turn-handler.test.ts
+++ b/src/conductor/turn-handler.test.ts
@@ -1,14 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-  applyIntentToCard,
-  applyIntentToWorkflowCard,
-  applyIntentToTaskCard,
-  createEmptyWorldCard,
-  createEmptyWorkflowCard,
-  createEmptyTaskCard,
-  handleTurn,
-  isDiffEmpty,
-} from './turn-handler';
+import { createEmptyWorldCard, createEmptyWorkflowCard, createEmptyTaskCard } from './card-factories';
+import { applyIntentToCard, applyIntentToWorkflowCard, applyIntentToTaskCard } from './card-mutations';
+import { handleTurn, isDiffEmpty } from './turn-handler';
 import { CardManager } from '../cards/card-manager';
 import { createDb, initSchema } from '../db';
 import type { LLMClient } from '../llm/client';

--- a/src/conductor/turn-handler.ts
+++ b/src/conductor/turn-handler.ts
@@ -12,30 +12,6 @@ import type { SkillData } from '../thyra-client/schemas';
 import { createEmptyCard, modeToCardType } from './card-factories';
 import { applyIntent } from './card-mutations';
 
-// Re-export everything from card-factories and card-mutations for backward compatibility
-export {
-  createEmptyWorldCard,
-  createEmptyWorkflowCard,
-  createEmptyTaskCard,
-  createEmptyPipelineCard,
-  createEmptyAdapterCard,
-  createEmptyCommerceCard,
-  createEmptyOrgCard,
-  modeToCardType,
-  createEmptyCard,
-} from './card-factories';
-
-export {
-  applyIntentToCard,
-  applyIntentToWorkflowCard,
-  applyIntentToTaskCard,
-  applyIntentToPipelineCard,
-  applyIntentToAdapterCard,
-  applyIntentToCommerceCard,
-  applyIntentToOrgCard,
-  applyIntent,
-} from './card-mutations';
-
 export interface TurnResult {
   reply: string;
   intent: Intent;

--- a/src/containers/types.ts
+++ b/src/containers/types.ts
@@ -24,4 +24,3 @@ export interface RoutingContext {
   conversationHistory?: string[];
 }
 
-export type { IntentType } from '../schemas/intent';


### PR DESCRIPTION
## Summary

Closes #287

- Remove the massive re-export block in `turn-handler.ts` (lines 16-37) that re-exported all symbols from `card-factories` and `card-mutations`
- Remove the `IntentType` re-export from `state-machine.ts` and `containers/types.ts`
- Update 4 consumer files to import directly from the canonical modules (`card-factories.ts`, `card-mutations.ts`)

## Test plan

- [x] All 1408 tests pass (0 failures)
- [x] No import breakage — every consumer now imports from the actual source module

🤖 Generated with [Claude Code](https://claude.com/claude-code)